### PR TITLE
Forward Content-Type header

### DIFF
--- a/.nais/apiendpoints.yaml
+++ b/.nais/apiendpoints.yaml
@@ -16,6 +16,7 @@ spec:
       method: POST
       forwardHeaders:
         - Authorization
+        - Content-Type
       backendHost: http://pensjonssimulator
       backendPath: /api/v1/tidligst-mulig-uttak
   openEndpoints:


### PR DESCRIPTION
API-gateway må videresende `Content-Type`-header, ellers vil responsen være `415 Unsupported Media Type`.