### PR TITLE
PEK-551 Use kravhode, statsborgerskap

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContext.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContext.kt
@@ -1,8 +1,6 @@
 package no.nav.pensjon.simulator.core
 
-import no.nav.pensjon.simulator.core.afp.privat.PrivatAfpSatser
 import no.nav.pensjon.simulator.core.domain.regler.Pakkseddel
-import no.nav.pensjon.simulator.core.domain.regler.VeietSatsResultat
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsResultatAfpPrivat
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsResultatAlderspensjon2011
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsResultatAlderspensjon2016
@@ -15,9 +13,7 @@ import no.nav.pensjon.simulator.core.exception.KanIkkeBeregnesException
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.createDate
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.fromLocalDate
 import no.nav.pensjon.simulator.core.util.DateNoonExtension.noon
-import no.nav.pensjon.simulator.generelt.GenerelleDataSpec
 import no.nav.pensjon.simulator.generelt.client.GenerelleDataClient
-import no.nav.pensjon.simulator.person.Pid
 import no.nav.pensjon.simulator.regel.client.GenericRegelClient
 import no.nav.pensjon.simulator.regel.client.RegelClient
 import org.springframework.stereotype.Component
@@ -30,34 +26,6 @@ class SimulatorContext(
     private val regelService: GenericRegelClient,
     private val penClient: GenerelleDataClient
 ) : RegelClient {
-    fun fetchFoedselDato(pid: Pid): LocalDate =
-        penClient.fetchGenerelleData(
-            spec = GenerelleDataSpec.forFoedselDato(pid)
-        ).foedselDato
-
-    // hentSatserAfpPrivat
-    fun fetchPrivatAfpSatser(virkningFom: LocalDate, foedselDato: LocalDate): PrivatAfpSatser =
-        penClient.fetchGenerelleData(
-            spec = GenerelleDataSpec.forPrivatAfp(virkningFom, foedselDato)
-        ).privatAfpSatser
-
-    // hentDelingstallUtvalg
-    fun fetchDelingstallUtvalg(virkningFom: LocalDate, foedselDato: LocalDate): DelingstallUtvalg =
-        penClient.fetchGenerelleData(
-            spec = GenerelleDataSpec.forDelingstall(virkningFom, foedselDato)
-        ).delingstallUtvalg
-
-    // hentForholdstallUtvalg
-    fun fetchForholdstallUtvalg(virkningFom: LocalDate, foedselDato: LocalDate): ForholdstallUtvalg =
-        penClient.fetchGenerelleData(
-            spec = GenerelleDataSpec.forForholdstall(virkningFom, foedselDato)
-        ).forholdstallUtvalg
-
-    // hentVeietGrunnbelopListe
-    fun fetchVeietGrunnbeloepListe(fomAar: Int?, tomAar: Int?): List<VeietSatsResultat> =
-        penClient.fetchGenerelleData(
-            spec = GenerelleDataSpec.forVeietGrunnbeloep(fomAar, tomAar)
-        ).satsResultatListe
 
     // BeregnAlderspensjon2011ForsteUttakConsumerCommand.execute
     override fun beregnAlderspensjon2011FoersteUttak(

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorCore.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorCore.kt
@@ -6,13 +6,11 @@ import no.nav.pensjon.simulator.core.afp.offentlig.pre2025.Pre2025OffentligAfpRe
 import no.nav.pensjon.simulator.core.afp.privat.PrivatAfpBeregner
 import no.nav.pensjon.simulator.core.afp.privat.PrivatAfpResult
 import no.nav.pensjon.simulator.core.afp.privat.PrivatAfpSpec
-import no.nav.pensjon.simulator.core.anonym.AnonymOutputMapper
 import no.nav.pensjon.simulator.core.beholdning.BeholdningUtil.SISTE_GYLDIGE_OPPTJENING_AAR
 import no.nav.pensjon.simulator.core.beregn.AlderspensjonBeregnerResult
 import no.nav.pensjon.simulator.core.beregn.AlderspensjonVilkaarsproeverBeregnerSpec
 import no.nav.pensjon.simulator.core.beregn.AlderspensjonVilkaarsproeverOgBeregner
-import no.nav.pensjon.simulator.core.knekkpunkt.KnekkpunktAarsak
-import no.nav.pensjon.simulator.core.krav.KravGjelder
+import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsResultatAfpPrivat
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.ForsteVirkningsdatoGrunnlag
@@ -21,19 +19,14 @@ import no.nav.pensjon.simulator.core.domain.regler.satstabeller.SatsResultat
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import no.nav.pensjon.simulator.core.exception.BeregningsmotorValidereException
 import no.nav.pensjon.simulator.core.exception.ForLavtTidligUttakException
+import no.nav.pensjon.simulator.core.knekkpunkt.KnekkpunktAarsak
 import no.nav.pensjon.simulator.core.knekkpunkt.KnekkpunktFinder
 import no.nav.pensjon.simulator.core.knekkpunkt.KnekkpunktSpec
-import no.nav.pensjon.simulator.core.knekkpunkt.TrygdetidFastsetter
-import no.nav.pensjon.simulator.core.krav.KravhodeCreator
-import no.nav.pensjon.simulator.core.krav.KravhodeSpec
-import no.nav.pensjon.simulator.core.krav.KravhodeUpdateSpec
-import no.nav.pensjon.simulator.core.krav.KravhodeUpdater
-import no.nav.pensjon.simulator.core.out.OutputPensjonCombo
+import no.nav.pensjon.simulator.core.krav.*
 import no.nav.pensjon.simulator.core.result.ResultPreparerSpec
 import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.result.SimuleringResultPreparer
 import no.nav.pensjon.simulator.core.trygd.ForKortTrygdetidException
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.util.toLocalDate
 import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDato
 import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDatoCombo
@@ -342,7 +335,8 @@ class SimulatorCore(
         return null
     }
 
-    override fun fetchFoedselDato(pid: Pid): LocalDate = generelleDataHolder.getFoedselDato(pid)
+    override fun fetchFoedselDato(pid: Pid): LocalDate =
+        generelleDataHolder.getPerson(pid).foedselDato
 
     private fun fetchGrunnbeloep(): Int {
         val grunnbeloepListe: List<SatsResultat> = context.fetchGrunnbeloepListe(LocalDate.now()).satsResultater

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2011SisteBeregningCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2011SisteBeregningCreator.kt
@@ -1,24 +1,24 @@
 package no.nav.pensjon.simulator.core.beregn
 
-import no.nav.pensjon.simulator.core.SimulatorContext
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 import no.nav.pensjon.simulator.core.domain.regler.enum.BorMedTypeEnum
+import no.nav.pensjon.simulator.krav.KravService
 import org.springframework.stereotype.Component
 
 @Component
-class Alderspensjon2011SisteBeregningCreator(context: SimulatorContext) : SisteBeregningCreatorBase(context) {
+class Alderspensjon2011SisteBeregningCreator(kravService: KravService) : SisteBeregningCreatorBase(kravService) {
 
     // AbstraktOpprettSisteAldersberegning.execute
-    override fun createBeregning(input: SisteBeregningSpec, beregningsresultat: AbstraktBeregningsResultat?) =
-        newSisteAldersberegning2016(input).also {
-            populate(it, input, beregningsresultat)
+    override fun createBeregning(spec: SisteBeregningSpec, beregningResultat: AbstraktBeregningsResultat?) =
+        newSisteAldersberegning2016(spec).also {
+            populate(it, spec, beregningResultat)
         }
 
     // OpprettSisteAldersberegning2016Regelverk2016.createAndInitSisteBeregning
-    private fun newSisteAldersberegning2016(input: SisteBeregningSpec): SisteBeregning =
+    private fun newSisteAldersberegning2016(spec: SisteBeregningSpec): SisteBeregning =
         SisteAldersberegning2016().apply {
-            regelverkTypeEnum = input.regelverkKodePaNyttKrav
-            val resultat2016 = input.beregningsresultat as? BeregningsResultatAlderspensjon2016
+            regelverkTypeEnum = spec.regelverkKodePaNyttKrav
+            val resultat2016 = spec.beregningsresultat as? BeregningsResultatAlderspensjon2016
             setBeregningsresultat2016Data(this, resultat2016)
             pensjonUnderUtbetaling2011 =
                 utenIrrelevanteYtelseskomponenter(resultat2016?.beregningsResultat2011?.pensjonUnderUtbetaling)
@@ -26,7 +26,7 @@ class Alderspensjon2011SisteBeregningCreator(context: SimulatorContext) : SisteB
                 utenIrrelevanteYtelseskomponenter(resultat2016?.beregningsResultat2025?.pensjonUnderUtbetaling)
 
             if (resultat2016?.beregningsResultat2011 != null) {
-                setAnvendtGjenlevenderettVedtak(this, input.filtrertVilkarsvedtakList)
+                setAnvendtGjenlevenderettVedtak(this, spec.filtrertVilkarsvedtakList)
             }
         }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2016SisteBeregningCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2016SisteBeregningCreator.kt
@@ -1,12 +1,12 @@
 package no.nav.pensjon.simulator.core.beregn
 
-import no.nav.pensjon.simulator.core.SimulatorContext
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 import no.nav.pensjon.simulator.core.domain.regler.enum.BorMedTypeEnum
+import no.nav.pensjon.simulator.krav.KravService
 import org.springframework.stereotype.Component
 
 @Component
-class Alderspensjon2016SisteBeregningCreator(context: SimulatorContext) : SisteBeregningCreatorBase(context) {
+class Alderspensjon2016SisteBeregningCreator(kravService: KravService) : SisteBeregningCreatorBase(kravService) {
 
     // AbstraktOpprettSisteAldersberegning.execute
     override fun createBeregning(spec: SisteBeregningSpec, beregningResultat: AbstraktBeregningsResultat?) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2025SisteBeregningCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2025SisteBeregningCreator.kt
@@ -1,19 +1,19 @@
 package no.nav.pensjon.simulator.core.beregn
 
-import no.nav.pensjon.simulator.core.SimulatorContext
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsResultatAlderspensjon2025
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.SisteAldersberegning2011
+import no.nav.pensjon.simulator.krav.KravService
 import org.springframework.stereotype.Component
 
 // Corresponds to AbstraktOpprettSisteAldersberegning + OpprettSisteAldersberegning2011Regelverk2025
 @Component
-class Alderspensjon2025SisteBeregningCreator(context: SimulatorContext) : SisteBeregningCreatorBase(context) {
+class Alderspensjon2025SisteBeregningCreator(kravService: KravService) : SisteBeregningCreatorBase(kravService) {
 
     // AbstraktOpprettSisteAldersberegning.execute
-    override fun createBeregning(spec: SisteBeregningSpec, beregningsresultat: AbstraktBeregningsResultat?) =
+    override fun createBeregning(spec: SisteBeregningSpec, beregningResultat: AbstraktBeregningsResultat?) =
         newSisteAldersberegning2011(spec).also {
-            populate(it, spec, beregningsresultat)
+            populate(it, spec, beregningResultat)
         }
 
     // OpprettSisteAldersberegning2011Regelverk2025.createAndInitSisteBeregning
@@ -23,8 +23,8 @@ class Alderspensjon2025SisteBeregningCreator(context: SimulatorContext) : SisteB
         }
 
         populateSisteBeregningFromBeregningsresultat2025(
-            sisteBeregning,
-            spec.beregningsresultat as? BeregningsResultatAlderspensjon2025
+            beregning = sisteBeregning,
+            beregningResultat = spec.beregningsresultat as? BeregningsResultatAlderspensjon2025
         )
 
         return sisteBeregning
@@ -33,9 +33,9 @@ class Alderspensjon2025SisteBeregningCreator(context: SimulatorContext) : SisteB
     // OpprettSisteAldersberegning2011Regelverk2025.populateSisteBeregningFromBeregningsresultat2025
     private fun populateSisteBeregningFromBeregningsresultat2025(
         beregning: SisteAldersberegning2011,
-        beregningsresultat: BeregningsResultatAlderspensjon2025?
+        beregningResultat: BeregningsResultatAlderspensjon2025?
     ) {
-        val aldersberegningKapittel20 = beregningsresultat?.beregningKapittel20
+        val aldersberegningKapittel20 = beregningResultat?.beregningKapittel20
 
         aldersberegningKapittel20?.let {
             setAlternativKonvensjonData(beregning, aldersberegningKapittel20, it.beregningsMetodeEnum!!)
@@ -46,10 +46,10 @@ class Alderspensjon2025SisteBeregningCreator(context: SimulatorContext) : SisteB
             beregning.beholdninger = it.beholdninger
         }
 
-        beregning.virkDato = beregningsresultat?.virkFom
-        beregning.pensjonUnderUtbetaling = utenIrrelevanteYtelseskomponenter(beregningsresultat?.pensjonUnderUtbetaling)
-        beregningsresultat?.benyttetSivilstandEnum?.let { beregning.benyttetSivilstandEnum = it }
-        val beregningsinformasjon = beregningsresultat?.beregningsInformasjonKapittel20
+        beregning.virkDato = beregningResultat?.virkFom
+        beregning.pensjonUnderUtbetaling = utenIrrelevanteYtelseskomponenter(beregningResultat?.pensjonUnderUtbetaling)
+        beregningResultat?.benyttetSivilstandEnum?.let { beregning.benyttetSivilstandEnum = it }
+        val beregningsinformasjon = beregningResultat?.beregningsInformasjonKapittel20
 
         beregningsinformasjon?.let {
             beregning.epsMottarPensjon = it.epsMottarPensjon
@@ -76,29 +76,6 @@ class Alderspensjon2025SisteBeregningCreator(context: SimulatorContext) : SisteB
 
         // Clear id values of all TtUtlandTrygdeavtale objects. Also copied by FPEN003 periodiserGrunnlag.
         trygdetid.ttUtlandTrygdeavtaler?.let { avtaler -> avtaler.forEach { it.ttUtlandTrygdeavtaleId = null } }
-    }
-    */
-
-    //TODO:
-    /* This method fetches krav from database; assumed to be irrelevant during simulation
-    private fun fetchPersongrunnlagFraForrigeKrav(
-        beregningsresultat: BeregningHoveddel?,
-        kravService: KravServiceBi,
-        fpenService: FpenServiceBi): Persongrunnlag? {
-        if (beregningsresultat == null || beregningsresultat.kravId == null) {
-            return null
-        }
-
-        val sisteKravhode: Kravhode = kravService.hentKrav(beregningsresultat.kravId) // NB DB access
-
-        val pgRequest = PeriodiserGrunnlagRequest().apply {
-            kravHode = sisteKravhode
-            virkDatoFom = beregningsresultat.virkFom
-            virkDatoTom = beregningsresultat.virkTom
-        }
-
-        val sisteKravhodePeriodisert: Kravhode = fpenService.periodiserGrunnlag(pgRequest).getKravhode()
-        return getEpsPersongrunnlag(sisteKravhodePeriodisert)
     }
     */
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreatorBase.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreatorBase.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.beregn
 
-import no.nav.pensjon.simulator.core.SimulatorContext
+import no.nav.pensjon.simulator.core.beregn.BehandlingPeriodeUtil.periodiserGrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 import no.nav.pensjon.simulator.core.domain.regler.enum.BeregningsmetodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
@@ -9,14 +9,16 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
+import no.nav.pensjon.simulator.core.util.toLocalDate
+import no.nav.pensjon.simulator.krav.KravService
 
 // AbstraktOpprettSisteAldersberegning, OpprettSisteAldersberegningCommon, OpprettSisteBeregningCommand
-abstract class SisteBeregningCreatorBase(private val context: SimulatorContext) {
+abstract class SisteBeregningCreatorBase(private val kravService: KravService) {
 
     // OpprettSisteBeregningCommand.execute
     abstract fun createBeregning(
-        input: SisteBeregningSpec,
-        beregningsresultat: AbstraktBeregningsResultat?
+        spec: SisteBeregningSpec,
+        beregningResultat: AbstraktBeregningsResultat?
     ): SisteBeregning
 
     // AbstraktOpprettSisteAldersberegning.populateCommonValuesOnSisteBeregning
@@ -76,7 +78,8 @@ abstract class SisteBeregningCreatorBase(private val context: SimulatorContext) 
         kravhode?.hentPersongrunnlagForRolle(GrunnlagsrolleEnum.AVDOD, false)
 
     // Extracted
-    private fun sokerDetalj(kravhode: Kravhode?): PersonDetalj? = kravhode?.findPersonDetaljIBruk(GrunnlagsrolleEnum.SOKER)
+    private fun sokerDetalj(kravhode: Kravhode?): PersonDetalj? =
+        kravhode?.findPersonDetaljIBruk(GrunnlagsrolleEnum.SOKER)
 
     // OpprettSisteAldersberegningCommon.findDelberegning (predicate from addAltKonv)
     private fun findTapendeDelberegning(
@@ -106,15 +109,14 @@ abstract class SisteBeregningCreatorBase(private val context: SimulatorContext) 
     }
 
     // OpprettSisteAldersberegningCommon.fetchPersongrunnlagFraForrigeKrav
-    private fun fetchEpsGrunnlag(beregningsresultat: AbstraktBeregningsResultat): Persongrunnlag? {
-        /*ANON
-        val kravhode: Kravhode? = beregningsresultat.kravId?.let(context::fetchKravhode)
+    private fun fetchEpsGrunnlag(beregningResultat: AbstraktBeregningsResultat): Persongrunnlag? {
+        val kravhode: Kravhode? = beregningResultat.kravId?.let(kravService::fetchKravhode)
 
         val periodisertKravhode: Kravhode? =
             kravhode?.let {
                 periodiserGrunnlag(
-                    virkFom = beregningsresultat.virkFom,
-                    virkTom = null,
+                    virkningFom = beregningResultat.virkFom.toLocalDate(),
+                    virkningTom = null,
                     originalKravhode = it,
                     periodiserFomTomDatoUtenUnntak = true,
                     sakType = null
@@ -122,8 +124,6 @@ abstract class SisteBeregningCreatorBase(private val context: SimulatorContext) 
             }
 
         return periodisertKravhode?.let(::getEpsGrunnlag)
-        */
-        return null
     }
 
     // OpprettSisteAldersberegningCommon.getEpsPersongrunnlag

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagMapper.kt
@@ -1,6 +1,5 @@
 package no.nav.pensjon.simulator.core.person
 
-import no.nav.pensjon.simulator.core.SimulatorContext
 import no.nav.pensjon.simulator.core.SimuleringSpec
 import no.nav.pensjon.simulator.core.beholdning.BeholdningUtil.SISTE_GYLDIGE_OPPTJENING_AAR
 import no.nav.pensjon.simulator.core.domain.SimuleringType
@@ -11,12 +10,13 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.InngangOgEksportGrun
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.fromLocalDate
+import no.nav.pensjon.simulator.generelt.GenerelleDataHolder
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
 // no.nav.service.pensjon.simulering.support.command.abstractsimulerapfra2011.PersongrunnlagMapper
 @Component
-class PersongrunnlagMapper(val context: SimulatorContext) {
+class PersongrunnlagMapper(private val generelleDataHolder: GenerelleDataHolder) {
 
     fun mapToPersongrunnlag(person: PenPerson, spec: SimuleringSpec) =
         createPersongrunnlag(
@@ -58,7 +58,7 @@ class PersongrunnlagMapper(val context: SimulatorContext) {
             gjelderUforetrygd = false
             penPerson = person
             fodselsdato = person.fodselsdato
-            statsborgerskapEnum = norge //ANON person.pid?.let(context::getStatsborgerskap)?.let { LandCti(it.name) } ?: norge
+            statsborgerskapEnum = person.pid?.let { generelleDataHolder.getPerson(it).statsborgerskap }
             bosattLandEnum = norge
             afpHistorikkListe = person.afpHistorikkListe ?: mutableListOf()
             uforeHistorikk = person.uforehistorikk

--- a/src/main/kotlin/no/nav/pensjon/simulator/generelt/GenerelleData.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/generelt/GenerelleData.kt
@@ -4,10 +4,9 @@ import no.nav.pensjon.simulator.core.afp.privat.PrivatAfpSatser
 import no.nav.pensjon.simulator.core.domain.regler.VeietSatsResultat
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.DelingstallUtvalg
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.ForholdstallUtvalg
-import java.time.LocalDate
 
 data class GenerelleData(
-    val foedselDato: LocalDate,
+    val person: Person,
     val privatAfpSatser: PrivatAfpSatser,
     val delingstallUtvalg: DelingstallUtvalg,
     val forholdstallUtvalg: ForholdstallUtvalg,

--- a/src/main/kotlin/no/nav/pensjon/simulator/generelt/GenerelleDataHolder.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/generelt/GenerelleDataHolder.kt
@@ -8,20 +8,21 @@ import no.nav.pensjon.simulator.generelt.client.GenerelleDataClient
 import no.nav.pensjon.simulator.person.Pid
 import org.springframework.stereotype.Component
 import java.time.LocalDate
+import java.util.Collections.synchronizedMap
 
 @Component
 class GenerelleDataHolder(val client: GenerelleDataClient) {
 
-    private val foedselDatoCache: MutableMap<Pid, LocalDate> = HashMap()
-    private val delingstallCache: MutableMap<DatoAvhengighetCacheKey, DelingstallUtvalg> = HashMap()
-    private val forholdstallCache: MutableMap<DatoAvhengighetCacheKey, ForholdstallUtvalg> = HashMap()
-    private val privatAfpSatsCache: MutableMap<DatoAvhengighetCacheKey, PrivatAfpSatser> = HashMap()
-    private val grunnbeloepCache: MutableMap<GrunnbeloepCacheKey, List<VeietSatsResultat>> = HashMap()
+    private val personCache: MutableMap<Pid, Person> = synchronizedMap(mutableMapOf())
+    private val delingstallCache: MutableMap<DatoAvhengighetCacheKey, DelingstallUtvalg> = synchronizedMap(mutableMapOf())
+    private val forholdstallCache: MutableMap<DatoAvhengighetCacheKey, ForholdstallUtvalg> = synchronizedMap(mutableMapOf())
+    private val privatAfpSatsCache: MutableMap<DatoAvhengighetCacheKey, PrivatAfpSatser> = synchronizedMap(mutableMapOf())
+    private val grunnbeloepCache: MutableMap<GrunnbeloepCacheKey, List<VeietSatsResultat>> = synchronizedMap(mutableMapOf())
 
-    fun getFoedselDato(pid: Pid): LocalDate =
-        foedselDatoCache[pid]
-            ?: client.fetchGenerelleData(GenerelleDataSpec.forFoedselDato(pid)).foedselDato.also {
-                foedselDatoCache[pid] = it
+    fun getPerson(pid: Pid): Person =
+        personCache[pid]
+            ?: client.fetchGenerelleData(GenerelleDataSpec.forPerson(pid)).person.also {
+                personCache[pid] = it
             }
 
     fun getDelingstallUtvalg(virkningFom: LocalDate, foedselDato: LocalDate): DelingstallUtvalg {

--- a/src/main/kotlin/no/nav/pensjon/simulator/generelt/GenerelleDataSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/generelt/GenerelleDataSpec.kt
@@ -11,7 +11,7 @@ data class GenerelleDataSpec(
     val inkludering: InkluderingSpec
 ) {
     companion object {
-        fun forFoedselDato(pid: Pid) =
+        fun forPerson(pid: Pid) =
             GenerelleDataSpec(
                 pid,
                 virkningFom = null,

--- a/src/main/kotlin/no/nav/pensjon/simulator/generelt/Person.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/generelt/Person.kt
@@ -1,0 +1,9 @@
+package no.nav.pensjon.simulator.generelt
+
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
+import java.time.LocalDate
+
+data class Person(
+    val foedselDato: LocalDate,
+    val statsborgerskap: LandkodeEnum
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/generelt/client/pen/PenGenerelleDataClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/generelt/client/pen/PenGenerelleDataClient.kt
@@ -3,10 +3,12 @@ package no.nav.pensjon.simulator.generelt.client.pen
 import mu.KotlinLogging
 import no.nav.pensjon.simulator.common.client.ExternalServiceClient
 import no.nav.pensjon.simulator.core.afp.privat.PrivatAfpSatser
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.DelingstallUtvalg
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.ForholdstallUtvalg
 import no.nav.pensjon.simulator.generelt.GenerelleData
 import no.nav.pensjon.simulator.generelt.GenerelleDataSpec
+import no.nav.pensjon.simulator.generelt.Person
 import no.nav.pensjon.simulator.generelt.client.GenerelleDataClient
 import no.nav.pensjon.simulator.generelt.client.pen.acl.PenGenerelleDataResult
 import no.nav.pensjon.simulator.generelt.client.pen.acl.PenGenerelleDataResultMapper
@@ -83,7 +85,7 @@ class PenGenerelleDataClient(
 
         private fun nullResult() =
             GenerelleData(
-                foedselDato = LocalDate.MIN,
+                person = Person(LocalDate.MIN, LandkodeEnum.NOR),
                 privatAfpSatser = PrivatAfpSatser(),
                 delingstallUtvalg = DelingstallUtvalg(),
                 forholdstallUtvalg = ForholdstallUtvalg(),

--- a/src/main/kotlin/no/nav/pensjon/simulator/generelt/client/pen/acl/PenGenerelleDataResult.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/generelt/client/pen/acl/PenGenerelleDataResult.kt
@@ -7,11 +7,16 @@ import java.time.LocalDate
  * Corresponds to SimulatorGenerelleData in pensjon-pen
  */
 data class PenGenerelleDataResult(
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "CET") val foedselDato: LocalDate?, // null if anonym
+    val person: PenPersonData?, // null if anonym
     val privatAfpSatser: PenPrivatAfpSatser?,
     val delingstallUtvalg: PenDelingstallUtvalg?,
     val forholdstallUtvalg: PenForholdstallUtvalg?,
     val satsResultatListe: List<PenVeietSatsResultat>?
+)
+
+data class PenPersonData(
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "CET") val foedselDato: LocalDate?,
+    val statsborgerskap: String?
 )
 
 data class PenPrivatAfpSatser(

--- a/src/main/kotlin/no/nav/pensjon/simulator/generelt/client/pen/acl/PenGenerelleDataResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/generelt/client/pen/acl/PenGenerelleDataResultMapper.kt
@@ -2,22 +2,32 @@ package no.nav.pensjon.simulator.generelt.client.pen.acl
 
 import no.nav.pensjon.simulator.core.afp.privat.PrivatAfpSatser
 import no.nav.pensjon.simulator.core.domain.regler.VeietSatsResultat
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Delingstall
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.DelingstallUtvalg
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Forholdstall
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.ForholdstallUtvalg
 import no.nav.pensjon.simulator.generelt.GenerelleData
+import no.nav.pensjon.simulator.generelt.Person
 import java.time.LocalDate
 
 object PenGenerelleDataResultMapper {
 
+    private val defaultPerson = Person(LocalDate.MIN, LandkodeEnum.NOR)
+
     fun fromDto(source: PenGenerelleDataResult) =
         GenerelleData(
-            foedselDato = source.foedselDato ?: LocalDate.MIN,
+            person = source.person?.let(::person) ?: defaultPerson,
             privatAfpSatser = source.privatAfpSatser?.let(::privatAfpSatser) ?: PrivatAfpSatser(),
             delingstallUtvalg = source.delingstallUtvalg?.let(::delingstallUtvalg) ?: DelingstallUtvalg(),
             forholdstallUtvalg = source.forholdstallUtvalg?.let(::forholdstallUtvalg) ?: ForholdstallUtvalg(),
             satsResultatListe = source.satsResultatListe.orEmpty().map(::veietSatsResultat)
+        )
+
+    private fun person(source: PenPersonData) =
+        Person(
+            foedselDato = source.foedselDato ?: defaultPerson.foedselDato,
+            statsborgerskap = source.statsborgerskap?.let(LandkodeEnum::valueOf) ?: defaultPerson.statsborgerskap
         )
 
     private fun privatAfpSatser(source: PenPrivatAfpSatser) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/krav/KravService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/krav/KravService.kt
@@ -1,0 +1,11 @@
+package no.nav.pensjon.simulator.krav
+
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.krav.client.KravClient
+import org.springframework.stereotype.Service
+
+@Service
+class KravService(private val client: KravClient) {
+
+    fun fetchKravhode(kravhodeId: Long): Kravhode = client.fetchKravhode(kravhodeId)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/krav/client/KravClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/krav/client/KravClient.kt
@@ -1,0 +1,7 @@
+package no.nav.pensjon.simulator.krav.client
+
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+
+interface KravClient {
+    fun fetchKravhode(kravhodeId: Long): Kravhode
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/PenKravClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/PenKravClient.kt
@@ -1,0 +1,74 @@
+package no.nav.pensjon.simulator.krav.client.pen
+
+import mu.KotlinLogging
+import no.nav.pensjon.simulator.common.client.ExternalServiceClient
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.krav.client.KravClient
+import no.nav.pensjon.simulator.krav.client.pen.acl.PenKravSpec
+import no.nav.pensjon.simulator.tech.security.egress.EgressAccess
+import no.nav.pensjon.simulator.tech.security.egress.config.EgressService
+import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.tech.web.CustomHttpHeaders
+import no.nav.pensjon.simulator.tech.web.EgressException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+@Component
+class PenKravClient(
+    @Value("\${ps.pen.url}") baseUrl: String,
+    @Value("\${ps.web-client.retry-attempts}") retryAttempts: String,
+    webClientBuilder: WebClient.Builder,
+    private val traceAid: TraceAid
+) : ExternalServiceClient(retryAttempts), KravClient {
+
+    private val log = KotlinLogging.logger {}
+    private val webClient = webClientBuilder.baseUrl(baseUrl).build()
+
+    override fun fetchKravhode(kravhodeId: Long): Kravhode {
+        val uri = "$BASE_PATH/$PATH"
+
+        return try {
+            webClient
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .headers(::setHeaders)
+                .bodyValue(PenKravSpec(kravhodeId))
+                .retrieve()
+                .bodyToMono(Kravhode::class.java)
+                .retryWhen(retryBackoffSpec(uri))
+                .block()
+                ?: Kravhode()
+            // NB: No mapping of response; it is assumed that PEN returns regler-compatible Kravhode
+        } catch (e: WebClientRequestException) {
+            throw EgressException("Failed calling $uri", e)
+        } catch (e: WebClientResponseException) {
+            throw EgressException(e.responseBodyAsString, e)
+        }
+    }
+
+    override fun service() = service
+
+    override fun toString(e: EgressException, uri: String) = "Failed calling $uri"
+
+    private fun setHeaders(headers: HttpHeaders) {
+        with(EgressAccess.token(service).value) {
+            headers.setBearerAuth(this)
+            log.debug { "Token: $this" }
+        }
+
+        headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
+    }
+
+    companion object {
+        private const val BASE_PATH = "api"
+        private const val PATH = "v1/simulering/kravhode"
+        private val service = EgressService.PENSJONSFAGLIG_KJERNE
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenKravSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenKravSpec.kt
@@ -1,0 +1,5 @@
+package no.nav.pensjon.simulator.krav.client.pen.acl
+
+data class PenKravSpec(
+    val kravId: Long
+)

--- a/src/test/kotlin/no/nav/pensjon/simulator/generelt/client/pen/acl/PenGenerelleDataResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/generelt/client/pen/acl/PenGenerelleDataResultMapperTest.kt
@@ -1,0 +1,168 @@
+package no.nav.pensjon.simulator.generelt.client.pen.acl
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.core.afp.privat.PrivatAfpSatser
+import no.nav.pensjon.simulator.core.domain.regler.VeietSatsResultat
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Delingstall
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.DelingstallUtvalg
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Forholdstall
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.ForholdstallUtvalg
+import no.nav.pensjon.simulator.generelt.GenerelleData
+import no.nav.pensjon.simulator.generelt.Person
+import java.time.LocalDate
+
+class PenGenerelleDataResultMapperTest : FunSpec({
+
+    test("fromDto with empty lists") {
+        PenGenerelleDataResultMapper.fromDto(
+            PenGenerelleDataResult(
+                person = PenPersonData(
+                    foedselDato = LocalDate.of(1964, 5, 6),
+                    statsborgerskap = "ABW"
+                ),
+                privatAfpSatser = PenPrivatAfpSatser(forholdstall = null),
+                delingstallUtvalg = PenDelingstallUtvalg(
+                    dt = 1.2,
+                    dt67soker = 3.4,
+                    dt67virk = 5.6,
+                    delingstallListe = mutableListOf()
+                ),
+                forholdstallUtvalg = PenForholdstallUtvalg(
+                    ft = 1.2,
+                    forholdstallListe = mutableListOf(),
+                    ft67soeker = 3.4,
+                    ft67virkning = 5.6,
+                    reguleringFaktor = 7.8
+                ),
+                satsResultatListe = listOf()
+            )
+        ) shouldBeEqualToComparingFields
+                GenerelleData(
+                    person = Person(
+                        foedselDato = LocalDate.of(1964, 5, 6),
+                        statsborgerskap = LandkodeEnum.ABW
+                    ),
+                    privatAfpSatser = PrivatAfpSatser(ft = null),
+                    delingstallUtvalg = DelingstallUtvalg().apply {
+                        dt = 1.2
+                        dt67soker = 0.0 // not mapped, so not 3.4
+                        dt67virk = 0.0 // not mapped, so not 5.6
+                        delingstallListe = mutableListOf()
+                    },
+                    forholdstallUtvalg = ForholdstallUtvalg().apply {
+                        ft = 1.2
+                        forholdstallListe = mutableListOf()
+                        ft67soker = 0.0 // not mapped, so not 3.4
+                        ft67virk = 0.0 // not mapped, so not 5.6
+                        reguleringsfaktor = 0.0 // not mapped, so not 7.8
+                    },
+                    satsResultatListe = listOf()
+                )
+    }
+
+    /* TODO does currently not work with filled lists
+    test("fromDto with all fields defined") {
+        PenGenerelleDataResultMapper.fromDto(
+            PenGenerelleDataResult(
+                person = PenPersonData(
+                    foedselDato = LocalDate.of(1964, 5, 6),
+                    statsborgerskap = "ABW"
+                ),
+                privatAfpSatser = PenPrivatAfpSatser(
+                    forholdstall = PenAarskullTall(
+                        aarskull = 1964L,
+                        alderAar = 62,
+                        maaneder = 7,
+                        tall = 12.34
+                    )
+                ),
+                delingstallUtvalg = PenDelingstallUtvalg(
+                    dt = 1.2,
+                    dt67soker = 3.4,
+                    dt67virk = 5.6,
+                    delingstallListe = mutableListOf(
+                        PenAarskullTall(
+                            aarskull = 1965L,
+                            alderAar = 63,
+                            maaneder = 8,
+                            tall = 123.45
+                        ),
+                        PenAarskullTall(
+                            aarskull = 1966L,
+                            alderAar = 64,
+                            maaneder = 9,
+                            tall = 0.12
+                        )
+                    )
+                ),
+                forholdstallUtvalg = PenForholdstallUtvalg(
+                    ft = 1.2,
+                    forholdstallListe = mutableListOf(
+                        PenAarskullTall(
+                            aarskull = 1965L,
+                            alderAar = 63,
+                            maaneder = 8,
+                            tall = 123.45
+                        )
+                    ),
+                    ft67soeker = 3.4,
+                    ft67virkning = 5.6,
+                    reguleringFaktor = 7.8
+                ),
+                satsResultatListe = listOf(PenVeietSatsResultat(aar = 2024, verdi = 43.21))
+            )
+        ) shouldBeEqualToComparingFields
+                GenerelleData(
+                    person = Person(
+                        foedselDato = LocalDate.of(1964, 5, 6),
+                        statsborgerskap = LandkodeEnum.ABW
+                    ),
+                    privatAfpSatser = PrivatAfpSatser(
+                        ft = Forholdstall(
+                            arskull = 1964,
+                            alder = 62,
+                            maned = 7,
+                            forholdstall = 12.34
+                        )
+                    ),
+                    delingstallUtvalg = DelingstallUtvalg().apply {
+                        dt = 1.2
+                        dt67soker = 0.0 // not mapped, so not 3.4
+                        dt67virk = 0.0 // not mapped, so not 5.6
+                        delingstallListe = mutableListOf(
+                            Delingstall().apply {
+                                arskull = 1965L
+                                alder = 63
+                                maned = 8
+                                delingstall = 123.45
+                            },
+                            Delingstall().apply {
+                                arskull = 1966L
+                                alder = 64
+                                maned = 9
+                                delingstall = 0.12
+                            }
+                        )
+                    },
+                    forholdstallUtvalg = ForholdstallUtvalg().apply {
+                        ft = 1.2
+                        forholdstallListe = mutableListOf(
+                            Forholdstall().apply {
+                                arskull = 1965L
+                                alder = 63
+                                maned = 8
+                                forholdstall = 123.45
+                            }
+                        )
+                        ft67soker = 0.0 // not mapped, so not 3.4
+                        ft67virk = 0.0 // not mapped, so not 5.6
+                        reguleringsfaktor = 0.0 // not mapped, so not 7.8
+                    },
+                    satsResultatListe = listOf(VeietSatsResultat(ar = 2024, verdi = 43.21))
+                )
+    }
+    */
+})

--- a/src/test/kotlin/no/nav/pensjon/simulator/krav/client/pen/PenKravClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/krav/client/pen/PenKravClientTest.kt
@@ -1,0 +1,672 @@
+package no.nav.pensjon.simulator.krav.client.pen
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.tech.security.egress.EnrichedAuthentication
+import no.nav.pensjon.simulator.tech.security.egress.config.EgressTokenSuppliersByService
+import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.intellij.lang.annotations.Language
+import org.mockito.Mockito.mock
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.reactive.function.client.WebClient
+import java.util.*
+
+class PenKravClientTest : FunSpec({
+    var server: MockWebServer? = null
+    var baseUrl: String? = null
+
+    beforeSpec {
+        SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext())
+
+        SecurityContextHolder.getContext().authentication = EnrichedAuthentication(
+            TestingAuthenticationToken(
+                "TEST_USER",
+                Jwt("j.w.t", null, null, mapOf(Pair("k", "v")), mapOf(Pair("k", "v")))
+            ),
+            EgressTokenSuppliersByService(mapOf())
+        )
+
+        server = MockWebServer().also { it.start() }
+        baseUrl = "http://localhost:${server!!.port}"
+    }
+
+    afterSpec {
+        server?.shutdown()
+    }
+
+    test("fetchKravhode deserializes response") {
+        val contextRunner = ApplicationContextRunner().withConfiguration(
+            AutoConfigurations.of(WebClientAutoConfiguration::class.java)
+        )
+
+        server!!.enqueue(
+            MockResponse()
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setResponseCode(HttpStatus.OK.value()).setBody(PenKravhodeResponse.KRAVHODE)
+        )
+
+        contextRunner.run {
+            val webClientBuilder = it.getBean(WebClient.Builder::class.java)
+            val client = PenKravClient(
+                baseUrl!!, retryAttempts = "0", webClientBuilder, mock(TraceAid::class.java)
+            )
+
+            val result: Kravhode = client.fetchKravhode(123L)
+
+            result.persongrunnlagListe.size shouldBe 1
+            with(result.persongrunnlagListe[0]) {
+                personDetaljListe.size shouldBe 1
+                personDetaljListe[0].bruk shouldBe true
+                fodselsdato shouldBe dateAtNoon(year = 1974, month = Calendar.MARCH, day = 30)
+            }
+            result.kravlinjeListe.size shouldBe 1
+            result.kravlinjeListe[0].kravlinjeType?.kode shouldBe "UT"
+        }
+    }
+})
+
+object PenKravhodeResponse {
+
+    @Language("json")
+    const val KRAVHODE = """{
+    "persongrunnlagListe": [
+        {
+            "penPerson": {
+                "penPersonId": 1234
+            },
+            "fodselsdato": "1974-03-30T12:00:00+0100",
+            "dodsdato": null,
+            "statsborgerskap": {
+                "kode": "NOR",
+                "dekode": null,
+                "dato_fom": null,
+                "dato_tom": null,
+                "er_gyldig": true,
+                "kommentar": null
+            },
+            "flyktning": false,
+            "personDetaljListe": [
+                {
+                    "grunnlagsrolle": {
+                        "kode": "SOKER",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "rolleFomDato": "1974-04-01T12:00:00+0100",
+                    "rolleTomDato": null,
+                    "sivilstandType": {
+                        "kode": "UGIF",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "sivilstandRelatertPerson": null,
+                    "borMed": null,
+                    "barnDetalj": null,
+                    "tillegg": false,
+                    "bruk": true,
+                    "grunnlagKilde": {
+                        "kode": "TPS",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "serskiltSatsUtenET": null,
+                    "epsAvkallEgenPensjon": null,
+                    "eps": false
+                }
+            ],
+            "sistMedlITrygden": null,
+            "sisteGyldigeOpptjeningsAr": 2016,
+            "hentetPopp": true,
+            "hentetInnt": false,
+            "hentetInst": false,
+            "hentetTT": true,
+            "hentetArbeid": false,
+            "overkompUtl": null,
+            "opptjeningsgrunnlagListe": [
+                {
+                    "ar": 2010,
+                    "pi": 653500,
+                    "pia": 516717,
+                    "pp": 5.92,
+                    "opptjeningType": {
+                        "kode": "PPI",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "maksUforegrad": 0,
+                    "bruk": true,
+                    "grunnlagKilde": {
+                        "kode": "POPP",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "opptjeningTypeListe": [
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "INN_LON",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        },
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "AI",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ar": 2011,
+                    "pi": 665000,
+                    "pia": 533763,
+                    "pp": 5.84,
+                    "opptjeningType": {
+                        "kode": "PPI",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "maksUforegrad": 0,
+                    "bruk": true,
+                    "grunnlagKilde": {
+                        "kode": "POPP",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "opptjeningTypeListe": [
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "INN_LON",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        },
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "AI",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ar": 2012,
+                    "pi": 649100,
+                    "pia": 540979,
+                    "pp": 5.67,
+                    "opptjeningType": {
+                        "kode": "PPI",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "maksUforegrad": 0,
+                    "bruk": true,
+                    "grunnlagKilde": {
+                        "kode": "POPP",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "opptjeningTypeListe": [
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "INN_LON",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        },
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "AI",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ar": 2013,
+                    "pi": 627300,
+                    "pia": 545916,
+                    "pp": 5.48,
+                    "opptjeningType": {
+                        "kode": "PPI",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "maksUforegrad": 0,
+                    "bruk": true,
+                    "grunnlagKilde": {
+                        "kode": "POPP",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "opptjeningTypeListe": [
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "INN_LON",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        },
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "AI",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ar": 2014,
+                    "pi": 631200,
+                    "pia": 559712,
+                    "pp": 5.41,
+                    "opptjeningType": {
+                        "kode": "PPI",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "maksUforegrad": 0,
+                    "bruk": true,
+                    "grunnlagKilde": {
+                        "kode": "POPP",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "opptjeningTypeListe": [
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "INN_LON",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        },
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "AI",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ar": 2015,
+                    "pi": 589300,
+                    "pia": 554441,
+                    "pp": 5.19,
+                    "opptjeningType": {
+                        "kode": "PPI",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "maksUforegrad": 0,
+                    "bruk": true,
+                    "grunnlagKilde": {
+                        "kode": "POPP",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "opptjeningTypeListe": [
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "INN_LON",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        },
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "AI",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        }
+                    ]
+                },
+                {
+                    "ar": 2016,
+                    "pi": 556600,
+                    "pia": 552493,
+                    "pp": 5.02,
+                    "opptjeningType": {
+                        "kode": "PPI",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "maksUforegrad": 0,
+                    "bruk": true,
+                    "grunnlagKilde": {
+                        "kode": "POPP",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "opptjeningTypeListe": [
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "INN_LON",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        },
+                        {
+                            "opptjeningPOPPTypeCti": {
+                                "kode": "AI",
+                                "dekode": null,
+                                "dato_fom": null,
+                                "dato_tom": null,
+                                "er_gyldig": true,
+                                "kommentar": null
+                            }
+                        }
+                    ]
+                }
+            ],
+            "inntektsgrunnlagListe": [],
+            "trygdetidPerioder": [
+                {
+                    "fom": "2010-01-01T12:00:00+0100",
+                    "tom": "2016-12-31T12:00:00+0100",
+                    "changed": null,
+                    "poengIInnAr": false,
+                    "poengIUtAr": false,
+                    "land": {
+                        "kode": "NOR",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "ikkeProRata": false,
+                    "bruk": true,
+                    "grunnlagKilde": {
+                        "kode": "SAKSB",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    }
+                }
+            ],
+            "trygdetidPerioderKapittel20": [],
+            "trygdetid": null,
+            "trygdetidKapittel20": null,
+            "trygdetidAlternativ": null,
+            "uforegrunnlag": null,
+            "uforeHistorikk": null,
+            "yrkesskadegrunnlag": null,
+            "dodAvYrkesskade": false,
+            "generellHistorikk": {
+                "generellHistorikkId": 52634486,
+                "fravik_19_3": null,
+                "fpp_eos": 0.0,
+                "ventetilleggsgrunnlag": null,
+                "poengtillegg": null,
+                "eosEkstra": null,
+                "garantiTrygdetid": null,
+                "sertillegg1943kull": null,
+                "giftFor2011": false
+            },
+            "afpHistorikkListe": [],
+            "barnekull": null,
+            "barnetilleggVurderingsperiode": null,
+            "antallArUtland": 0,
+            "medlemIFolketrygdenSiste3Ar": null,
+            "over60ArKanIkkeForsorgesSelv": null,
+            "utenlandsoppholdListe": [
+                {
+                    "fom": "1998-01-01T12:00:00+0100",
+                    "tom": "2002-12-31T12:00:00+0100",
+                    "land": {
+                        "kode": "SWE",
+                        "dekode": null,
+                        "dato_fom": null,
+                        "dato_tom": null,
+                        "er_gyldig": true,
+                        "kommentar": null
+                    },
+                    "pensjonsordning": null,
+                    "bodd": true,
+                    "arbeidet": true
+                }
+            ],
+            "trygdeavtale": null,
+            "trygdeavtaledetaljer": null,
+            "inngangOgEksportGrunnlag": null,
+            "forsteVirkningsdatoGrunnlagListe": [],
+            "arligPGIMinst1G": null,
+            "artikkel10": null,
+            "vernepliktAr": [],
+            "skiltesDelAvAvdodesTP": -99,
+            "instOpphReduksjonsperiodeListe": [],
+            "instOpphFasteUtgifterperiodeListe": [],
+            "bosattLand": null,
+            "pensjonsbeholdning": {
+                "type": "Pensjonsbeholdning",
+                "ar": 2018,
+                "totalbelop": 844321.0148069302,
+                "opptjening": {
+                    "ar": 2016,
+                    "opptjeningsgrunnlag": 556600.0,
+                    "anvendtOpptjeningsgrunnlag": 556600.0,
+                    "arligOpptjening": 102820.11680059433,
+                    "lonnsvekstInformasjon": null,
+                    "poengtall": {
+                        "type": "Poengtall",
+                        "pp": 0.0,
+                        "pia": 0,
+                        "pi": 0,
+                        "ar": 0,
+                        "bruktIBeregning": false,
+                        "gv": 0,
+                        "poengtallType": null,
+                        "maksUforegrad": 0,
+                        "uforear": false,
+                        "merknadListe": [],
+                        "omsorg": false,
+                        "opptjeningsar": 0,
+                        "inntektIAvtaleland": false,
+                        "justertBelop": 0.0,
+                        "verdi": 0.0
+                    },
+                    "inntektUtenDagpenger": 556600.0,
+                    "uforeOpptjening": null,
+                    "dagpenger": 0.0,
+                    "dagpengerFiskerOgFangstmenn": 0.0,
+                    "omsorg": 0.0,
+                    "forstegangstjeneste": 0.0,
+                    "arligOpptjeningOmsorg": 0.0,
+                    "arligOpptjeningUtenOmsorg": 0.0,
+                    "psatsOpptjening": 0.0
+                },
+                "lonnsvekstInformasjon": {
+                    "lonnsvekst": 0.0,
+                    "reguleringsDato": "2018-05-01T12:00:00+0200",
+                    "uttaksgradVedRegulering": 0
+                },
+                "reguleringsInformasjon": {
+                    "lonnsvekst": 0.0,
+                    "fratrekksfaktor": 0.0,
+                    "gammelG": 0,
+                    "nyG": 0,
+                    "reguleringsfaktor": 0.0,
+                    "gjennomsnittligUttaksgradSisteAr": 0.0,
+                    "reguleringsbelop": 28315.395007055602,
+                    "prisOgLonnsvekst": 0.0
+                },
+                "formelkode": null,
+                "beholdningsType": {
+                    "kode": "PEN_B",
+                    "dekode": null,
+                    "dato_fom": null,
+                    "dato_tom": null,
+                    "er_gyldig": true,
+                    "kommentar": null
+                },
+                "merknadListe": []
+            },
+            "forstegangstjenestegrunnlag": null,
+            "dagpengegrunnlagListe": [],
+            "omsorgsgrunnlagListe": [],
+            "arbeidsforholdsgrunnlagListe": [],
+            "arbeidsforholdEtterUforgrunnlagListe": [],
+            "overgangsInfoUPtilUT": null,
+            "utbetalingsgradUTListe": [],
+            "sortedTrygdetidPerioderKapittel20": [],
+            "vernepliktArAsList": [],
+            "barnOrFosterbarn": false,
+            "afpTpoUpGrunnlag": null,
+            "soker": true,
+            "avdod": false,
+            "p67": false,
+            "eps": false
+        }
+    ],
+    "kravlinjeListe": [
+        {
+            "kravlinjeType": {
+                "kode": "UT",
+                "dekode": null,
+                "dato_fom": null,
+                "dato_tom": null,
+                "er_gyldig": true,
+                "kommentar": null,
+                "hovedKravlinje": true
+            },
+            "relatertPerson": {
+                "penPersonId": 22204461
+            },
+            "kravlinjeAvbrutt": false
+        }
+    ],
+    "afpOrdning": null,
+    "afptillegg": false,
+    "brukOpptjeningFra65I66Aret": false,
+    "kravVelgType": {
+        "kode": "VARIG",
+        "dekode": null,
+        "dato_fom": null,
+        "dato_tom": null,
+        "er_gyldig": true,
+        "kommentar": null,
+        "hovedKravlinje": false
+    },
+    "boddEllerArbeidetIUtlandet": true,
+    "boddArbeidUtlandFar": false,
+    "boddArbeidUtlandMor": false,
+    "boddArbeidUtlandAvdod": false,
+    "uttaksgradListe": [],
+    "regelverkTypeCti": null,
+    "sisteSakstypeForAP": null,
+    "overstyrendeP_satsGP": 0.0,
+    "btVurderingsperiodeBenyttet": true,
+    "uforetrygd": true
+}"""
+}

--- a/src/test/kotlin/no/nav/pensjon/simulator/testutil/TestDateUtil.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/testutil/TestDateUtil.kt
@@ -1,0 +1,16 @@
+package no.nav.pensjon.simulator.testutil
+
+import java.util.*
+
+/**
+ * Date-related utility functions for use in tests.
+ */
+object TestDateUtil {
+
+    fun dateAtNoon(year: Int, month: Int, day: Int): Date =
+        Calendar.getInstance().apply {
+            this.clear()
+            this[year, month] = day
+            this[Calendar.HOUR_OF_DAY] = 12
+        }.time
+}


### PR DESCRIPTION
Del 1 av endringer for å støtte "innlogget" simulering.
Henter kravhode og statsborgerskap fra PEN der det behøves.

Pluss fjernet ubrukt kode i `SimulatorContext`.