### PR TITLE
PEK-490 Adjust 'simuler alderspensjon V4' response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>no.nav.pensjon</groupId>
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>7.4</version>
+            <version>8.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.5.0</version>
+            <version>2.6.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.yaml</groupId>

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonResult.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonResult.kt
@@ -6,7 +6,7 @@ data class AlderspensjonResult(
     val simuleringSuksess: Boolean,
     val aarsakListeIkkeSuksess: List<PensjonSimuleringStatus>,
     val alderspensjon: List<AlderspensjonFraFolketrygden>,
-    val alternativerVedForLavOpptjening: PensjonAlternativerVedForLavOpptjening?,
+    val alternativerVedForLavOpptjening: ForslagVedForLavOpptjening?,
     val harUttak: Boolean
 )
 
@@ -16,9 +16,14 @@ data class AlderspensjonFraFolketrygden(
     val uttaksgrad: Uttaksgrad
 )
 
-data class PensjonAlternativerVedForLavOpptjening(
-    val alderspensjonVedTidligstMuligUttak: List<AlderspensjonFraFolketrygden>,
-    val alderspensjonVedHoeyestMuligGrad: List<AlderspensjonFraFolketrygden>
+data class ForslagVedForLavOpptjening(
+    val gradertUttak: GradertUttak?,
+    val heltUttakFom: LocalDate
+)
+
+data class GradertUttak(
+    val fom: LocalDate,
+    val uttaksgrad: Uttaksgrad
 )
 
 data class PensjonSimuleringStatus(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/acl/AlderspensjonResultMapperV4.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/acl/AlderspensjonResultMapperV4.kt
@@ -9,7 +9,7 @@ object AlderspensjonResultMapperV4 {
             simuleringSuksess = source.simuleringSuksess,
             aarsakListeIkkeSuksess = source.aarsakListeIkkeSuksess.map(::status),
             alderspensjon = source.alderspensjon.map(::alderspensjon),
-            alternativerVedForLavOpptjening = source.alternativerVedForLavOpptjening?.let(::alternativer),
+            alternativerVedForLavOpptjening = source.alternativerVedForLavOpptjening?.let(::forslagVedForLavOpptjening),
             harUttak = source.harUttak
         )
 
@@ -32,9 +32,15 @@ object AlderspensjonResultMapperV4 {
             statusBeskrivelse = source.statusBeskrivelse
         )
 
-    private fun alternativer(source: PensjonAlternativerVedForLavOpptjening) =
-        PensjonAlternativerVedForLavOpptjeningV4(
-            alderspensjonVedTidligstMuligUttak = source.alderspensjonVedTidligstMuligUttak.map(::alderspensjon),
-            alderspensjonVedHoyestMuligGrad = source.alderspensjonVedHoeyestMuligGrad.map(::alderspensjon)
+    private fun forslagVedForLavOpptjening(source: ForslagVedForLavOpptjening) =
+        ForslagVedForLavOpptjeningV4(
+            gradertUttak = source.gradertUttak?.let(::gradertUttak),
+            heltUttakFraOgMedDato = source.heltUttakFom
+        )
+
+    private fun gradertUttak(source: GradertUttak) =
+        GradertUttakV4(
+            fraOgMedDato = source.fom,
+            uttaksgrad = source.uttaksgrad.prosentsats
         )
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/acl/AlderspensjonResultV4.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/acl/AlderspensjonResultV4.kt
@@ -5,11 +5,15 @@ import no.nav.pensjon.simulator.alderspensjon.PensjonSimuleringStatusKode
 import no.nav.pensjon.simulator.alderspensjon.PensjonType
 import java.time.LocalDate
 
+/**
+ * Version 4 of result for 'simuler alderspensjon'.
+ * NB: Versions 1 to 3 are services offered by PEN.
+ */
 data class AlderspensjonResultV4(
     val simuleringSuksess: Boolean,
     val aarsakListeIkkeSuksess: List<PensjonSimuleringStatusV4>,
     val alderspensjon: List<AlderspensjonFraFolketrygdenV4>,
-    val alternativerVedForLavOpptjening: PensjonAlternativerVedForLavOpptjeningV4?,
+    val alternativerVedForLavOpptjening: ForslagVedForLavOpptjeningV4?,
     val harUttak: Boolean
 )
 
@@ -19,9 +23,14 @@ data class AlderspensjonFraFolketrygdenV4(
     val uttaksgrad: Int
 )
 
-data class PensjonAlternativerVedForLavOpptjeningV4(
-    val alderspensjonVedTidligstMuligUttak: List<AlderspensjonFraFolketrygdenV4>,
-    val alderspensjonVedHoyestMuligGrad: List<AlderspensjonFraFolketrygdenV4>
+data class ForslagVedForLavOpptjeningV4(
+    val gradertUttak: GradertUttakV4?,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") val heltUttakFraOgMedDato: LocalDate
+)
+
+data class GradertUttakV4(
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") val fraOgMedDato: LocalDate,
+    val uttaksgrad: Int
 )
 
 data class PensjonSimuleringStatusV4(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/acl/AlderspensjonSpecMapperV4.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/acl/AlderspensjonSpecMapperV4.kt
@@ -16,7 +16,7 @@ object AlderspensjonSpecMapperV4 {
             pid = source.personId?.let(::pid) ?: missing("personId"),
             gradertUttak = source.gradertUttak?.let(::gradertUttak),
             heltUttakFom = source.heltUttakFraOgMedDato?.let(LocalDate::parse) ?: missing("heltUttakFraOgMedDato"),
-            antallAarUtenlandsEtter16Aar = source.arIUtlandetEtter16 ?: 0,
+            antallAarUtenlandsEtter16Aar = source.aarIUtlandetEtter16 ?: 0,
             epsHarPensjon = source.epsPensjon ?: false,
             epsHarInntektOver2G = source.eps2G ?: false,
             fremtidigInntektListe = source.fremtidigInntektListe.orEmpty().map(::inntekt),
@@ -25,7 +25,7 @@ object AlderspensjonSpecMapperV4 {
 
     private fun pid(value: String) = if (hasLength(value)) Pid(value) else missing("personId")
 
-    private fun gradertUttak(source: GradertUttakV4) =
+    private fun gradertUttak(source: GradertUttakSpecV4) =
         GradertUttakSpec(
             uttaksgrad = Uttaksgrad.from(source.uttaksgrad),
             fom = source.fraOgMedDato?.let(LocalDate::parse) ?: missing("gradertUttak.fraOgMedDato")
@@ -33,7 +33,7 @@ object AlderspensjonSpecMapperV4 {
 
     private fun inntekt(source: PensjonInntektSpecV4) =
         InntektSpec(
-            aarligBeloep = source.arligInntekt ?: 0,
+            aarligBeloep = source.aarligInntekt ?: 0,
             fom = source.fraOgMedDato?.let(LocalDate::parse) ?: missing("fremtidigInntekt.fraOgMedDato")
         )
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/acl/AlderspensjonSpecV4.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/acl/AlderspensjonSpecV4.kt
@@ -6,21 +6,21 @@ package no.nav.pensjon.simulator.alderspensjon.api.acl
  */
 data class AlderspensjonSpecV4(
     val personId: String? = null,
-    val gradertUttak: GradertUttakV4? = null,
+    val gradertUttak: GradertUttakSpecV4? = null,
     val heltUttakFraOgMedDato: String? = null,
+    val aarIUtlandetEtter16: Int? = null,
     val epsPensjon: Boolean? = null,
     val eps2G: Boolean? = null,
-    val arIUtlandetEtter16: Int? = null,
     val fremtidigInntektListe: List<PensjonInntektSpecV4>? = null,
     val rettTilAfpOffentligDato: String? = null
 )
 
-data class GradertUttakV4(
+data class GradertUttakSpecV4(
     val fraOgMedDato: String? = null,
     val uttaksgrad: Int? = null
 )
 
 data class PensjonInntektSpecV4(
-    val arligInntekt: Int? = null,
+    val aarligInntekt: Int? = null,
     val fraOgMedDato: String? = null
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/client/pen/acl/PenAlderspensjonResult.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/client/pen/acl/PenAlderspensjonResult.kt
@@ -1,5 +1,8 @@
 package no.nav.pensjon.simulator.alderspensjon.client.pen.acl
 
+import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDate
+
 /**
  * Ref. API specification:
  * https://confluence.adeo.no/pages/viewpage.action?pageId=583317319
@@ -8,7 +11,7 @@ data class PenAlderspensjonResult(
     val simuleringSuksess: Boolean?,
     val aarsakListeIkkeSuksess: List<PenPensjonSimuleringStatus>?,
     val alderspensjon: List<PenAlderspensjonFraFolketrygden>?,
-    val alternativerVedForLavOpptjening: PenPensjonAlternativerVedForLavOpptjening?,
+    val alternativerVedForLavOpptjening: PenForslagVedForLavOpptjening?,
     val harUttak: Boolean?
 )
 
@@ -18,9 +21,14 @@ data class PenAlderspensjonFraFolketrygden(
     val uttaksgrad: Int?
 )
 
-data class PenPensjonAlternativerVedForLavOpptjening(
-    val alderspensjonVedTidligstMuligUttak: List<PenAlderspensjonFraFolketrygden>?,
-    val alderspensjonVedHoyestMuligGrad: List<PenAlderspensjonFraFolketrygden>?
+data class PenForslagVedForLavOpptjening(
+    val gradertUttak: PenGradertUttak?,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") val heltUttakFraOgMedDato: LocalDate
+)
+
+data class PenGradertUttak(
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd") val fraOgMedDato: LocalDate,
+    val uttaksgrad: Int
 )
 
 data class PenPensjonSimuleringStatus(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/client/pen/acl/PenAlderspensjonResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/client/pen/acl/PenAlderspensjonResultMapper.kt
@@ -10,7 +10,7 @@ object PenAlderspensjonResultMapper {
             simuleringSuksess = source.simuleringSuksess ?: false,
             aarsakListeIkkeSuksess = source.aarsakListeIkkeSuksess.orEmpty().map(::status),
             alderspensjon = source.alderspensjon.orEmpty().map(::alderspensjonFraFolketrygden),
-            alternativerVedForLavOpptjening = source.alternativerVedForLavOpptjening?.let(::alternativer),
+            alternativerVedForLavOpptjening = source.alternativerVedForLavOpptjening?.let(::forslagVedForLavOpptjening),
             harUttak = source.harUttak ?: false
         )
 
@@ -28,10 +28,16 @@ object PenAlderspensjonResultMapper {
             beloep = source.belop ?: 0
         )
 
-    private fun alternativer(source: PenPensjonAlternativerVedForLavOpptjening) =
-        PensjonAlternativerVedForLavOpptjening(
-            source.alderspensjonVedTidligstMuligUttak.orEmpty().map(::alderspensjonFraFolketrygden),
-            source.alderspensjonVedHoyestMuligGrad.orEmpty().map(::alderspensjonFraFolketrygden)
+    private fun forslagVedForLavOpptjening(source: PenForslagVedForLavOpptjening) =
+        ForslagVedForLavOpptjening(
+            gradertUttak = source.gradertUttak?.let(::gradertUttak),
+            heltUttakFom = source.heltUttakFraOgMedDato
+        )
+
+    private fun gradertUttak(source: PenGradertUttak) =
+        GradertUttak(
+            fom = source.fraOgMedDato,
+            uttaksgrad = Uttaksgrad.from(source.uttaksgrad)
         )
 
     private fun status(source: PenPensjonSimuleringStatus) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/doc/OpenApiConfiguration.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/doc/OpenApiConfiguration.kt
@@ -1,0 +1,23 @@
+package no.nav.pensjon.simulator.tech.doc
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Configuration of OpenAPI (formerly known as Swagger).
+ */
+@Configuration
+class OpenApiConfiguration {
+
+    @Bean
+    fun openApi() =
+        OpenAPI()
+            .info(
+                Info()
+                    .title("Pensjonssimulator API")
+                    .description("Tjenester for simulering av alderspensjon")
+                    .version("v0.2.0")
+            )
+}

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/acl/AlderspensjonSpecMapperV4Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/acl/AlderspensjonSpecMapperV4Test.kt
@@ -17,10 +17,10 @@ class AlderspensjonSpecMapperV4Test : FunSpec({
                 heltUttakFraOgMedDato = "2031-02-03",
                 epsPensjon = true,
                 eps2G = false,
-                arIUtlandetEtter16 = 5,
+                aarIUtlandetEtter16 = 5,
                 fremtidigInntektListe = listOf(
                     PensjonInntektSpecV4(
-                        arligInntekt = 123000,
+                        aarligInntekt = 123000,
                         fraOgMedDato = "2029-05-06"
                     )
                 ),


### PR DESCRIPTION
Tilpasning til seneste versjon av [Simulerings-APIer - alternativ 3 - Request/Response](https://confluence.adeo.no/pages/viewpage.action?pageId=583317319)  > Simuler Alderspensjon.

NB: [Denne PEN PR](https://github.com/navikt/pesys/pull/13095) må deployes først.