### PR TITLE
PEK-551 Add simulering endpoint for 1963+

### DIFF
--- a/.nais/deploy-dev.yml
+++ b/.nais/deploy-dev.yml
@@ -56,10 +56,13 @@ spec:
   accessPolicy:
     inbound:
       rules:
+        - application: pensjon-pen-q2
+          namespace: pensjon-q2
+          cluster: dev-fss
         - application: pensjonskalkulator-backend
-        - application: azure-token-generator
+        - application: azure-token-generator # dev only
           namespace: aura
-        - application: tokenx-token-generator
+        - application: tokenx-token-generator # dev only
           namespace: aura
     outbound:
       rules:

--- a/.nais/deploy-prod.yml
+++ b/.nais/deploy-prod.yml
@@ -53,6 +53,12 @@ spec:
             - orgno: "982583462" # SPK
             - orgno: "931936492" # Storebrand Pensjonstjenester
   accessPolicy:
+    inbound:
+      rules:
+        - application: pensjon-pen
+          namespace: pensjondeployer
+          cluster: prod-fss
+        - application: pensjonskalkulator-backend
     outbound:
       rules:
         - application: pensjon-pen

--- a/src/main/kotlin/no/nav/pensjon/simulator/alder/Alder.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alder/Alder.kt
@@ -1,4 +1,4 @@
-package no.nav.pensjon.simulator.core.domain
+package no.nav.pensjon.simulator.alder
 
 data class Alder(val aar: Int, val maaneder: Int) {
 
@@ -11,6 +11,8 @@ data class Alder(val aar: Int, val maaneder: Int) {
         MAANEDER_PER_AAR * (aar - alder.aar) + maaneder - alder.maaneder
 
     fun minusAar(antall: Int) = Alder(aar - antall, maaneder)
+
+    fun plusAar(antall: Int) = Alder(aar + antall, maaneder)
 
     fun minusMaaneder(antall: Int): Alder {
         if (antall < 0) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/alder/AlderDato.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alder/AlderDato.kt
@@ -1,0 +1,36 @@
+package no.nav.pensjon.simulator.alder
+
+import java.time.LocalDate
+import java.time.Period
+
+/**
+ * Inneholder alder og den datoen som alderen representerer relativt til fødselsdato.
+ */
+data class AlderDato(
+    val alder: Alder,
+    val dato: LocalDate
+) {
+    constructor(foedselDato: LocalDate, alder: Alder)
+            : this(alder, datoVedAlder(foedselDato, alder))
+
+    constructor(foedselDato: LocalDate, dato: LocalDate)
+            : this(alderVedDato(foedselDato, dato), dato)
+
+    private companion object {
+        /**
+         * Pensjonsrelatert dato er første dag i måneden etter 'aldersbasert' dato.
+         */
+        private fun datoVedAlder(foedselDato: LocalDate, alder: Alder): LocalDate =
+            foedselDato
+                .plusYears(alder.aar.toLong())
+                .withDayOfMonth(1) // første dag i...
+                .plusMonths(alder.maaneder.toLong() + 1L) // ...måneden etter 'aldersbasert' dato
+
+        // TODO compare this with SimuleringRequestConverter.convertDatoFomToAlder
+        private fun alderVedDato(foedselDato: LocalDate, dato: LocalDate): Alder =
+            Period.between(
+                foedselDato.withDayOfMonth(1),
+                dato.withDayOfMonth(1)
+            ).let { Alder(it.years, it.months) }
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alder/PensjonAlderDato.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alder/PensjonAlderDato.kt
@@ -4,9 +4,10 @@ import java.time.LocalDate
 import java.time.Period
 
 /**
- * Inneholder alder og den datoen som alderen representerer relativt til fødselsdato.
+ * Inneholder pensjonsrelatart alder og den datoen som alderen representerer relativt til fødselsdato.
+ * "Pensjonsrelatert" vil si at det er første dag i måneden som brukes.
  */
-data class AlderDato(
+data class PensjonAlderDato(
     val alder: Alder,
     val dato: LocalDate
 ) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativSimuleringResult.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativSimuleringResult.kt
@@ -1,0 +1,25 @@
+package no.nav.pensjon.simulator.alderspensjon.alternativ
+
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.result.SimulatorOutput
+import no.nav.pensjon.simulator.search.ValueAssessment
+import java.time.LocalDate
+
+/**
+ * Inneholder input-parametre og output-resultat for en alternativ simulering.
+ */
+data class AlternativSimuleringResult(
+    override val valueIsGood: Boolean,
+    val simulertPensjon: SimulatorOutput?,
+    val usedParameters: AlternativSimuleringSpec,
+    val uttakAlderTransition: Boolean = false
+) : ValueAssessment
+
+data class AlternativSimuleringSpec(
+    val gradertUttakFom: LocalDate?,
+    val gradertUttakAlderIndex: Int?,
+    val uttakGrad: UttakGradKode,
+    val heltUttakFom: LocalDate,
+    val heltUttakAlderIndex: Int,
+    val inntektEtterHeltUttakAntallAar: Int? = null
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativSimuleringService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativSimuleringService.kt
@@ -1,0 +1,282 @@
+package no.nav.pensjon.simulator.alderspensjon.alternativ
+
+import no.nav.pensjon.simulator.alderspensjon.convert.SimulatorOutputConverter.pensjon
+import no.nav.pensjon.simulator.core.spec.SimuleringSpecUtil.utkantSimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpecUtil.withLavereUttakGrad
+import no.nav.pensjon.simulator.core.SimulatorCore
+import no.nav.pensjon.simulator.core.SimulatorFlags
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.domain.SimuleringType
+import no.nav.pensjon.simulator.core.exception.AvslagVilkaarsproevingForKortTrygdetidException
+import no.nav.pensjon.simulator.core.exception.AvslagVilkaarsproevingForLavtTidligUttakException
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.result.SimulatorOutput
+import no.nav.pensjon.simulator.core.spec.GradertUttakSimuleringSpec
+import no.nav.pensjon.simulator.core.spec.HeltUttakSimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpecUtil
+import no.nav.pensjon.simulator.normalder.NormAlderService
+import no.nav.pensjon.simulator.uttak.UttakUtil.uttakDato
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+/**
+ * Utfører simulering med alternative parametre, i den hensikt å finne kombinasjoner som gir "innvilget" i vilkårsprøvingen.
+ * Parameterne som varieres er én eller flere av:
+ * - Uttaksgrad
+ * - Alder for uttak av gradert alderspensjon
+ * - Alder for uttak av hel alderspensjon
+ * -------------------------
+ * Parameter 'inkluderPensjonHvisUbetinget' er relevant hvis bruker kun kan ta ut pensjon ved normalder (ubetinget alder):
+ * - Hvis 'true' vil responsen inkludere simulert pensjon
+ * - Hvis 'false' vil responsen bare inneholde informasjon om at bruker kun kan ta ut pensjon ved normalder
+ */
+@Service
+class AlternativSimuleringService(
+    private val simulator: SimulatorCore,
+    private val normAlderService: NormAlderService
+) {
+    fun simulerMedNesteLavereUttakGrad(
+        spec: SimuleringSpec,
+        foedselDato: LocalDate,
+        inkluderPensjonHvisUbetinget: Boolean
+    ): SimulertPensjonEllerAlternativ {
+        return try {
+            val lavereGradSpec: SimuleringSpec = withLavereUttakGrad(spec)
+            val flags: SimulatorFlags = simulatorFlags(lavereGradSpec)
+            val result: SimulatorOutput = simulator.simuler(lavereGradSpec, flags)
+            // Lavere grad innvilget; returner dette som alternativ og avslutt:
+            alternativResponse(lavereGradSpec, foedselDato, pensjon(result))
+        } catch (e: AvslagVilkaarsproevingForLavtTidligUttakException) {
+            // Lavere grad ga "avslått" resultat; prøv utkanttilfellet og ev. alternative parametre:
+            simulerAlternativHvisUtkanttilfelletInnvilges(spec, foedselDato, inkluderPensjonHvisUbetinget)
+        } catch (e: AvslagVilkaarsproevingForKortTrygdetidException) {
+            simulerAlternativHvisUtkanttilfelletInnvilges(spec, foedselDato, inkluderPensjonHvisUbetinget)
+        }
+    }
+
+    /**
+     * "Utkanttilfellet" er den "dårligst" mulige kombinasjon av uttaksalder og -grad for gradert uttak.
+     * Denne kombinasjonen består av:
+     * - Lavest mulig uttaksgrad (20 %)
+     * - Høyest mulig alder for uttak av gradert alderspensjon (én måned før normalder)
+     * - Normalder for uttak av hel alderspensjon (før 2026 er dette 67 år)
+     * ---------------
+     * Hensikten med å simulere for ytkanttilfellet er å fastslå hvorvidt brukeren kan ta gradert uttak i det hele tatt.
+     * Hvis utkantilfellet gir "avslått" i vilkårsprøvingen, kan vi konkludere med at brukeren kun kan ta ut helt uttak,
+     * og uttaket kan tidligst starte ved normalderen.
+     */
+    fun simulerAlternativHvisUtkanttilfelletInnvilges(
+        spec: SimuleringSpec,
+        foedselDato: LocalDate,
+        inkluderPensjonHvisUbetinget: Boolean
+    ): SimulertPensjonEllerAlternativ {
+        val normAlder: Alder = normAlderService.normAlder(foedselDato)
+
+        return try {
+            val utkantSpec: SimuleringSpec = utkantSimuleringSpec(spec, normAlder, foedselDato)
+            val flags: SimulatorFlags = simulatorFlags(spec)
+
+            simulator.simuler(utkantSpec, flags)
+            // resultatet av 'simuler' ignoreres - det interessante er om en exception oppstår
+
+            // Ingen exception => utkanttilfellet innvilget => prøv alternative parametre:
+            findAlternativtUttak(spec, flags, foedselDato, spec.gradertUttak(foedselDato), spec.heltUttak(foedselDato))
+        } catch (e: AvslagVilkaarsproevingForLavtTidligUttakException) {
+            // Utkanttilfellet avslått (intet gradert uttak mulig); returner alternativ for ubetinget uttak:
+            if (inkluderPensjonHvisUbetinget)
+                ubetingetUttakResponseMedSimulertPensjon(spec, normAlder, foedselDato)
+            else
+                ubetingetUttakResponseUtenSimulertPensjon(foedselDato, normAlder)
+        } catch (e: AvslagVilkaarsproevingForKortTrygdetidException) {
+            if (inkluderPensjonHvisUbetinget)
+                ubetingetUttakResponseMedSimulertPensjon(spec, normAlder, foedselDato)
+            else
+                ubetingetUttakResponseUtenSimulertPensjon(foedselDato, normAlder)
+        }
+    }
+
+    private fun ubetingetUttakResponseMedSimulertPensjon(
+        spec: SimuleringSpec,
+        normAlder: Alder,
+        foedselDato: LocalDate
+    ): SimulertPensjonEllerAlternativ =
+        try {
+            val ubetingetSpec: SimuleringSpec = SimuleringSpecUtil.ubetingetSimuleringSpec(spec, normAlder, foedselDato)
+            val flags: SimulatorFlags = simulatorFlags(spec)
+            val result: SimulatorOutput = simulator.simuler(ubetingetSpec, flags)
+            alternativResponse(ubetingetSpec, foedselDato, pensjon(result))
+        } catch (e: AvslagVilkaarsproevingForKortTrygdetidException) {
+            // Skal ikke kunne skje
+            throw RuntimeException("Simulering for ubetinget alder feilet", e)
+        } catch (e: AvslagVilkaarsproevingForLavtTidligUttakException) {
+            // Skal ikke kunne skje
+            throw RuntimeException("Simulering for ubetinget alder feilet", e)
+        }
+
+    private fun ubetingetUttakResponseUtenSimulertPensjon(foedselDato: LocalDate, normAlder: Alder) =
+        alternativResponse(ubetingetUttakAlternativ(foedselDato, normAlder), alternativPensjon = null)
+
+    private fun findAlternativtUttak(
+        spec: SimuleringSpec,
+        flags: SimulatorFlags,
+        foedselDato: LocalDate,
+        gradertUttak: GradertUttakSimuleringSpec?,
+        heltUttak: HeltUttakSimuleringSpec
+    ): SimulertPensjonEllerAlternativ {
+
+        val pensjonEllerAlternativ: SimulertPensjonEllerAlternativ =
+            findAlternativtUttak(
+                spec,
+                flags,
+                foedselDato,
+                heltUttakInntektTomAlderAar = heltUttak.inntektTom.alder.aar,
+                foersteUttakAngittAlder = forsteUttakAlder(gradertUttak, heltUttak),
+                andreUttakAngittAlder = andreUttakAlder(gradertUttak, heltUttak),
+                maxUttakGrad = gradertUttak?.grad ?: UttakGradKode.P_100
+            )
+
+        return pensjonEllerAlternativ.pensjon
+            ?.let { pensjonEllerAlternativ } ?: findAlternativFailed()
+    }
+
+    private fun findAlternativtUttak(
+        spec: SimuleringSpec,
+        flags: SimulatorFlags,
+        foedselDato: LocalDate,
+        heltUttakInntektTomAlderAar: Int,
+        foersteUttakAngittAlder: Alder,
+        andreUttakAngittAlder: Alder?, // null if not gradert
+        maxUttakGrad: UttakGradKode
+    ): SimulertPensjonEllerAlternativ {
+        val normAlder: Alder = normAlderService.normAlder(foedselDato)
+        val foersteUttakMaxAlder = normAlder.minusMaaneder(2)
+        val finder =
+            AlternativtUttakFinder(simulator, spec, flags, normAlderService, heltUttakInntektTomAlderAar)
+        val foersteUttakMinAlder = foersteUttakAngittAlder.plusMaaneder(1)
+        val andreUttakMinAlder: Alder? =
+            andreUttakAngittAlder?.let { if (foersteUttakMinAlder == it) it.plusMaaneder(1) else it }
+
+        val initialResult: SimulertPensjonEllerAlternativ =
+            finder.findAlternativtUttak(
+                foersteUttakMinAlder,
+                foersteUttakMaxAlder,
+                andreUttakMinAlder,
+                andreUttakMaxAlder = normAlder,
+                maxUttakGrad,
+                keepUttakGradConstant = false
+            )
+
+        return initialResult.alternativ?.let {
+            if (it.resultStatus == SimulatorResultStatus.SUBOPTIMAL)
+                findMoreOptimalUttak(it, finder, foersteUttakAngittAlder, andreUttakAngittAlder) ?: initialResult
+            else
+                initialResult
+        } ?: initialResult
+    }
+
+    private fun findMoreOptimalUttak(
+        suboptimal: SimulertAlternativ,
+        finder: AlternativtUttakFinder,
+        foersteUttakAngittAlder: Alder,
+        andreUttakAngittAlder: Alder?
+    ): SimulertPensjonEllerAlternativ? {
+        val gradertUttakAlder: SimulertUttakAlder? = suboptimal.gradertUttakAlder
+        val heltUttakAlder: SimulertUttakAlder = suboptimal.heltUttakAlder
+        val foersteUttakSuboptimalAlder: SimulertUttakAlder = gradertUttakAlder ?: heltUttakAlder
+        val andreUttakSuboptimalAlder: SimulertUttakAlder? =
+            if (gradertUttakAlder == null) null else heltUttakAlder
+
+        val betterResult: SimulertPensjonEllerAlternativ =
+            finder.findAlternativtUttak(
+                foersteUttakMinAlder = foersteUttakAngittAlder,
+                foersteUttakMaxAlder = foersteUttakSuboptimalAlder.alder.minusMaaneder(1),
+                andreUttakMinAlder = andreUttakAngittAlder,
+                andreUttakMaxAlder = andreUttakSuboptimalAlder?.alder,
+                maxUttakGrad = suboptimal.uttakGrad,
+                keepUttakGradConstant = true
+            )
+
+        return when (betterResult.alternativ?.resultStatus) {
+            SimulatorResultStatus.GOOD -> betterResult
+            else -> null
+        }
+    }
+
+    private companion object {
+
+        private fun alternativ(spec: SimuleringSpec, foedselDato: LocalDate): SimulertAlternativ? =
+            spec.gradertUttak(foedselDato)?.let {
+                SimulertAlternativ(
+                    gradertUttakAlder = uttakAlder(it.uttakFom.alder, foedselDato),
+                    uttakGrad = it.grad,
+                    heltUttakAlder = uttakAlder(spec.heltUttak(foedselDato).uttakFom.alder, foedselDato),
+                    resultStatus = SimulatorResultStatus.GOOD
+                )
+            }
+
+        private fun forsteUttakAlder(
+            gradertUttak: GradertUttakSimuleringSpec?,
+            heltUttak: HeltUttakSimuleringSpec
+        ): Alder {
+            val alder = (gradertUttak?.uttakFom ?: heltUttak.uttakFom).alder
+            return Alder(alder.aar, alder.maaneder)
+        }
+
+        private fun andreUttakAlder(
+            gradertUttak: GradertUttakSimuleringSpec?,
+            heltUttak: HeltUttakSimuleringSpec
+        ): Alder? {
+            if (gradertUttak == null) {
+                return null
+            }
+
+            return heltUttak.uttakFom.alder.let { Alder(it.aar, it.maaneder) }
+        }
+
+        private fun uttakAlder(alder: Alder, foedselDato: LocalDate) =
+            SimulertUttakAlder(
+                alder = Alder(alder.aar, alder.maaneder),
+                uttakDato = uttakDato(foedselDato, alder)
+            )
+
+        private fun ubetingetUttakAlternativ(foedselDato: LocalDate, normAlder: Alder) =
+            SimulertAlternativ(
+                gradertUttakAlder = null,
+                uttakGrad = UttakGradKode.P_100,
+                heltUttakAlder = ubetingetUttakAlder(foedselDato, normAlder),
+                resultStatus = SimulatorResultStatus.GOOD
+            )
+
+        private fun ubetingetUttakAlder(foedselDato: LocalDate, normAlder: Alder) =
+            SimulertUttakAlder(
+                alder = normAlder,
+                uttakDato = uttakDato(foedselDato, normAlder)
+            )
+
+        private fun alternativResponse(
+            spec: SimuleringSpec,
+            foedselDato: LocalDate,
+            alternativPensjon: SimulertPensjon?
+        ) =
+            alternativResponse(alternativ(spec, foedselDato), alternativPensjon)
+
+        private fun alternativResponse(alternativ: SimulertAlternativ?, alternativPensjon: SimulertPensjon?) =
+            SimulertPensjonEllerAlternativ(
+                pensjon = alternativPensjon,
+                alternativ
+            )
+
+        private fun simulatorFlags(lavereGradSpec: SimuleringSpec) =
+            SimulatorFlags(
+                inkluderLivsvarigOffentligAfp = lavereGradSpec.type == SimuleringType.ALDER_MED_AFP_OFFENTLIG_LIVSVARIG,
+                inkluderPensjonBeholdninger = lavereGradSpec.isHentPensjonsbeholdninger,
+                ignoreAvslag = false,
+                outputSimulertBeregningInformasjonForAllKnekkpunkter = lavereGradSpec.isOutputSimulertBeregningsinformasjonForAllKnekkpunkter
+            )
+
+        private fun findAlternativFailed(): Nothing {
+            throw RuntimeException("Failed to find alternative simuleringsparametre")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakFinder.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakFinder.kt
@@ -1,0 +1,150 @@
+package no.nav.pensjon.simulator.alderspensjon.alternativ
+
+import no.nav.pensjon.simulator.alderspensjon.convert.SimulatorOutputConverter.pensjon
+import no.nav.pensjon.simulator.core.SimulatorFlags
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.core.UttakAlderDiscriminator
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.exception.InvalidArgumentException
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.result.SimulatorOutput
+import no.nav.pensjon.simulator.normalder.NormAlderService
+import no.nav.pensjon.simulator.search.SmallestValueSearch
+import no.nav.pensjon.simulator.uttak.UttakUtil.uttakDato
+import java.time.LocalDate
+import java.time.Period
+
+/**
+ * Gitt at 'ønskede' verdier for uttaksgrad og -alder er angitt, og vilkårsprøvingen av disse gir avslag,
+ * så finner denne klassen et alternativt sett av verdier som vilkårsprøvingen godtar.
+ * Dokumentasjon: https://confluence.adeo.no/display/PEN/Simuleringsstrategi+2024
+ */
+class AlternativtUttakFinder(
+    private val discriminator: UttakAlderDiscriminator,
+    private val simuleringSpec: SimuleringSpec,
+    private val flags: SimulatorFlags,
+    private val normAlderService: NormAlderService,
+    private val heltUttakInntektTomAlderAar: Int? // behøves bare ved helt uttak når fom/tom angis i form av alder
+) {
+    private val foedselDato: LocalDate by lazy {
+        simuleringSpec.pid?.let(discriminator::fetchFoedselDato) ?: throw InvalidArgumentException("Udefinert PID")
+    }
+
+    private val normAlder: Alder by lazy { normAlderService.normAlder(foedselDato) }
+
+    fun findAlternativtUttak(
+        foersteUttakMinAlder: Alder,
+        foersteUttakMaxAlder: Alder,
+        andreUttakMinAlder: Alder?,
+        andreUttakMaxAlder: Alder?,
+        maxUttakGrad: UttakGradKode,
+        keepUttakGradConstant: Boolean
+    ): SimulertPensjonEllerAlternativ {
+        val foersteUttakAlderValueCount: Int = foersteUttakMaxAlder.antallMaanederEtter(foersteUttakMinAlder) + 1
+        val andreUttakAlderValueCount: Int? =
+            andreUttakMinAlder?.let { (andreUttakMaxAlder?.antallMaanederEtter(it) ?: 0) + 1 }
+
+        val simulering = IndexBasedSimulering(
+            discriminator,
+            simuleringSpec,
+            flags,
+            foedselDato,
+            foersteUttakAlderValueCount,
+            andreUttakAlderValueCount = andreUttakAlderValueCount?.let { if (it < 1) 1 else it },
+            maxUttakGrad,
+            keepUttakGradConstant,
+            foersteUttakMinAlder,
+            andreUttakMinAlder,
+            heltUttakInntektTomAlderAar
+        )
+
+        val searchResult: AlternativSimuleringResult? =
+            SmallestValueSearch(
+                discriminator = simulering::tryIndex,
+                max = foersteUttakAlderValueCount
+            ).search()
+
+        return pensjonEllerAlternativ(
+            usedParameters = searchResult?.usedParameters ?: defaultParameters(),
+            pensjon = searchResult?.simulertPensjon,
+            resultStatus = searchResult?.let(::resultStatus) ?: SimulatorResultStatus.BAD
+        )
+    }
+
+    private fun pensjonEllerAlternativ(
+        usedParameters: AlternativSimuleringSpec,
+        pensjon: SimulatorOutput?,
+        resultStatus: SimulatorResultStatus
+    ): SimulertPensjonEllerAlternativ {
+        val gradertPeriode = usedParameters.gradertUttakFom?.let { periodBetweenFirstDayOfMonth(foedselDato, it) }
+        val helPeriode = periodBetweenFirstDayOfMonth(foedselDato, usedParameters.heltUttakFom)
+        val gradertAlder = gradertPeriode?.let(::alder)
+        val helAlder = alder(helPeriode)
+
+        return SimulertPensjonEllerAlternativ(
+            pensjon = pensjon?.let(::pensjon),
+            alternativ = SimulertAlternativ(
+                uttakGrad = usedParameters.uttakGrad,
+                gradertUttakAlder = usedParameters.gradertUttakFom?.let {
+                    SimulertUttakAlder(
+                        Alder(
+                            aar = gradertAlder!!.aar,
+                            maaneder = gradertAlder.maaneder
+                        ),
+                        uttakDato = it
+                    )
+                },
+                heltUttakAlder = SimulertUttakAlder(
+                    Alder(
+                        aar = helAlder.aar,
+                        maaneder = helAlder.maaneder
+                    ),
+                    uttakDato = usedParameters.heltUttakFom
+                ),
+                resultStatus = resultStatus
+            )
+        )
+    }
+
+    /**
+     * Default er utkanttilfellet (edge case), dvs. det "dårligst mulige" alternativet for gradert tidliguttak (før 67 år).
+     * "Dårligst" vil si minste mulige uttaksgrad (20 %) kombinert med høyeste mulige alder (66 år 11 måneder).
+     */
+    private fun defaultParameters() =
+        AlternativSimuleringSpec(
+            gradertUttakFom = uttakDato(foedselDato, normAlder.minusMaaneder(1)),
+            gradertUttakAlderIndex = null,
+            uttakGrad = UttakGradKode.P_20,
+            heltUttakFom = uttakDato(foedselDato, normAlder),
+            heltUttakAlderIndex = 0
+        )
+
+    private companion object {
+
+        private fun periodBetweenFirstDayOfMonth(a: LocalDate, b: LocalDate) =
+            Period.between(a.withDayOfMonth(1), b.withDayOfMonth(1))
+
+        /**
+         * Det trekkes fra 1 måned fra perioden for å gi tilsvarende alder.
+         * Dette siden periode er beregnet ved å "runde av" startdatoen nedover til første dag i måneden
+         * (noe som gjør første måned til en hel måned), mens fødselsdato kan være midt i en måned (noe som ikke gir en hel førstemåned).
+         * ---------
+         * Eksempel: Fødselsdato = 1964-01-15, dato = 1995-04-01 => alder = 31 år 2 måneder (siden 3. måned ikke er helt fylt)
+         *           Periode = fom. 1964-01-01 tom. 1995-04-01 => lengde = 31 år 3 måneder
+         */
+        private fun alder(period: Period) =
+            Alder(
+                aar = period.years,
+                maaneder = period.months
+            ).minusMaaneder(antall = 1)
+
+        private fun resultStatus(result: AlternativSimuleringResult): SimulatorResultStatus =
+            if (result.valueIsGood)
+                if (result.uttakAlderTransition)
+                    SimulatorResultStatus.SUBOPTIMAL
+                else
+                    SimulatorResultStatus.GOOD
+            else
+                SimulatorResultStatus.BAD
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/IndexBasedSimulering.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/IndexBasedSimulering.kt
@@ -1,0 +1,157 @@
+package no.nav.pensjon.simulator.alderspensjon.alternativ
+
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.SimulatorFlags
+import no.nav.pensjon.simulator.core.UttakAlderDiscriminator
+import no.nav.pensjon.simulator.core.exception.AvslagVilkaarsproevingForKortTrygdetidException
+import no.nav.pensjon.simulator.core.exception.AvslagVilkaarsproevingForLavtTidligUttakException
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.result.SimulatorOutput
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.uttak.UttakUtil.indexedUttakGradSubmap
+import no.nav.pensjon.simulator.uttak.UttakUtil.uttakDatoKandidat
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import kotlin.math.floor
+
+/**
+ * Utfører simulering der parameterne utledes fra en heltallsverdi (0-basert).
+ * Dette for å tilpasse til binærsøk (algoritmen blir enklere med søk blant heltallsverdier).
+ * Heltallsverdien er gitt ved gradertUttakAlderIndex.
+ * Dokumentasjon: https://confluence.adeo.no/display/PEN/Simuleringsstrategi+2024
+ */
+class IndexBasedSimulering(
+    private val discriminator: UttakAlderDiscriminator,
+    private val simuleringSpec: SimuleringSpec,
+    private val flags: SimulatorFlags,
+    private val foedselDato: LocalDate,
+    foersteUttakAlderValueCount: Int,
+    andreUttakAlderValueCount: Int?,
+    maxUttakGrad: UttakGradKode, // høyeste uttaksgrad å ta i betraktning
+    keepUttakGradConstant: Boolean,
+    private val foersteUttakMinAlder: Alder,
+    private val andreUttakMinAlder: Alder?,
+    private val heltUttakInntektTomAlderAar: Int? // behøves bare ved helt uttak når fom/tom angis i form av alder
+) {
+    private val log = LoggerFactory.getLogger(IndexBasedSimulering::class.java)
+    private val gradert = andreUttakAlderValueCount != null
+    private val indexedRelevantUttakGrader = indexRelevantUttakGrader(maxUttakGrad, keepUttakGradConstant)
+    private val uttakGradValueCount = indexedRelevantUttakGrader.size
+
+    // Spread factor = Factor for 'spreading' a set of integers so that each value is mapped the same number of times to integers in a larger set.
+    // E.g. if the task is to map the set [0, 1, 2] to the set [0, 1, 2, 3, 4, 5, 6, 7, 8], then the mapping can be:
+    // i = 0 1 2 3 4 5 6 7 8
+    // j = 0 0 0 1 1 1 2 2 2
+    // This mapping can be expressed as j = floor(i*M/N), where M is the smaller number of values (10) and N is the larger number of values (3)
+    // The spread factor = M/N
+    private val andreUttakAlderSpreadFactor: Double =
+        if (gradert)
+            andreUttakAlderValueCount!!.toDouble() / foersteUttakAlderValueCount // M/N
+        else
+            1.0
+
+    private val uttakGradSpreadFactor: Double =
+        if (gradert && uttakGradValueCount < foersteUttakAlderValueCount)
+            uttakGradValueCount.toDouble() / foersteUttakAlderValueCount // M/N
+        else
+            1.0
+
+    /**
+     * forsteUttakAlderIndex = antall måneder etter laveste alder for første uttak
+     * Laveste uttaksalder = Ønsket (men avslått) uttaksalder + 1 måned
+     */
+    fun tryIndex(foersteUttakAlderIndex: Int): AlternativSimuleringResult {
+        val uttakGradIndex: Int = if (gradert) floor(foersteUttakAlderIndex * uttakGradSpreadFactor).toInt() else 0
+
+        val parameters =
+            if (gradert)
+                gradertUttakSimuleringSpec(foersteUttakAlderIndex, uttakGradIndex)
+            else
+                heltUttakSimuleringSpec(foersteUttakAlderIndex)
+
+        return try {
+            val indexSimulatorSpec = simuleringSpec.withUttak(
+                foersteUttakDato = parameters.gradertUttakFom ?: parameters.heltUttakFom,
+                uttakGrad = parameters.uttakGrad,
+                heltUttakDato = parameters.heltUttakFom,
+                inntektEtterHeltUttakAntallAar = parameters.inntektEtterHeltUttakAntallAar
+            )
+
+            val simulertPensjon: SimulatorOutput = discriminator.simuler(indexSimulatorSpec, flags)
+            log.info("Gyldig første uttaksdato - antall måneder: {}", foersteUttakAlderIndex)
+            val uttakGradTransition: Boolean =
+                gradert && previousUttakGradIndex(foersteUttakAlderIndex) < uttakGradIndex
+            AlternativSimuleringResult(valueIsGood = true, simulertPensjon, parameters, uttakGradTransition)
+        } catch (e: AvslagVilkaarsproevingForKortTrygdetidException) {
+            log.info("Ugyldig første uttaksdato (for kort trygdetid) - antall måneder: $foersteUttakAlderIndex")
+            AlternativSimuleringResult(valueIsGood = false, simulertPensjon = null, parameters)
+        } catch (e: AvslagVilkaarsproevingForLavtTidligUttakException) {
+            log.info("Ugyldig første uttaksdato (for lavt tidlig uttak) - antall måneder: $foersteUttakAlderIndex")
+            AlternativSimuleringResult(valueIsGood = false, simulertPensjon = null, parameters)
+            //} catch (e: FunctionalRecoverableException) {
+            //    throw SimuleringException("Søk etter første uttaksdato feilet - antall måneder: $forsteUttakAlderIndex", e)
+        }
+    }
+
+    /**
+     * Maps each relevant uttaksgrad to an index (0-based integer)
+     */
+    private fun indexRelevantUttakGrader(maxGrad: UttakGradKode, useOnlyMaxGrad: Boolean) =
+        if (gradert)
+            if (useOnlyMaxGrad)
+                mapOf(0 to maxGrad)
+            else
+                indexedUttakGradSubmap(maxGrad)
+        else
+            mapOf(0 to UttakGradKode.P_100)
+
+    private fun gradertUttakSimuleringSpec(
+        gradertUttakAlderIndex: Int,
+        uttakGradIndex: Int
+    ): AlternativSimuleringSpec {
+        val heltUttakAlderIndex: Int = andreUttakAlderIndex(gradertUttakAlderIndex)
+        val gradertUttakFom: LocalDate = uttakDatoKandidat(foedselDato, foersteUttakMinAlder, gradertUttakAlderIndex)
+        val heltUttakFom: LocalDate = uttakDatoKandidat(foedselDato, andreUttakMinAlder!!, heltUttakAlderIndex)
+        val uttakGgrad: UttakGradKode = indexedRelevantUttakGrader[uttakGradIndex] ?: UttakGradKode.P_0
+        return AlternativSimuleringSpec(
+            gradertUttakFom,
+            gradertUttakAlderIndex,
+            uttakGgrad,
+            heltUttakFom,
+            heltUttakAlderIndex
+        )
+    }
+
+    private fun heltUttakSimuleringSpec(heltUttakAlderIndex: Int): AlternativSimuleringSpec {
+        val heltUttakFom: LocalDate = uttakDatoKandidat(foedselDato, foersteUttakMinAlder, heltUttakAlderIndex)
+        val uttakGrad = UttakGradKode.P_100
+        val inntektEtterHeltUttakAntallAar =
+            if (simuleringSpec.inntektEtterHeltUttakAntallAar == null && heltUttakInntektTomAlderAar != null)
+            // antallArInntektEtterHeltUttak avhenger her av heltUttakFom (som har vært ukjent inntil nå)
+            // Nå er heltUttakFom kjent, så antallArInntektEtterHeltUttak kan utledes:
+                heltUttakInntektTomAlderAar - heltUttakFom.year + 1 // +1 p.g.a. fra/til OG MED
+            else
+                foedselDato.year + (simuleringSpec.inntektEtterHeltUttakAntallAar?: 0) - heltUttakFom.year + 1 // +1, siden fra/til OG MED
+
+        return AlternativSimuleringSpec(
+            gradertUttakFom = null,
+            gradertUttakAlderIndex = null,
+            uttakGrad,
+            heltUttakFom,
+            heltUttakAlderIndex,
+            inntektEtterHeltUttakAntallAar
+        )
+    }
+
+    private fun andreUttakAlderIndex(foersteUttakAlderIndex: Int): Int =
+        if (foersteUttakAlderIndex > 0)
+            floor(foersteUttakAlderIndex * andreUttakAlderSpreadFactor).toInt()
+        else
+            0
+
+    private fun previousUttakGradIndex(foersteUttakAlderIndex: Int): Int =
+        if (foersteUttakAlderIndex > 0)
+            floor((foersteUttakAlderIndex - 1) * uttakGradSpreadFactor).toInt()
+        else
+            0
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimuleringFacade.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimuleringFacade.kt
@@ -1,0 +1,87 @@
+package no.nav.pensjon.simulator.alderspensjon.alternativ
+
+import no.nav.pensjon.simulator.alderspensjon.convert.SimulatorOutputConverter.pensjon
+import no.nav.pensjon.simulator.core.SimulatorCore
+import no.nav.pensjon.simulator.core.SimulatorFlags
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.core.domain.SimuleringType
+import no.nav.pensjon.simulator.core.exception.AvslagVilkaarsproevingForKortTrygdetidException
+import no.nav.pensjon.simulator.core.exception.BeregningsmotorValidereException
+import no.nav.pensjon.simulator.core.exception.BeregningstjenesteFeiletException
+import no.nav.pensjon.simulator.core.exception.ForLavtTidligUttakException
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.result.SimulatorOutput
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+// PEN: SimpleSimuleringService
+// Vil brukes av NAV-klienter og tjenestepensjonsordninger
+@Service
+class SimuleringFacade(
+    private val simulator: SimulatorCore,
+    private val alternativSimuleringService: AlternativSimuleringService
+) {
+    fun simulerAlderspensjon(
+        spec: SimuleringSpec,
+        foedselDato: LocalDate?,
+        inkluderPensjonHvisUbetinget: Boolean
+    ): SimulertPensjonEllerAlternativ {
+        try {
+            val result: SimulatorOutput = simulator.simuler(spec, simulatorFlags(spec, ignoreAvslag = false))
+
+            return SimulertPensjonEllerAlternativ(
+                pensjon = pensjon(result),
+                alternativ = null
+            )
+        } catch (e: ForLavtTidligUttakException) {
+            // Brukers angitte parametre ga "avslått" resultat; prøv med alternative parametre:
+            return if (isGradertAndReducible(spec))
+                alternativSimuleringService.simulerMedNesteLavereUttakGrad(
+                    spec,
+                    foedselDato!!,
+                    inkluderPensjonHvisUbetinget
+                ) else
+                alternativSimuleringService.simulerAlternativHvisUtkanttilfelletInnvilges(
+                    spec,
+                    foedselDato!!,
+                    inkluderPensjonHvisUbetinget
+                )
+        } catch (e: AvslagVilkaarsproevingForKortTrygdetidException) {
+            return if (isGradertAndReducible(spec))
+                alternativSimuleringService.simulerMedNesteLavereUttakGrad(
+                    spec,
+                    foedselDato!!,
+                    inkluderPensjonHvisUbetinget
+                ) else
+                alternativSimuleringService.simulerAlternativHvisUtkanttilfelletInnvilges(
+                    spec,
+                    foedselDato!!,
+                    inkluderPensjonHvisUbetinget
+                )
+        } catch (e: BeregningsmotorValidereException) {
+            //throw SimuleringException("simuler alderspensjon 1963+ feilet", e)
+            throw RuntimeException("simuler alderspensjon 1963+ feilet", e)
+        } catch (e: BeregningstjenesteFeiletException) {
+            //throw SimuleringException("simuler alderspensjon 1963+ feilet", e)
+            throw RuntimeException("simuler alderspensjon 1963+ feilet", e)
+        }
+    }
+
+    private companion object {
+        // Sett ignoreAvslag = true hvis simulering alderspensjon for folketrygdbeholdning
+        private fun simulatorFlags(spec: SimuleringSpec, ignoreAvslag: Boolean) =
+            SimulatorFlags(
+                inkluderLivsvarigOffentligAfp = spec.type === SimuleringType.ALDER_MED_AFP_OFFENTLIG_LIVSVARIG,
+                inkluderPensjonBeholdninger = spec.isHentPensjonsbeholdninger,
+                ignoreAvslag,
+                outputSimulertBeregningInformasjonForAllKnekkpunkter = spec.isOutputSimulertBeregningsinformasjonForAllKnekkpunkter
+            )
+
+        private fun isGradertAndReducible(spec: SimuleringSpec): Boolean =
+            spec.isGradert() && isReducible(spec.uttakGrad)
+
+        private fun isReducible(grad: UttakGradKode): Boolean =
+            grad !== UttakGradKode.P_20 // 20 % is lowest gradert uttak
+                    && grad !== UttakGradKode.P_100 // 100 % is not gradert uttak and hence not "adjustable" to a lower grad
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
@@ -1,0 +1,69 @@
+package no.nav.pensjon.simulator.alderspensjon.alternativ
+
+import no.nav.pensjon.simulator.core.beholdning.OpptjeningGrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
+import java.time.LocalDate
+
+// PEN: SimulatorSimulertPensjon
+data class SimulertPensjon(
+    val alderspensjon: List<SimulertAarligAlderspensjon>,
+    val alderspensjonFraFolketrygden: List<SimulertAlderspensjonFraFolketrygden>,
+    val privatAfp: List<SimulertPrivatAfp>,
+    val pre2025OffentligAfp: SimulertPre2025OffentligAfp?,
+    val livsvarigOffentligAfp: List<SimulertLivsvarigOffentligAfp>,
+    val pensjonBeholdningPeriodeListe: List<SimulertPensjonBeholdningPeriode>,
+    val harUttak: Boolean,
+    val harNokTrygdetidForGarantipensjon: Boolean,
+    val trygdetid: Int,
+    val opptjeningGrunnlagListe: List<OpptjeningGrunnlag>
+)
+
+data class SimulertAarligAlderspensjon(
+    val alderAar: Int,
+    val beloep: Int,
+    val inntektspensjon: Int?,
+    val garantipensjon: Int?,
+    val delingstall: Double?,
+    val pensjonBeholdningFoerUttak: Int?
+)
+
+class SimulertAlderspensjonFraFolketrygden(
+    val datoFom: LocalDate,
+    val delytelseListe: List<SimulertDelytelse>,
+    val uttakGrad: Int
+)
+
+data class SimulertPrivatAfp(
+    val alderAar: Int,
+    val beloep: Int
+)
+
+data class SimulertPre2025OffentligAfp(
+    val alderAar: Int,
+    val beloep: Int
+)
+
+data class SimulertLivsvarigOffentligAfp(
+    val alderAar: Int,
+    val beloep: Int
+)
+
+data class SimulertPensjonBeholdningPeriode(
+    val pensjonBeholdning: Double,
+    val garantipensjonBeholdning: Double,
+    val garantitilleggBeholdning: Double,
+    val datoFom: LocalDate,
+    var garantipensjonNivaa: SimulertGarantipensjonNivaa
+)
+
+data class SimulertGarantipensjonNivaa(
+    val beloep: Double?,
+    val satsType: String?,
+    val sats: Double?,
+    val anvendtTrygdetid: Int?
+)
+
+data class SimulertDelytelse(
+    val type: YtelseskomponentTypeEnum,
+    val beloep: Int
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjonEllerAlternativ.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjonEllerAlternativ.kt
@@ -1,0 +1,30 @@
+package no.nav.pensjon.simulator.alderspensjon.alternativ
+
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import java.time.LocalDate
+
+data class SimulertPensjonEllerAlternativ(
+    val pensjon: SimulertPensjon?,
+    val alternativ: SimulertAlternativ?
+)
+
+// PEN: SimulatorSimulertAlternativ
+data class SimulertAlternativ(
+    val gradertUttakAlder: SimulertUttakAlder?,
+    val uttakGrad: UttakGradKode,
+    val heltUttakAlder: SimulertUttakAlder,
+    val resultStatus: SimulatorResultStatus
+)
+
+// PEN: SimulatorSimulertUttaksalder
+data class SimulertUttakAlder(
+    val alder: Alder,
+    val uttakDato: LocalDate
+)
+
+enum class SimulatorResultStatus {
+    GOOD,
+    SUBOPTIMAL,
+    BAD
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/anonym/api/acl/v1in/AnonymSimuleringSpecMapperV1.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/anonym/api/acl/v1in/AnonymSimuleringSpecMapperV1.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.alderspensjon.anonym.api.acl.v1in
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 
 /**
  * Maps between data transfer objects (DTOs) and domain objects related to 'anonym simulering'.
@@ -27,6 +27,7 @@ object AnonymSimuleringSpecMapperV1 {
             erAnonym = true,
             // Resten er irrelevante for anonym simulering:
             pid = null,
+            foedselDato = null,
             avdoed = null,
             isTpOrigSimulering = false,
             simulerForTp = false,

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
@@ -16,7 +16,7 @@ import no.nav.pensjon.simulator.core.result.PensjonPeriode
 import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.result.SimulertAlderspensjon
 import no.nav.pensjon.simulator.core.result.SimulertBeregningInformasjon
-import no.nav.pensjon.simulator.alder.AlderDato
+import no.nav.pensjon.simulator.alder.PensjonAlderDato
 import no.nav.pensjon.simulator.alderspensjon.alternativ.*
 import no.nav.pensjon.simulator.core.util.toLocalDate
 import java.time.LocalDate
@@ -189,14 +189,14 @@ object SimulatorOutputConverter {
      * Bakgrunnen for dette er at det i pensjonssammenheng opereres med hele måneder;
      * det er den første dag i påfølgende måned som legges til grunn ved f.eks. uttak av pensjon.
      */
-    private fun alderDato(foedselDato: LocalDate, dato: LocalDate): AlderDato =
+    private fun alderDato(foedselDato: LocalDate, dato: LocalDate): PensjonAlderDato =
         with(
             Period.between(
                 foedselDato.plusMonths(1).withDayOfMonth(1),
                 dato.withDayOfMonth(1)
             )
         ) {
-            AlderDato(
+            PensjonAlderDato(
                 alder = Alder(aar = this.years, maaneder = this.months),
                 dato = dato
             )

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
@@ -1,0 +1,204 @@
+package no.nav.pensjon.simulator.alderspensjon.convert
+
+import no.nav.pensjon.simulator.core.afp.privat.SimulertPrivatAfpPeriode
+import no.nav.pensjon.simulator.core.beholdning.OpptjeningGrunnlag
+import no.nav.pensjon.simulator.core.beregn.BeholdningPeriode
+import no.nav.pensjon.simulator.core.beregn.GarantipensjonNivaa
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.domain.regler.beregning.Beregning
+import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Opptjeningsgrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
+import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isAfterByDay
+import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isBeforeByDay
+import no.nav.pensjon.simulator.core.out.OutputLivsvarigOffentligAfp
+import no.nav.pensjon.simulator.core.result.PensjonPeriode
+import no.nav.pensjon.simulator.core.result.SimulatorOutput
+import no.nav.pensjon.simulator.core.result.SimulertAlderspensjon
+import no.nav.pensjon.simulator.core.result.SimulertBeregningInformasjon
+import no.nav.pensjon.simulator.alder.AlderDato
+import no.nav.pensjon.simulator.alderspensjon.alternativ.*
+import no.nav.pensjon.simulator.core.util.toLocalDate
+import java.time.LocalDate
+import java.time.Period
+import java.util.*
+
+/**
+ * Converts from simulator output to pensjon in an intermediate format.
+ */
+object SimulatorOutputConverter {
+
+    /**
+     * https://lovdata.no/dokument/NL/lov/1997-02-28-19/KAPITTEL_7-2#KAPITTEL_7-2
+     * § 20-10.Garantipensjon – trygdetid
+     */
+    private const val MINIMUM_TRYGDETID_FOR_GARANTIPENSJON_ANTALL_AAR = 5
+
+    private const val ALDER_REPRESENTING_LOPENDE_YTELSER = 0
+
+    fun pensjon(source: SimulatorOutput): SimulertPensjon {
+        val alderspensjon: SimulertAlderspensjon? = source.alderspensjon
+        val pensjonsperioder: List<PensjonPeriode> = alderspensjon?.pensjonPeriodeListe.orEmpty()
+        val trygdetid = anvendtKapittel20Trygdetid(pensjonsperioder)
+
+        return SimulertPensjon(
+            alderspensjon = pensjonsperioder.map(SimulatorOutputConverter::alderspensjon),
+            alderspensjonFraFolketrygden = alderspensjon?.simulertBeregningInformasjonListe.orEmpty()
+                .map(SimulatorOutputConverter::alderspensjonFraFolketrygden),
+            privatAfp = source.privatAfpPeriodeListe.map(SimulatorOutputConverter::privatAfp),
+            pre2025OffentligAfp = source.pre2025OffentligAfp?.beregning?.let {
+                pre2025OffentligAfp(it, source.foedselDato)
+            },
+            livsvarigOffentligAfp = source.livsvarigOffentligAfp.orEmpty().map(SimulatorOutputConverter::livsvarigOffentligAfp),
+            pensjonBeholdningPeriodeListe = alderspensjon?.pensjonBeholdningListe.orEmpty()
+                .map(SimulatorOutputConverter::beholdningPeriode),
+            harUttak = alderspensjon?.uttakGradListe.orEmpty().any(SimulatorOutputConverter::harUttakToday),
+            harNokTrygdetidForGarantipensjon = trygdetid >= MINIMUM_TRYGDETID_FOR_GARANTIPENSJON_ANTALL_AAR,
+            trygdetid = trygdetid,
+            opptjeningGrunnlagListe = source.persongrunnlag?.opptjeningsgrunnlagListe.orEmpty()
+                .map(SimulatorOutputConverter::opptjeningGrunnlag).sortedBy { it.aar }
+        )
+    }
+
+    private fun anvendtKapittel20Trygdetid(perioder: List<PensjonPeriode>): Int =
+        perioder.firstOrNull()?.simulertBeregningInformasjonListe?.firstOrNull()?.tt_anv_kap20 ?: 0
+
+    private fun alderspensjon(source: PensjonPeriode): SimulertAarligAlderspensjon {
+        val info = source.simulertBeregningInformasjonListe.firstOrNull()
+
+        return SimulertAarligAlderspensjon(
+            alderAar = source.alderAar ?: ALDER_REPRESENTING_LOPENDE_YTELSER,
+            beloep = source.beloep ?: 0,
+            inntektspensjon = info?.inntektspensjon,
+            garantipensjon = info?.garantipensjon,
+            delingstall = info?.delingstall,
+            pensjonBeholdningFoerUttak = beholdningFoerUttak(source.simulertBeregningInformasjonListe)
+        )
+    }
+
+    private fun beholdningFoerUttak(list: List<SimulertBeregningInformasjon>): Int? =
+        list.firstOrNull { it.pensjonBeholdningFoerUttak != null }?.pensjonBeholdningFoerUttak
+
+    // SimulerAlderspensjonResponseV3Converter.convertSimulertBeregningsinfoToAlderspensjonFraFolketrygden
+    private fun alderspensjonFraFolketrygden(source: SimulertBeregningInformasjon) =
+        SimulertAlderspensjonFraFolketrygden(
+            datoFom = source.datoFom ?: LocalDate.MIN,
+            delytelseListe = delytelser(source),
+            uttakGrad = source.uttakGrad?.toInt() ?: 0
+        )
+
+    // SimulerAlderspensjonResponseV3Converter.getDelytelserFromSimulertBeregningsinformasjon
+    private fun delytelser(source: SimulertBeregningInformasjon): List<SimulertDelytelse> {
+        val ytelser: MutableList<SimulertDelytelse> = mutableListOf()
+        source.grunnpensjon?.let { addYtelse(it, ytelser, YtelseskomponentTypeEnum.GP) }
+        source.tilleggspensjon?.let { addYtelse(it, ytelser, YtelseskomponentTypeEnum.TP) }
+        source.pensjonstillegg?.let { addYtelse(it, ytelser, YtelseskomponentTypeEnum.PT) }
+        source.individueltMinstenivaaTillegg?.let {
+            addYtelse(
+                it,
+                ytelser,
+                YtelseskomponentTypeEnum.MIN_NIVA_TILL_INDV
+            )
+        }
+        source.inntektspensjon?.let { addYtelse(it, ytelser, YtelseskomponentTypeEnum.IP) }
+        source.garantipensjon?.let { addYtelse(it, ytelser, YtelseskomponentTypeEnum.GAP) }
+        source.garantitillegg?.let { addYtelse(it, ytelser, YtelseskomponentTypeEnum.GAT) }
+        source.skjermingstillegg?.let { addYtelse(it, ytelser, YtelseskomponentTypeEnum.SKJERMT) }
+        return ytelser
+    }
+
+    private fun addYtelse(belop: Int, ytelser: MutableList<SimulertDelytelse>, type: YtelseskomponentTypeEnum) {
+        ytelser.add(SimulertDelytelse(type, belop))
+    }
+
+    private fun privatAfp(source: SimulertPrivatAfpPeriode) =
+        SimulertPrivatAfp(source.alderAar ?: 0, source.aarligBeloep ?: 0)
+
+    /**
+     * Ref. BeregningFormPopulator.createBeregningFormDataFromBeregning in pensjon-pselv
+     */
+    private fun pre2025OffentligAfp(
+        beregning: Beregning,
+        foedselDato: LocalDate?
+    ): SimulertPre2025OffentligAfp? =
+        if (foedselDato == null)
+            null
+        else
+            beregning.virkFom?.let {
+                SimulertPre2025OffentligAfp(
+                    alderAar = alderAar(foedselDato, it),
+                    beregning.netto
+                )
+            }
+
+    private fun livsvarigOffentligAfp(source: OutputLivsvarigOffentligAfp) =
+        SimulertLivsvarigOffentligAfp(source.alderAar, source.beloep)
+
+    private fun beholdningPeriode(source: BeholdningPeriode) =
+        SimulertPensjonBeholdningPeriode(
+            pensjonBeholdning = source.pensjonsbeholdning ?: 0.0,
+            garantipensjonBeholdning = source.garantipensjonsbeholdning ?: 0.0,
+            garantitilleggBeholdning = source.garantitilleggsbeholdning ?: 0.0,
+            datoFom = source.datoFom,
+            garantipensjonNivaa = source.garantipensjonsniva?.let(SimulatorOutputConverter::garantipensjonNivaa)
+                ?: nullGarantipensjonNivaa()
+        )
+
+    private fun garantipensjonNivaa(source: GarantipensjonNivaa) =
+        SimulertGarantipensjonNivaa(
+            beloep = source.beloep,
+            satsType = source.satsType,
+            sats = source.sats,
+            anvendtTrygdetid = source.anvendtTrygdetid
+        )
+
+    private fun nullGarantipensjonNivaa() =
+        SimulertGarantipensjonNivaa(
+            beloep = 0.0,
+            satsType = "",
+            sats = 0.0,
+            anvendtTrygdetid = 0
+        )
+
+    private fun opptjeningGrunnlag(source: Opptjeningsgrunnlag) =
+        OpptjeningGrunnlag(
+            aar = source.ar,
+            pensjonsgivendeInntekt = source.pi
+        )
+
+    private fun alderAar(foedselDato: LocalDate, dato: Date): Int =
+        alderDato(foedselDato, dato.toLocalDate()!!).alder.aar
+
+    private fun harUttakToday(grad: Uttaksgrad) = grad.uttaksgrad > 0 && coversToday(grad.fomDato, grad.tomDato)
+
+    // SimulerAlderspensjonResponseV3Converter.isUttaksgradToday
+    private fun coversToday(fom: Date?, tom: Date?): Boolean {
+        val today = LocalDate.now() //TODO use DateProvider
+
+        if (isAfterByDay(today, fom, true)) {
+            return tom == null || isBeforeByDay(today, tom, true)
+        }
+
+        return false
+    }
+
+    /**
+     * Beregner alder ved angitt dato.
+     * Kun helt fylte år og helt fylte måneder telles med.
+     * (Eksempel: En alder av 5 år, 11 måneder og 27 dager returneres som 5 år og 11 måneder.)
+     * Bakgrunnen for dette er at det i pensjonssammenheng opereres med hele måneder;
+     * det er den første dag i påfølgende måned som legges til grunn ved f.eks. uttak av pensjon.
+     */
+    private fun alderDato(foedselDato: LocalDate, dato: LocalDate): AlderDato =
+        with(
+            Period.between(
+                foedselDato.plusMonths(1).withDayOfMonth(1),
+                dato.withDayOfMonth(1)
+            )
+        ) {
+            AlderDato(
+                alder = Alder(aar = this.years, maaneder = this.months),
+                dato = dato
+            )
+        }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/NavAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/NavAlderspensjonController.kt
@@ -1,0 +1,93 @@
+package no.nav.pensjon.simulator.alderspensjon.nav.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import jakarta.servlet.http.HttpServletRequest
+import mu.KotlinLogging
+import no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1in.NavSimuleringSpecMapperV1.fromNavSimuleringSpecV1
+import no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1in.NavSimuleringSpecV1
+import no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1out.NavSimuleringResultMapperV1.mapNavSimuleringResultV1
+import no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1out.NavSimuleringResultV1
+import no.nav.pensjon.simulator.alderspensjon.alternativ.SimuleringFacade
+import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertPensjonEllerAlternativ
+import no.nav.pensjon.simulator.common.api.ControllerBase
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.generelt.GenerelleDataHolder
+import no.nav.pensjon.simulator.person.Pid
+import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.tech.validation.InvalidEnumValueException
+import no.nav.pensjon.simulator.tech.web.BadRequestException
+import no.nav.pensjon.simulator.tech.web.EgressException
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("api/nav")
+@SecurityRequirement(name = "BearerAuthentication")
+class NavAlderspensjonController(
+    private val service: SimuleringFacade,
+    private val generelleDataHolder: GenerelleDataHolder,
+    private val traceAid: TraceAid
+) : ControllerBase(traceAid, organisasjonsnummerProvider = null, tpregisteretService = null) {
+    private val log = KotlinLogging.logger {}
+
+    @PostMapping("v1/simuler-alderspensjon")
+    @Operation(
+        summary = "Simuler alderspensjon for NAV-klient",
+        description = "Lager en prognose for utbetaling av alderspensjon, basert på NAV-lagret info og input fra bruker.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Simulering av alderspensjon utført."
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "Simulering kunne ikke utføres pga. uakseptabel input. Det kan være: " +
+                        " (1) helt uttak ikke etter gradert uttak," +
+                        " (2) inntekt ikke 1. i måneden," +
+                        " (3) inntekter har lik startdato, " +
+                        " (4) negativ inntekt."
+            )
+        ]
+    )
+    fun simulerAlderspensjon(
+        @RequestBody specV1: NavSimuleringSpecV1,
+        request: HttpServletRequest
+    ): NavSimuleringResultV1 {
+        traceAid.begin()
+        log.debug { "$FUNCTION_ID request: $specV1" }
+        countCall(FUNCTION_ID)
+
+        return try {
+            val foedselDato: LocalDate = generelleDataHolder.getPerson(Pid(specV1.pid)).foedselDato
+            val spec: SimuleringSpec = fromNavSimuleringSpecV1(specV1, foedselDato)
+
+            val result: SimulertPensjonEllerAlternativ =
+                service.simulerAlderspensjon(spec, foedselDato, inkluderPensjonHvisUbetinget = false)
+
+            mapNavSimuleringResultV1(result)
+        } catch (e: EgressException) {
+            handle(e)!!
+        } catch (e: BadRequestException) {
+            badRequest(e)!!
+        } catch (e: InvalidEnumValueException) {
+            badRequest(e)!!
+        } finally {
+            traceAid.end()
+        }
+    }
+
+    override fun errorMessage() = ERROR_MESSAGE
+
+    private companion object {
+        private const val ERROR_MESSAGE = "feil ved simulering av alderspensjon for NAV-klient"
+        private const val FUNCTION_ID = "nav-ap"
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1in/NavSimuleringSpecMapperV1.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1in/NavSimuleringSpecMapperV1.kt
@@ -1,0 +1,152 @@
+package no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1in
+
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
+import no.nav.pensjon.simulator.core.exception.BeregningsmotorValidereException
+import no.nav.pensjon.simulator.core.krav.FremtidigInntekt
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.legacy.util.DateUtil.fromLocalDate
+import no.nav.pensjon.simulator.core.trygd.UtlandPeriode
+import no.nav.pensjon.simulator.core.util.toLocalDate
+import no.nav.pensjon.simulator.person.Pid
+import no.nav.pensjon.simulator.uttak.UttakUtil.uttakDato
+import java.time.LocalDate
+import java.util.*
+
+/**
+ * Maps between data transfer objects (DTOs) and domain objects related to 'anonym simulering'.
+ * The DTOs are specified by version 1 of the API offered to clients.
+ */
+object NavSimuleringSpecMapperV1 {
+
+    fun fromNavSimuleringSpecV1(
+        source: NavSimuleringSpecV1,
+        foedselDato: LocalDate
+    ): SimuleringSpec {
+        val gradertUttak: SimuleringGradertUttak? = gradertUttak(source, foedselDato)
+        val heltUttak: SimuleringHeltUttak = heltUttak(source, foedselDato)
+        val utenlandsperiodeListe: List<UtlandPeriode> = source.utenlandsperiodeListe.orEmpty().map(
+            NavSimuleringSpecMapperV1::utlandPeriode
+        )
+
+        return SimuleringSpec(
+            type = NavSimuleringTypeSpecV1.fromExternalValue(source.simuleringstype.name).internalValue,
+            foedselAar = 0, // only for anonym
+            forventetInntektBeloep = source.sisteInntekt,
+            inntektOver1GAntallAar = 0, // only for anonym
+            foersteUttakDato = (gradertUttak?.uttakFom ?: heltUttak.uttakFom).toLocalDate(),
+            uttakGrad = gradertUttak?.let { NavUttakGradSpecV1.fromExternalValue(it.grad.value).internalValue }
+                ?: UttakGradKode.P_100,
+            inntektUnderGradertUttakBeloep = gradertUttak?.aarligInntekt ?: 0,
+            heltUttakDato = heltUttak.uttakFom.toLocalDate(),
+            inntektEtterHeltUttakBeloep = heltUttak.aarligInntekt,
+            inntektEtterHeltUttakAntallAar = heltUttak.antallArInntektEtterHeltUttak,
+            utlandAntallAar = 0, // only for anonym
+            sivilstatus = NavSivilstandSpecV1.fromExternalValue(source.sivilstand.name).internalValue,
+            epsHarPensjon = source.epsHarPensjon ?: false,
+            epsHarInntektOver2G = source.epsHarInntektOver2G ?: false,
+            erAnonym = false,
+            // Resten er kun for ikke-anonym simulering:
+            pid = Pid(source.pid),
+            foedselDato = foedselDato,
+            avdoed = null,
+            isTpOrigSimulering = false,
+            simulerForTp = false,
+            boddUtenlands = utenlandsperiodeListe.isNotEmpty(),
+            flyktning = false,
+            utlandPeriodeListe = utenlandsperiodeListe.toMutableList(),
+            fremtidigInntektListe = source.fremtidigInntektListe.orEmpty().map(NavSimuleringSpecMapperV1::fremtidigInntekt).toMutableList(),
+            rettTilOffentligAfpFom = null
+        )
+    }
+
+    private fun gradertUttak(
+        source: NavSimuleringSpecV1,
+        foedselDato: LocalDate
+    ): SimuleringGradertUttak? =
+        source.gradertUttak?.let {
+            val localUttakFom: LocalDate =
+            // if (source.isTpOriginatedSimulering)
+            //     it.uttakFom.dato
+            // else
+                //TODO V4
+                uttakDato(foedselDato, alder(it.uttakFomAlder!!))
+
+            SimuleringGradertUttak(
+                grad = it.grad!!,
+                uttakFom = fromLocalDate(validated(localUttakFom))!!,
+                aarligInntekt = it.aarligInntekt ?: 0
+            )
+        }
+
+    /**
+     * 'Inntekt til og med'-dato beregnes på minimumsbasis for at ikke inntekt skal overvurderes i simuleringen.
+     */
+    // SimulatorPensjonTidUtil
+    private fun inntektTomDato(foedselDato: LocalDate, tomAlder: Alder) =
+        foedselDato
+            .plusYears(tomAlder.aar.toLong())
+            .plusMonths(tomAlder.maaneder.toLong())
+
+    private fun heltUttak(source: NavSimuleringSpecV1, foedselDato: LocalDate): SimuleringHeltUttak {
+        val heltUttak = source.heltUttak
+        val uttakFomAlderSpec = heltUttak.uttakFomAlder
+        val inntektTomAlderSpec = heltUttak.inntektTomAlder
+
+        val localUttakFom: LocalDate =
+        //if (source.isTpOriginatedSimulering)
+        //    heltUttak.uttakFom.dato
+        //else
+            //TODO V4
+            uttakDato(foedselDato, alder(uttakFomAlderSpec))
+
+        return SimuleringHeltUttak(
+            uttakFom = fromLocalDate(validated(localUttakFom))!!,
+            aarligInntekt = heltUttak.aarligInntekt,
+            inntektTom = fromLocalDate(inntektTomDato(foedselDato, alder(inntektTomAlderSpec)))!!,
+            antallArInntektEtterHeltUttak = inntektTomAlderSpec.aar - uttakFomAlderSpec.aar + 1 // +1, siden fra/til OG MED
+        )
+    }
+
+    private fun fremtidigInntekt(source: NavSimuleringInntektSpecV1) =
+        FremtidigInntekt(
+            aarligInntektBeloep = source.aarligInntekt ?: 0,
+            fom = source.fom.toLocalDate()!!
+        )
+
+    private fun utlandPeriode(source: NavSimuleringUtlandSpecV1) =
+        UtlandPeriode(
+            fom = source.fom.toLocalDate()!!,
+            tom = source.tom.toLocalDate()!!,
+            land = LandkodeEnum.valueOf(source.land),
+            arbeidet = source.arbeidetUtenlands
+        )
+
+    private fun alder(source: NavSimuleringAlderSpecV1) = Alder(source.aar, source.maaneder)
+
+    private fun validated(uttakFom: LocalDate): LocalDate =
+        if (uttakFom < LocalDate.now())
+            throw BeregningsmotorValidereException("Uttaksdato ($uttakFom) kan ikke være i fortid")
+        else
+            uttakFom
+
+    /**
+     * Domain object for 'gradert uttak' in the context of 'simulering av alderspensjon'.
+     */
+    private data class SimuleringGradertUttak(
+        val grad: UttakGradKode,
+        val uttakFom: Date,
+        val aarligInntekt: Int
+    )
+
+    /**
+     * Domain object for 'helt uttak' in the context of 'simulering av alderspensjon'.
+     */
+    private data class SimuleringHeltUttak(
+        val uttakFom: Date, //TODO LocalDate?
+        val aarligInntekt: Int,
+        val inntektTom: Date,
+        val antallArInntektEtterHeltUttak: Int
+    )
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1in/NavSimuleringSpecV1.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1in/NavSimuleringSpecV1.kt
@@ -1,0 +1,56 @@
+package no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1in
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import no.nav.pensjon.simulator.core.domain.SivilstatusType
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import java.util.*
+
+// SimuleringSpecDtoAlderspensjon1963Plus
+/**
+ * Data transfer object som representerer inn-data (spesifikasjon) for
+ * simulering av alderspensjon for brukere født 1963 eller senere.
+ */
+data class NavSimuleringSpecV1(
+    val pid: String,
+    val sivilstand: SivilstatusType,
+    val harEps: Boolean? = false, // TODO remove (unused)
+    val uttaksar: Int,
+    val sisteInntekt: Int,
+    val simuleringstype: NavSivilstandSpecV1,
+    val gradertUttak: NavSimuleringGradertUttakSpecV1? = null,
+    val heltUttak: NavSimuleringHeltUttakSpecV1,
+    val aarUtenlandsEtter16Aar: Int? = null,
+    val epsHarPensjon: Boolean? = null,
+    val epsHarInntektOver2G: Boolean? = null,
+    val fremtidigInntektListe: List<NavSimuleringInntektSpecV1>? = null,
+    val utenlandsperiodeListe: List<NavSimuleringUtlandSpecV1>? = null
+)
+
+data class NavSimuleringGradertUttakSpecV1(
+    val grad: UttakGradKode? = null,
+    val uttakFomAlder: NavSimuleringAlderSpecV1? = null,
+    val aarligInntekt: Int? = null
+)
+
+data class NavSimuleringHeltUttakSpecV1(
+    val uttakFomAlder: NavSimuleringAlderSpecV1,
+    val aarligInntekt: Int,
+    val inntektTomAlder: NavSimuleringAlderSpecV1
+)
+
+data class NavSimuleringInntektSpecV1(
+    val aarligInntekt: Int? = null,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "CET") val fom: Date? = null
+)
+
+data class NavSimuleringUtlandSpecV1(
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "CET") val fom: Date,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "CET") val tom: Date?,
+    val land: String,
+    val arbeidetUtenlands: Boolean
+)
+
+data class NavSimuleringAlderSpecV1(
+    val aar: Int,
+    val maaneder: Int
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1in/NavSimuleringTypeSpecV1.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1in/NavSimuleringTypeSpecV1.kt
@@ -1,0 +1,82 @@
+package no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1in
+
+import mu.KotlinLogging
+import no.nav.pensjon.simulator.core.domain.SimuleringType
+import org.springframework.util.StringUtils
+
+// no.nav.domain.pensjon.kjerne.kodetabeller.SimuleringTypeCode
+enum class NavSimuleringTypeSpecV1(val externalValue: String, val internalValue: SimuleringType) {
+    /**
+     * AFP
+     */
+    //AFP("AFP", SimuleringType.AFP),
+
+    /**
+     * AFP i offentlig sektor etterfulgt av alderspensjon
+     */
+    AFP_ETTERF_ALDER("AFP_ETTERF_ALDER", SimuleringType.AFP_ETTERF_ALDER),
+
+    /**
+     * AFP - vedtak om fremtidig pensjonspoeng
+     */
+    //AFP_FPP("AFP_FPP", SimuleringType.AFP_FPP),
+
+    /**
+     * Alderspensjon
+     */
+    ALDER("ALDER", SimuleringType.ALDER),
+
+    /**
+     * Alderspensjon
+     */
+    //ALDER_KAP_20("ALDER_KAP_20", SimuleringType.ALDER_KAP_20),
+
+    /**
+     * Alderspensjon med AFP i privat sektor
+     */
+    ALDER_M_AFP_PRIVAT("ALDER_M_AFP_PRIVAT", SimuleringType.ALDER_M_AFP_PRIVAT),
+
+    /**
+     * Alderspensjon med gjenlevenderettigheter
+     */
+    ALDER_M_GJEN("ALDER_M_GJEN", SimuleringType.ALDER_M_GJEN),
+
+    /**
+     * Barnepensjon
+     */
+    //BARN("BARN", SimuleringType.BARN),
+
+    /**
+     * Endring av alderspensjon
+     */
+    ENDR_ALDER("ENDR_ALDER", SimuleringType.ENDR_ALDER),
+
+    /**
+     * Endring av alderspensjon med gjenlevenderettigheter
+     */
+    ENDR_ALDER_M_GJEN("ENDR_ALDER_M_GJEN", SimuleringType.ENDR_ALDER_M_GJEN),
+
+    /**
+     * Endring av alderspensjon med AFP i privat sektor
+     */
+    ENDR_AP_M_AFP_PRIVAT("ENDR_AP_M_AFP_PRIVAT", SimuleringType.ENDR_AP_M_AFP_PRIVAT);
+
+    /**
+     * Gjenlevendepensjon
+     */
+    //GJENLEVENDE("GJENLEVENDE", SimuleringType.GJENLEVENDE);
+
+    companion object {
+        private val values = entries.toTypedArray()
+        private val log = KotlinLogging.logger {}
+
+        fun fromExternalValue(value: String?): NavSimuleringTypeSpecV1 =
+            values.singleOrNull { it.externalValue.equals(value, true) } ?: default(value)
+
+        private fun default(externalValue: String?): NavSimuleringTypeSpecV1 =
+            if (StringUtils.hasLength(externalValue))
+                ALDER.also { log.warn { "Unknown AnonymSimuleringTypeSpec: '$externalValue'" } }
+            else
+                ALDER
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1in/NavSivilstandSpecV1.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1in/NavSivilstandSpecV1.kt
@@ -1,0 +1,97 @@
+package no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1in
+
+import mu.KotlinLogging
+import no.nav.pensjon.simulator.core.domain.SivilstatusType
+import org.springframework.util.StringUtils
+
+// no.nav.domain.pensjon.kjerne.kodetabeller.SivilstatusTypeCode
+enum class NavSivilstandSpecV1(val externalValue: String, val internalValue: SivilstatusType) {
+    /**
+     * Enke/-mann
+     */
+    ENKE("ENKE", SivilstatusType.ENKE),
+
+    /**
+     * Gift
+     */
+    GIFT("GIFT", SivilstatusType.GIFT),
+
+    /**
+     * Gjenlevende etter samlivsbrudd
+     */
+    GJES("GJES", SivilstatusType.GJES),
+
+    /**
+     * Gjenlevende partner
+     */
+    GJPA("GJPA", SivilstatusType.GJPA),
+
+    /**
+     * Gjenlevende samboer
+     */
+    GJSA("GJSA", SivilstatusType.GJSA),
+
+    /**
+     * Gift, lever adskilt
+     */
+    GLAD("GLAD", SivilstatusType.GLAD),
+
+    /**
+     * -
+     */
+    NULL("NULL", SivilstatusType.NULL),
+
+    /**
+     * Registrert partner, lever adskilt
+     */
+    PLAD("PLAD", SivilstatusType.PLAD),
+
+    /**
+     * Registrert partner
+     */
+    REPA("REPA", SivilstatusType.REPA),
+
+    /**
+     * Samboer
+     */
+    SAMB("SAMB", SivilstatusType.SAMB),
+
+    /**
+     * Separert partner
+     */
+    SEPA("SEPA", SivilstatusType.SEPA),
+
+    /**
+     * Separert
+     */
+    SEPR("SEPR", SivilstatusType.SEPR),
+
+    /**
+     * Skilt
+     */
+    SKIL("SKIL", SivilstatusType.SKIL),
+
+    /**
+     * Skilt partner
+     */
+    SKPA("SKPA", SivilstatusType.SKPA),
+
+    /**
+     * Ugift
+     */
+    UGIF("UGIF", SivilstatusType.UGIF);
+
+    companion object {
+        private val values = entries.toTypedArray()
+        private val log = KotlinLogging.logger {}
+
+        fun fromExternalValue(value: String?): NavSivilstandSpecV1 =
+            values.singleOrNull { it.externalValue.equals(value, true) } ?: default(value)
+
+        private fun default(externalValue: String?): NavSivilstandSpecV1 =
+            if (StringUtils.hasLength(externalValue))
+                UGIF.also { log.warn { "Unknown NavSivilstandSpecV1: '$externalValue'" } }
+            else
+                UGIF
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1in/NavUttakGradSpecV1.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1in/NavUttakGradSpecV1.kt
@@ -1,0 +1,57 @@
+package no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1in
+
+import mu.KotlinLogging
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import org.springframework.util.StringUtils
+
+// no.nav.domain.pensjon.kjerne.kodetabeller.UttaksgradCode
+enum class NavUttakGradSpecV1(val externalValue: String, val internalValue: UttakGradKode) {
+    /**
+     * 0 %
+     */
+    P_0("0", UttakGradKode.P_0),
+
+    /**
+     * 100 %
+     */
+    P_100("100", UttakGradKode.P_100),
+
+    /**
+     * 20 %
+     */
+    P_20("20", UttakGradKode.P_20),
+
+    /**
+     * 40 %
+     */
+    P_40("40", UttakGradKode.P_40),
+
+    /**
+     * 50 %
+     */
+    P_50("50", UttakGradKode.P_50),
+
+    /**
+     * 60 %
+     */
+    P_60("60", UttakGradKode.P_60),
+
+    /**
+     * 80 %
+     */
+    P_80("80", UttakGradKode.P_80);
+
+    companion object {
+        private val values = entries.toTypedArray()
+        private val log = KotlinLogging.logger {}
+
+        fun fromExternalValue(value: String?): NavUttakGradSpecV1 =
+            values.singleOrNull { it.externalValue.equals(value, true) } ?: default(value)
+
+        private fun default(externalValue: String?): NavUttakGradSpecV1 =
+            if (StringUtils.hasLength(externalValue))
+                P_100.also { log.warn { "Unknown AnonymUttakGradSpec: '$externalValue'" } }
+            else
+                P_100
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1out/NavSimuleringResultMapperV1.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1out/NavSimuleringResultMapperV1.kt
@@ -1,0 +1,69 @@
+package no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1out
+
+import no.nav.pensjon.simulator.alderspensjon.alternativ.*
+import no.nav.pensjon.simulator.core.beholdning.OpptjeningGrunnlag
+
+/**
+ * Maps between data transfer objects (DTOs) and domain objects related to simulering.
+ * The DTOs are specified by version 1 of the API offered to clients.
+ */
+object NavSimuleringResultMapperV1 {
+
+    fun mapNavSimuleringResultV1(source: SimulertPensjonEllerAlternativ?) =
+        NavSimuleringResultV1(
+            alderspensjon = source?.pensjon?.alderspensjon.orEmpty().map(NavSimuleringResultMapperV1::alderspensjon),
+            afpPrivat = source?.pensjon?.privatAfp.orEmpty().map(NavSimuleringResultMapperV1::privatAfp),
+            afpOffentliglivsvarig = source?.pensjon?.livsvarigOffentligAfp.orEmpty().map(NavSimuleringResultMapperV1::livsvarigOffentligAfp),
+            vilkaarsproeving = vilkaarsproevingResultat(source?.alternativ),
+            harNokTrygdetidForGarantipensjon = source?.pensjon?.harNokTrygdetidForGarantipensjon,
+            trygdetid = source?.pensjon?.trygdetid ?: 0,
+            opptjeningGrunnlagListe = source?.pensjon?.opptjeningGrunnlagListe.orEmpty().map(NavSimuleringResultMapperV1::opptjeningGrunnlag)
+        )
+
+    private fun alderspensjon(source: SimulertAarligAlderspensjon) =
+        SimulertAlderspensjonV1(
+            alder = source.alderAar,
+            beloep = source.beloep,
+            inntektspensjon = source.inntektspensjon,
+            garantipensjon = source.garantipensjon,
+            delingstall = source.delingstall,
+            pensjonBeholdningFoerUttak = source.pensjonBeholdningFoerUttak
+        )
+
+    private fun privatAfp(source: SimulertPrivatAfp) =
+        SimulertPrivatAfpV1(
+            alder = source.alderAar,
+            beloep = source.beloep
+        )
+
+    private fun livsvarigOffentligAfp(source: SimulertLivsvarigOffentligAfp) =
+        SimulertLivsvarigOffentligAfpV1(
+            alder = source.alderAar,
+            beloep = source.beloep
+        )
+
+    private fun vilkaarsproevingResultat(source: SimulertAlternativ?) =
+        VilkaarsproevingResultatV1(
+            vilkaarErOppfylt = source == null,
+            alternativ = source?.let(NavSimuleringResultMapperV1::alternativ)
+        )
+
+    private fun opptjeningGrunnlag(source: OpptjeningGrunnlag) =
+        SimulatorOpptjeningGrunnlagV1(
+            aar = source.aar,
+            pensjonsgivendeInntekt = source.pensjonsgivendeInntekt
+        )
+
+    private fun alternativ(source: SimulertAlternativ) =
+        AlternativtResultatV1(
+            gradertUttaksalder = source.gradertUttakAlder?.let(NavSimuleringResultMapperV1::alder),
+            uttaksgrad = source.uttakGrad.value.toInt(),
+            heltUttaksalder = alder(source.heltUttakAlder)
+        )
+
+    private fun alder(source: SimulertUttakAlder) =
+        AlderV1(
+            aar = source.alder.aar,
+            maaneder = source.alder.maaneder
+        )
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1out/NavSimuleringResultV1.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/nav/api/acl/v1out/NavSimuleringResultV1.kt
@@ -1,0 +1,54 @@
+package no.nav.pensjon.simulator.alderspensjon.nav.api.acl.v1out
+
+// SimuleringsresultatAlderspensjon1963Plus
+data class NavSimuleringResultV1(
+    val alderspensjon: List<SimulertAlderspensjonV1>,
+    val afpPrivat: List<SimulertPrivatAfpV1>,
+    val afpOffentliglivsvarig: List<SimulertLivsvarigOffentligAfpV1>,
+    val vilkaarsproeving: VilkaarsproevingResultatV1,
+    val harNokTrygdetidForGarantipensjon: Boolean?,
+    val trygdetid: Int,
+    val opptjeningGrunnlagListe: List<SimulatorOpptjeningGrunnlagV1>
+)
+
+// no.nav.pensjon.pen.domain.api.simulering.dto.SimulertAlderspensjon
+data class SimulertAlderspensjonV1(
+    val alder: Int,
+    val beloep: Int,
+    val inntektspensjon: Int?,
+    val garantipensjon: Int?,
+    val delingstall: Double?,
+    val pensjonBeholdningFoerUttak: Int?
+)
+
+data class SimulertPrivatAfpV1(
+    val alder: Int,
+    val beloep: Int
+)
+
+data class SimulertLivsvarigOffentligAfpV1(
+    val alder: Int,
+    val beloep: Int
+)
+
+// no.nav.pensjon.pen.domain.api.simulering.SimulatorOpptjeningGrunnlag
+data class SimulatorOpptjeningGrunnlagV1(
+    val aar: Int,
+    val pensjonsgivendeInntekt: Int
+)
+
+data class VilkaarsproevingResultatV1(
+    val vilkaarErOppfylt: Boolean,
+    val alternativ: AlternativtResultatV1?
+)
+
+data class AlternativtResultatV1(
+    val gradertUttaksalder: AlderV1?,
+    val uttaksgrad: Int,
+    val heltUttaksalder: AlderV1
+)
+
+data class AlderV1(
+    val aar: Int,
+    val maaneder: Int
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContext.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContext.kt
@@ -13,7 +13,6 @@ import no.nav.pensjon.simulator.core.exception.KanIkkeBeregnesException
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.createDate
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.fromLocalDate
 import no.nav.pensjon.simulator.core.util.DateNoonExtension.noon
-import no.nav.pensjon.simulator.generelt.client.GenerelleDataClient
 import no.nav.pensjon.simulator.regel.client.GenericRegelClient
 import no.nav.pensjon.simulator.regel.client.RegelClient
 import org.springframework.stereotype.Component
@@ -23,8 +22,7 @@ import java.util.*
 
 @Component
 class SimulatorContext(
-    private val regelService: GenericRegelClient,
-    private val penClient: GenerelleDataClient
+    private val regelService: GenericRegelClient
 ) : RegelClient {
 
     // BeregnAlderspensjon2011ForsteUttakConsumerCommand.execute

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/UttakAlderDiscriminator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/UttakAlderDiscriminator.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.simulator.core
 
 import no.nav.pensjon.simulator.core.exception.ForLavtTidligUttakException
 import no.nav.pensjon.simulator.core.result.SimulatorOutput
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.trygd.ForKortTrygdetidException
 import no.nav.pensjon.simulator.person.Pid
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/livsvarig/LivsvarigOffentligAfpResult.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/livsvarig/LivsvarigOffentligAfpResult.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.afp.offentlig.livsvarig
 
-import no.nav.pensjon.simulator.core.domain.Alder
+import no.nav.pensjon.simulator.alder.Alder
 import java.time.LocalDate
 
 // no.nav.consumer.pensjon.pen.simuleroffentligtjenestepensjon.to.afpoffentliglivsvarig.response.SimulerAFPOffentligLivsvarigResponse

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/privat/PrivatAfpBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/privat/PrivatAfpBeregner.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.simulator.core.afp.privat
 
 import no.nav.pensjon.simulator.core.SimulatorContext
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.SakType
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/privat/PrivatAfpSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/privat/PrivatAfpSpec.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.afp.privat
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsResultatAfpPrivat
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beholdning/OpptjeningGrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beholdning/OpptjeningGrunnlag.kt
@@ -1,0 +1,7 @@
+package no.nav.pensjon.simulator.core.beholdning
+
+// no.nav.pensjon.pen.domain.api.simulering.SimulatorOpptjeningGrunnlag
+data class OpptjeningGrunnlag(
+    val aar: Int,
+    val pensjonsgivendeInntekt: Int
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverBeregnerSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverBeregnerSpec.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.simulator.core.beregn
 //TODO move to beregn
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.afp.offentlig.livsvarig.LivsvarigOffentligAfpResult
 import no.nav.pensjon.simulator.core.knekkpunkt.KnekkpunktAarsak
 import no.nav.pensjon.simulator.core.krav.KravGjelder

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregner.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.beregn
 
 import mu.KotlinLogging
 import no.nav.pensjon.simulator.core.SimulatorContext
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.afp.offentlig.livsvarig.LivsvarigOffentligAfpYtelseMedDelingstall
 import no.nav.pensjon.simulator.core.beholdning.BeholdningType
 import no.nav.pensjon.simulator.core.beregn.PeriodiseringUtil.periodiserGrunnlagAndModifyKravhode

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/TTPeriode.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/TTPeriode.kt
@@ -54,23 +54,17 @@ class TTPeriode(
     }
     // end SIMDOM-ADD
 
-    constructor(tTPeriode: TTPeriode) : this() {
-        if (tTPeriode.fom != null) {
-            this.fom = tTPeriode.fom!!.clone() as Date
-        }
-        if (tTPeriode.tom != null) {
-            this.tom = tTPeriode.tom!!.clone() as Date
-        }
-        this.poengIInnAr = tTPeriode.poengIInnAr
-        this.poengIUtAr = tTPeriode.poengIUtAr
-        if (tTPeriode.land != null) {
-            this.land = LandCti(tTPeriode.land)
-        }
-        this.ikkeProRata = tTPeriode.ikkeProRata
-        this.bruk = tTPeriode.bruk
-        if (tTPeriode.grunnlagKilde != null) {
-            this.grunnlagKilde = GrunnlagKildeCti(tTPeriode.grunnlagKilde)
-        }
+    constructor(source: TTPeriode) : this() {
+        source.fom?.let { this.fom = it.clone() as Date }
+        source.rawFom?.let { this.rawFom = it.clone() as Date }
+        source.tom?.let { this.tom = it.clone() as Date }
+        source.rawTom?.let { this.rawTom = it.clone() as Date }
+        this.poengIInnAr = source.poengIInnAr
+        this.poengIUtAr = source.poengIUtAr
+        source.land?.let { this.land = LandCti(it) }
+        this.ikkeProRata = source.ikkeProRata
+        this.bruk = source.bruk
+        source.grunnlagKilde?.let { this.grunnlagKilde = GrunnlagKildeCti(it) }
     }
 
     override fun compareTo(other: TTPeriode): Int {

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/knekkpunkt/KnekkpunktFinder.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/knekkpunkt/KnekkpunktFinder.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.knekkpunkt
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.domain.regler.Trygdetid
 import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.KravlinjeTypeEnum

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/knekkpunkt/KnekkpunktSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/knekkpunkt/KnekkpunktSpec.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.knekkpunkt
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import java.time.LocalDate
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravUtil.kt
@@ -1,15 +1,10 @@
 package no.nav.pensjon.simulator.core.krav
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
-import no.nav.pensjon.simulator.core.domain.regler.enum.KravlinjeTypeEnum
-import no.nav.pensjon.simulator.core.domain.regler.kode.KravlinjeTypeCti
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.tech.time.DateUtil.maanederInnenforAaret
 import no.nav.pensjon.simulator.tech.time.DateUtil.maanederInnenforRestenAvAaret
 
 object KravUtil {
-
-    //fun kravlinjeType(type: KravlinjeTypeEnum) =
-    //    KravlinjeTypeCti(type.name).apply { hovedKravlinje = type.erHovedkravlinje }
 
     /**
      * Finner antall hele måneder utenlands i et gitt år.

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeCreator.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.simulator.core.krav
 
 import no.nav.pensjon.simulator.core.SimulatorContext
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.beholdning.BeholdningUpdater
 import no.nav.pensjon.simulator.core.beholdning.BeholdningUtil.SISTE_GYLDIGE_OPPTJENING_AAR
 import no.nav.pensjon.simulator.core.beregn.InntektType

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeSpec.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.krav
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 
 // Corresponds to OpprettKravhodeRequest

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeUpdateSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeUpdateSpec.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.krav
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeUpdater.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeUpdater.kt
@@ -1,13 +1,13 @@
 package no.nav.pensjon.simulator.core.krav
 
 import no.nav.pensjon.simulator.core.SimulatorContext
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.afp.offentlig.pre2025.Pre2025OffentligAfpBeholdning
 import no.nav.pensjon.simulator.core.beholdning.BeholdningType
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.SimuleringType
 import no.nav.pensjon.simulator.core.domain.regler.TTPeriode
 import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.RegelverkTypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Opptjeningsgrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
@@ -221,7 +221,7 @@ class KravhodeUpdater(
             val trygdetidGrunnlag = TrygdetidGrunnlagFactory.trygdetidPeriode(
                 fom = LocalDate.of(aar, 1, 1),
                 tom = LocalDate.of(aar, 12, 31),
-                land = Land.NOR
+                land = LandkodeEnum.NOR
             )
 
             trygdetidListe.add(TrygdetidOpphold(periode = trygdetidGrunnlag, arbeidet = true))

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/krav/UttakGradKode.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/krav/UttakGradKode.kt
@@ -1,5 +1,7 @@
 package no.nav.pensjon.simulator.core.krav
 
+//TODO replace by no.nav.pensjon.simulator.core.domain.regler.enum.UttaksgradEnum?
+// no.nav.domain.pensjon.kjerne.kodetabeller.UttaksgradCode
 enum class UttakGradKode(val value: String) {
     /**
      * 0 %

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagMapper.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.person
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.beholdning.BeholdningUtil.SISTE_GYLDIGE_OPPTJENING_AAR
 import no.nav.pensjon.simulator.core.domain.SimuleringType
 import no.nav.pensjon.simulator.core.domain.SivilstatusType

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/ResultPreparerSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/ResultPreparerSpec.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.result
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.out.OutputLivsvarigOffentligAfp
 import no.nav.pensjon.simulator.core.beregn.BeholdningPeriode
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutput.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutput.kt
@@ -2,8 +2,10 @@ package no.nav.pensjon.simulator.core.result
 
 import no.nav.pensjon.simulator.core.afp.privat.SimulertPrivatAfpPeriode
 import no.nav.pensjon.simulator.core.domain.regler.enum.SivilstandEnum
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresultat
 import no.nav.pensjon.simulator.core.out.OutputLivsvarigOffentligAfp
+import java.time.LocalDate
 
 // no.nav.domain.pensjon.kjerne.simulering.SimuleringEtter2011Resultat
 class SimulatorOutput {
@@ -18,4 +20,7 @@ class SimulatorOutput {
     var epsHarInntektOver2G: Boolean = false
     val privatAfpPeriodeListe: MutableList<SimulertPrivatAfpPeriode> = mutableListOf()
     val opptjeningListe: MutableList<SimulertOpptjening> = mutableListOf()
+
+    var foedselDato: LocalDate? = null
+    var persongrunnlag: Persongrunnlag? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutputMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutputMapper.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.result
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.afp.privat.SimulertPrivatAfpPeriode
 import no.nav.pensjon.simulator.core.beholdning.BeholdningType
 import no.nav.pensjon.simulator.core.domain.GrunnlagRolle

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimuleringResultPreparer.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimuleringResultPreparer.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.result
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.beholdning.BeholdningType
 import no.nav.pensjon.simulator.core.beholdning.BeholdningUtil.findElementOfType
 import no.nav.pensjon.simulator.core.beholdning.BeholdningUtil.sortedSubset

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpec.kt
@@ -1,16 +1,18 @@
-package no.nav.pensjon.simulator.core
+package no.nav.pensjon.simulator.core.spec
 
+import no.nav.pensjon.simulator.alder.AlderDato
+import no.nav.pensjon.simulator.core.afp.AfpOrdningType
 import no.nav.pensjon.simulator.core.domain.Avdoed
 import no.nav.pensjon.simulator.core.domain.SimuleringType
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
-import no.nav.pensjon.simulator.core.afp.AfpOrdningType
 import no.nav.pensjon.simulator.core.krav.FremtidigInntekt
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
 import no.nav.pensjon.simulator.core.trygd.UtlandPeriode
 import no.nav.pensjon.simulator.person.Pid
 import java.time.LocalDate
 
-// no.nav.domain.pensjon.kjerne.simulering.SimuleringEtter2011
+// no.nav.domain.pensjon.kjerne.simulering.SimuleringEtter2011 &
+// SimuleringSpecAlderspensjon1963Plus
 data class SimuleringSpec(
     val type: SimuleringType,
     val sivilstatus: SivilstatusType,
@@ -18,6 +20,7 @@ data class SimuleringSpec(
     val foersteUttakDato: LocalDate?,
     var heltUttakDato: LocalDate?, // NB var
     val pid: Pid?, // null for forenklet simulering
+    val foedselDato: LocalDate?, // null for forenklet simulering
     val avdoed: Avdoed?,
     val isTpOrigSimulering: Boolean,
     var simulerForTp: Boolean,
@@ -37,8 +40,55 @@ data class SimuleringSpec(
     val rettTilOffentligAfpFom: LocalDate?,
     val afpOrdning: AfpOrdningType? = null, // Hvilken AFP-ordning bruker er tilknyttet (kun for simulering av pre-2025 offentlig AFP)
     val afpInntektMaanedFoerUttak: Int? = null, // Brukers inntekt måneden før uttak av AFP (kun for simulering av pre-2025 offentlig AFP)
-    var erAnonym: Boolean
+    var erAnonym: Boolean,
+    val isHentPensjonsbeholdninger: Boolean = false,
+    val isOutputSimulertBeregningsinformasjonForAllKnekkpunkter: Boolean = false
 ) {
+
+    fun isGradert() = isGradert(uttakGrad)
+
+    fun gradertUttak(foedselDato: LocalDate): GradertUttakSimuleringSpec? =
+        if (isGradert())
+            GradertUttakSimuleringSpec(
+                grad = uttakGrad,
+                uttakFom = foersteUttakDato?.let { AlderDato(it, foedselDato) }
+                    ?: throw IllegalArgumentException("gradertUttak.uttakFomAlder undefined"),
+                aarligInntektBeloep = inntektUnderGradertUttakBeloep
+            )
+        else
+            null
+
+    fun gradertUttak(foersteUttakFom: AlderDato,
+                     uttakGrad: UttakGradKode): GradertUttakSimuleringSpec? =
+        if (isGradert(uttakGrad))
+            GradertUttakSimuleringSpec(
+                grad = uttakGrad,
+                uttakFom = foersteUttakFom,
+                aarligInntektBeloep = inntektUnderGradertUttakBeloep
+            )
+        else
+            null
+
+    fun heltUttak(foedselDato: LocalDate): HeltUttakSimuleringSpec {
+        val uttakDato: LocalDate = heltUttakDato ?: foersteUttakDato?: throw IllegalArgumentException("Ingen uttaksdato definert")
+        val inntektAntallAar = inntektEtterHeltUttakAntallAar?.toLong() ?: 0L
+
+        return HeltUttakSimuleringSpec(
+            uttakFom = AlderDato(uttakDato, foedselDato),
+            aarligInntektBeloep = inntektEtterHeltUttakBeloep,
+            inntektTom = AlderDato(uttakDato.plusYears(inntektAntallAar), foedselDato)
+        )
+    }
+
+    fun heltUttak(foedselDato: LocalDate, heltUttakFom: AlderDato): HeltUttakSimuleringSpec {
+        val inntektAntallAar = inntektEtterHeltUttakAntallAar?.toLong() ?: 0L
+
+        return HeltUttakSimuleringSpec(
+            uttakFom = heltUttakFom,
+            aarligInntektBeloep = inntektEtterHeltUttakBeloep,
+            inntektTom = AlderDato(heltUttakFom.dato.plusYears(inntektAntallAar), foedselDato)
+        )
+    }
 
     fun withUttak(
         foersteUttakDato: LocalDate?,
@@ -53,6 +103,7 @@ data class SimuleringSpec(
             foersteUttakDato = foersteUttakDato,
             heltUttakDato = heltUttakDato,
             pid,
+            foedselDato,
             avdoed,
             isTpOrigSimulering,
             simulerForTp,
@@ -73,6 +124,8 @@ data class SimuleringSpec(
             afpOrdning,
             afpInntektMaanedFoerUttak,
             erAnonym,
+            isHentPensjonsbeholdninger,
+            isOutputSimulertBeregningsinformasjonForAllKnekkpunkter
         )
 
     fun gjelderPre2025OffentligAfp() =
@@ -81,8 +134,15 @@ data class SimuleringSpec(
     fun gjelderPrivatAfpFoersteUttak() =
         type == SimuleringType.ALDER_M_AFP_PRIVAT
 
+    //TODO move to SimuleringType?
     fun gjelderEndring() =
         type == SimuleringType.ENDR_ALDER ||
                 type == SimuleringType.ENDR_AP_M_AFP_PRIVAT ||
                 type == SimuleringType.ENDR_ALDER_M_GJEN
+
+    private companion object{
+        //TODO move to UttakGradKode?
+        private fun isGradert(grad: UttakGradKode) =
+            grad != UttakGradKode.P_0 && grad != UttakGradKode.P_100
+    }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpec.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.spec
 
-import no.nav.pensjon.simulator.alder.AlderDato
+import no.nav.pensjon.simulator.alder.PensjonAlderDato
 import no.nav.pensjon.simulator.core.afp.AfpOrdningType
 import no.nav.pensjon.simulator.core.domain.Avdoed
 import no.nav.pensjon.simulator.core.domain.SimuleringType
@@ -51,15 +51,17 @@ data class SimuleringSpec(
         if (isGradert())
             GradertUttakSimuleringSpec(
                 grad = uttakGrad,
-                uttakFom = foersteUttakDato?.let { AlderDato(it, foedselDato) }
+                uttakFom = foersteUttakDato?.let { PensjonAlderDato(it, foedselDato) }
                     ?: throw IllegalArgumentException("gradertUttak.uttakFomAlder undefined"),
                 aarligInntektBeloep = inntektUnderGradertUttakBeloep
             )
         else
             null
 
-    fun gradertUttak(foersteUttakFom: AlderDato,
-                     uttakGrad: UttakGradKode): GradertUttakSimuleringSpec? =
+    fun gradertUttak(
+        foersteUttakFom: PensjonAlderDato,
+        uttakGrad: UttakGradKode
+    ): GradertUttakSimuleringSpec? =
         if (isGradert(uttakGrad))
             GradertUttakSimuleringSpec(
                 grad = uttakGrad,
@@ -70,23 +72,24 @@ data class SimuleringSpec(
             null
 
     fun heltUttak(foedselDato: LocalDate): HeltUttakSimuleringSpec {
-        val uttakDato: LocalDate = heltUttakDato ?: foersteUttakDato?: throw IllegalArgumentException("Ingen uttaksdato definert")
+        val uttakDato: LocalDate =
+            heltUttakDato ?: foersteUttakDato ?: throw IllegalArgumentException("Ingen uttaksdato definert")
         val inntektAntallAar = inntektEtterHeltUttakAntallAar?.toLong() ?: 0L
 
         return HeltUttakSimuleringSpec(
-            uttakFom = AlderDato(uttakDato, foedselDato),
+            uttakFom = PensjonAlderDato(uttakDato, foedselDato),
             aarligInntektBeloep = inntektEtterHeltUttakBeloep,
-            inntektTom = AlderDato(uttakDato.plusYears(inntektAntallAar), foedselDato)
+            inntektTom = PensjonAlderDato(uttakDato.plusYears(inntektAntallAar), foedselDato)
         )
     }
 
-    fun heltUttak(foedselDato: LocalDate, heltUttakFom: AlderDato): HeltUttakSimuleringSpec {
+    fun heltUttak(foedselDato: LocalDate, heltUttakFom: PensjonAlderDato): HeltUttakSimuleringSpec {
         val inntektAntallAar = inntektEtterHeltUttakAntallAar?.toLong() ?: 0L
 
         return HeltUttakSimuleringSpec(
             uttakFom = heltUttakFom,
             aarligInntektBeloep = inntektEtterHeltUttakBeloep,
-            inntektTom = AlderDato(heltUttakFom.dato.plusYears(inntektAntallAar), foedselDato)
+            inntektTom = PensjonAlderDato(heltUttakFom.dato.plusYears(inntektAntallAar), foedselDato)
         )
     }
 
@@ -140,7 +143,7 @@ data class SimuleringSpec(
                 type == SimuleringType.ENDR_AP_M_AFP_PRIVAT ||
                 type == SimuleringType.ENDR_ALDER_M_GJEN
 
-    private companion object{
+    private companion object {
         //TODO move to UttakGradKode?
         private fun isGradert(grad: UttakGradKode) =
             grad != UttakGradKode.P_0 && grad != UttakGradKode.P_100

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpecUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpecUtil.kt
@@ -1,0 +1,147 @@
+package no.nav.pensjon.simulator.core.spec
+
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.alder.AlderDato
+import java.time.LocalDate
+
+object SimuleringSpecUtil {
+
+    private val utkantUttakGrad = UttakGradKode.P_20 // kun hvis gradert uttak
+
+    /**
+     * Spesifikasjon for å simulere for ubetinget uttaksalder (normalder, dvs. alderen der enhver kan ta ut pensjon).
+     */
+    fun ubetingetSimuleringSpec(
+        source: SimuleringSpec,
+        normAlder: Alder,
+        foedselDato: LocalDate
+    ): SimuleringSpec {
+        val uttakFomAlder = AlderDato(foedselDato, alderSpec(normAlder))
+
+        return newSimuleringSpec(
+            source,
+            foersteUttakFom = uttakFomAlder,
+            uttakGrad = UttakGradKode.P_100,
+            heltUttakFom = uttakFomAlder,
+            foedselDato
+        )
+    }
+
+    /**
+     * Spesifikasjon for simulering med "utkanttilfellet" (dårligste uttaksparametre før normalder).
+     */
+    fun utkantSimuleringSpec(
+        source: SimuleringSpec,
+        normAlder: Alder,
+        foedselDato: LocalDate
+    ): SimuleringSpec {
+        val gradert = source.isGradert()
+        val utkantFoersteUttakAlder: Alder = normAlder.minusMaaneder(1)
+        val utkantFoersteUttakFomAlderSpec: Alder = alderSpec(utkantFoersteUttakAlder)
+        val heltUttakFomAlderDto: Alder =
+            if (gradert) alderSpec(normAlder) else utkantFoersteUttakFomAlderSpec
+
+        return newSimuleringSpec(
+            source,
+            foersteUttakFom = AlderDato(foedselDato, utkantFoersteUttakFomAlderSpec),
+            uttakGrad = if (gradert) utkantUttakGrad else UttakGradKode.P_100,
+            heltUttakFom = AlderDato(foedselDato, heltUttakFomAlderDto),
+            foedselDato
+        )
+    }
+
+    fun withLavereUttakGrad(source: SimuleringSpec): SimuleringSpec =
+        newSimuleringSpec(
+            source,
+            uttaksgrad = if (source.isGradert()) naermesteLavereUttakGrad(source.uttakGrad) else UttakGradKode.P_100
+        )
+
+    private fun newSimuleringSpec(
+        source: SimuleringSpec,
+        foersteUttakFom: AlderDato,
+        uttakGrad: UttakGradKode,
+        heltUttakFom: AlderDato,
+        foedselDato: LocalDate
+    ): SimuleringSpec {
+        val heltUttakDato: LocalDate = source.heltUttak(foedselDato, heltUttakFom).uttakFom.dato
+
+        return SimuleringSpec(
+            type = source.type,
+            sivilstatus = source.sivilstatus,
+            epsHarPensjon = source.epsHarPensjon,
+            foersteUttakDato = source.gradertUttak(foersteUttakFom, uttakGrad)?.uttakFom?.dato ?: heltUttakDato,
+            heltUttakDato = heltUttakDato,
+            pid = source.pid,
+            foedselDato = source.foedselDato,
+            avdoed = source.avdoed,
+            isTpOrigSimulering = source.isTpOrigSimulering,
+            simulerForTp = source.simulerForTp,
+            uttakGrad = uttakGrad,
+            forventetInntektBeloep = source.forventetInntektBeloep,
+            inntektUnderGradertUttakBeloep = source.inntektUnderGradertUttakBeloep,
+            inntektEtterHeltUttakBeloep = source.inntektEtterHeltUttakBeloep,
+            inntektEtterHeltUttakAntallAar = source.inntektEtterHeltUttakAntallAar, // assuming this is independent of heltUttakFom
+            foedselAar = source.foedselAar,
+            boddUtenlands = source.boddUtenlands,
+            utlandAntallAar = source.utlandAntallAar,
+            utlandPeriodeListe = source.utlandPeriodeListe,
+            fremtidigInntektListe = source.fremtidigInntektListe,
+            inntektOver1GAntallAar = source.inntektOver1GAntallAar,
+            flyktning = source.flyktning,
+            epsHarInntektOver2G = source.epsHarInntektOver2G,
+            rettTilOffentligAfpFom = source.rettTilOffentligAfpFom,
+            afpOrdning = source.afpOrdning,
+            afpInntektMaanedFoerUttak = source.afpInntektMaanedFoerUttak,
+            erAnonym = source.erAnonym,
+            isHentPensjonsbeholdninger = source.isHentPensjonsbeholdninger,
+            isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = source.isOutputSimulertBeregningsinformasjonForAllKnekkpunkter
+        )
+    }
+
+    private fun newSimuleringSpec(source: SimuleringSpec, uttaksgrad: UttakGradKode) =
+        SimuleringSpec(
+            type = source.type,
+            sivilstatus = source.sivilstatus,
+            epsHarPensjon = source.epsHarPensjon,
+            foersteUttakDato = source.foersteUttakDato,
+            heltUttakDato = source.heltUttakDato,
+            pid = source.pid,
+            foedselDato = source.foedselDato,
+            avdoed = source.avdoed,
+            isTpOrigSimulering = source.isTpOrigSimulering,
+            simulerForTp = source.simulerForTp,
+            uttakGrad = uttaksgrad,
+            forventetInntektBeloep = source.forventetInntektBeloep,
+            inntektUnderGradertUttakBeloep = source.inntektUnderGradertUttakBeloep,
+            inntektEtterHeltUttakBeloep = source.inntektEtterHeltUttakBeloep,
+            inntektEtterHeltUttakAntallAar = source.inntektEtterHeltUttakAntallAar,
+            foedselAar = source.foedselAar,
+            boddUtenlands = source.boddUtenlands,
+            utlandAntallAar = source.utlandAntallAar,
+            utlandPeriodeListe = source.utlandPeriodeListe,
+            fremtidigInntektListe = source.fremtidigInntektListe,
+            inntektOver1GAntallAar = source.inntektOver1GAntallAar,
+            flyktning = source.flyktning,
+            epsHarInntektOver2G = source.epsHarInntektOver2G,
+            rettTilOffentligAfpFom = source.rettTilOffentligAfpFom,
+            afpOrdning = source.afpOrdning,
+            afpInntektMaanedFoerUttak = source.afpInntektMaanedFoerUttak,
+            erAnonym = source.erAnonym,
+            isHentPensjonsbeholdninger = source.isHentPensjonsbeholdninger,
+            isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = source.isOutputSimulertBeregningsinformasjonForAllKnekkpunkter
+        )
+
+    private fun naermesteLavereUttakGrad(grad: UttakGradKode) =
+        when (grad) {
+            UttakGradKode.P_0 -> UttakGradKode.P_0
+            UttakGradKode.P_20 -> UttakGradKode.P_0
+            UttakGradKode.P_40 -> UttakGradKode.P_20
+            UttakGradKode.P_50 -> UttakGradKode.P_40
+            UttakGradKode.P_60 -> UttakGradKode.P_50
+            UttakGradKode.P_80 -> UttakGradKode.P_60
+            UttakGradKode.P_100 -> UttakGradKode.P_80
+        }
+
+    private fun alderSpec(source: Alder) = Alder(source.aar, source.maaneder)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpecUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpecUtil.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.spec
 
 import no.nav.pensjon.simulator.alder.Alder
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
-import no.nav.pensjon.simulator.alder.AlderDato
+import no.nav.pensjon.simulator.alder.PensjonAlderDato
 import java.time.LocalDate
 
 object SimuleringSpecUtil {
@@ -17,7 +17,7 @@ object SimuleringSpecUtil {
         normAlder: Alder,
         foedselDato: LocalDate
     ): SimuleringSpec {
-        val uttakFomAlder = AlderDato(foedselDato, alderSpec(normAlder))
+        val uttakFomAlder = PensjonAlderDato(foedselDato, alderSpec(normAlder))
 
         return newSimuleringSpec(
             source,
@@ -44,9 +44,9 @@ object SimuleringSpecUtil {
 
         return newSimuleringSpec(
             source,
-            foersteUttakFom = AlderDato(foedselDato, utkantFoersteUttakFomAlderSpec),
+            foersteUttakFom = PensjonAlderDato(foedselDato, utkantFoersteUttakFomAlderSpec),
             uttakGrad = if (gradert) utkantUttakGrad else UttakGradKode.P_100,
-            heltUttakFom = AlderDato(foedselDato, heltUttakFomAlderDto),
+            heltUttakFom = PensjonAlderDato(foedselDato, heltUttakFomAlderDto),
             foedselDato
         )
     }
@@ -59,9 +59,9 @@ object SimuleringSpecUtil {
 
     private fun newSimuleringSpec(
         source: SimuleringSpec,
-        foersteUttakFom: AlderDato,
+        foersteUttakFom: PensjonAlderDato,
         uttakGrad: UttakGradKode,
-        heltUttakFom: AlderDato,
+        heltUttakFom: PensjonAlderDato,
         foedselDato: LocalDate
     ): SimuleringSpec {
         val heltUttakDato: LocalDate = source.heltUttak(foedselDato, heltUttakFom).uttakFom.dato

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/spec/UttakSimuleringSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/spec/UttakSimuleringSpec.kt
@@ -1,16 +1,16 @@
 package no.nav.pensjon.simulator.core.spec
 
-import no.nav.pensjon.simulator.alder.AlderDato
+import no.nav.pensjon.simulator.alder.PensjonAlderDato
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
 
 data class GradertUttakSimuleringSpec(
     val grad: UttakGradKode,
-    val uttakFom: AlderDato,
+    val uttakFom: PensjonAlderDato,
     val aarligInntektBeloep: Int?
 )
 
 data class HeltUttakSimuleringSpec(
-    val uttakFom: AlderDato,
+    val uttakFom: PensjonAlderDato,
     val aarligInntektBeloep: Int,
-    val inntektTom: AlderDato
+    val inntektTom: PensjonAlderDato
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/spec/UttakSimuleringSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/spec/UttakSimuleringSpec.kt
@@ -1,0 +1,16 @@
+package no.nav.pensjon.simulator.core.spec
+
+import no.nav.pensjon.simulator.alder.AlderDato
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+
+data class GradertUttakSimuleringSpec(
+    val grad: UttakGradKode,
+    val uttakFom: AlderDato,
+    val aarligInntektBeloep: Int?
+)
+
+data class HeltUttakSimuleringSpec(
+    val uttakFom: AlderDato,
+    val aarligInntektBeloep: Int,
+    val inntektTom: AlderDato
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdetidGrunnlagFactory.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdetidGrunnlagFactory.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.simulator.core.trygd
 
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.regler.TTPeriode
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.kode.LandCti
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.fromLocalDate
 import java.time.LocalDate
@@ -19,13 +19,13 @@ object TrygdetidGrunnlagFactory {
             tom = tom?.let { Date(it.time) },
             poengIInnAr = false,
             poengIUtAr = false,
-            land = LandCti(Land.NOR.name),
+            land = LandCti(LandkodeEnum.NOR.name),
             ikkeProRata = false,
             bruk = true,
         ).also { it.finishInit() }
 
     // SettTrygdetidHelper.createTrygdetidsgrunnlagNorge + TrygdetidsgrunnlagFactory.createTrygdetidsgrunnlag
-    fun trygdetidPeriode(fom: Date, tom: Date?, land: Land?, ikkeProRata: Boolean, bruk: Boolean) =
+    fun trygdetidPeriode(fom: Date, tom: Date?, land: LandkodeEnum?, ikkeProRata: Boolean, bruk: Boolean) =
         TTPeriode(
             fom = fom,
             tom = tom,
@@ -36,11 +36,11 @@ object TrygdetidGrunnlagFactory {
             bruk = bruk
         ).also { it.finishInit() }
 
-    fun trygdetidPeriode(fom: LocalDate, tom: LocalDate?, land: Land?, ikkeProRata: Boolean, bruk: Boolean) =
+    fun trygdetidPeriode(fom: LocalDate, tom: LocalDate?, land: LandkodeEnum?, ikkeProRata: Boolean, bruk: Boolean) =
         trygdetidPeriode(fromLocalDate(fom)!!, fromLocalDate(tom), land, ikkeProRata, bruk)
 
     // TrygdetidsgrunnlagFactory.createTrygdetidsgrunnlag
-    fun trygdetidPeriode(fom: Date?, tom: Date?, land: Land?) =
+    fun trygdetidPeriode(fom: Date?, tom: Date?, land: LandkodeEnum?) =
         TTPeriode(
             fom = fom?.let { Date(it.time) },
             tom = tom?.let { Date(it.time) },
@@ -51,7 +51,7 @@ object TrygdetidGrunnlagFactory {
             bruk = true
         ).also { it.finishInit() }
 
-    fun trygdetidPeriode(fom: LocalDate?, tom: LocalDate?, land: Land) =
+    fun trygdetidPeriode(fom: LocalDate?, tom: LocalDate?, land: LandkodeEnum) =
         trygdetidPeriode(fromLocalDate(fom), fromLocalDate(tom), land)
 
     // TrygdetidsgrunnlagFactory.createTrygdetidsgrunnlagForenkletSimulering + createTrygdetidsgrunnlag
@@ -61,8 +61,8 @@ object TrygdetidGrunnlagFactory {
             tom = tom?.let { Date(it.time) },
             poengIInnAr = false,
             poengIUtAr = false,
-            land = LandCti(Land.NOR.name),
-            ikkeProRata = true, // true for forenklet
+            land = LandCti(LandkodeEnum.NOR.name),
+            ikkeProRata = true, // true for anonym
             bruk = true
         ).also { it.finishInit() }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdetidGrunnlagSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdetidGrunnlagSpec.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.trygd
 
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdetidSetter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdetidSetter.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.simulator.core.trygd
 
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.regler.TTPeriode
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Opptjeningsgrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.LOCAL_ETERNITY
@@ -177,7 +177,7 @@ object TrygdetidSetter {
         TrygdetidGrunnlagFactory.trygdetidPeriode(
             fom = fromLocalDate(fom)!!, //TODO noon?
             tom = fromLocalDate(tom),
-            land = Land.NOR,
+            land = LandkodeEnum.NOR,
             ikkeProRata = ikkeProRata,
             bruk = true
         )

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/UtlandPeriode.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/UtlandPeriode.kt
@@ -1,13 +1,12 @@
 package no.nav.pensjon.simulator.core.trygd
 
-import no.nav.pensjon.simulator.core.domain.Land
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import java.time.LocalDate
 
 // no.nav.domain.pensjon.kjerne.simulering.UtenlandsperiodeForSimulering
 data class UtlandPeriode(
     val fom: LocalDate,
     val tom: LocalDate?,
-    val land: Land,
+    val land: LandkodeEnum,
     val arbeidet: Boolean
 )
-

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/UtlandPeriodeTrygdetidMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/UtlandPeriodeTrygdetidMapper.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.trygd
 
-import no.nav.pensjon.simulator.core.domain.Land
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.fromLocalDate
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isAfterByDay
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isBeforeByDay
@@ -65,7 +65,7 @@ object UtlandPeriodeTrygdetidMapper {
         val trygdetidPeriode = TrygdetidGrunnlagFactory.trygdetidPeriode(
             fom = opprinnelig.fom,
             tom = opprinnelig.tom,
-            land = opprinnelig.land?.let { Land.valueOf(it.kode) }
+            land = opprinnelig.land?.let { LandkodeEnum.valueOf(it.kode) }
         )
 
         return TrygdetidOpphold(trygdetidPeriode, utlandPeriode.arbeidet)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/ytelse/LoependeYtelseGetter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/ytelse/LoependeYtelseGetter.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.simulator.core.ytelse
 
 import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDato
-import no.nav.pensjon.simulator.core.SimuleringSpec
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.domain.SakType
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getFirstDayOfMonth2
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/pensjon/simulator/normalder/NormAlderService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/normalder/NormAlderService.kt
@@ -1,0 +1,24 @@
+package no.nav.pensjon.simulator.normalder
+
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.generelt.GenerelleDataHolder
+import no.nav.pensjon.simulator.person.Pid
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+/**
+ * Simulator utilities related to "normalder".
+ * The term "normalder" is defined in "NOU 2022: 7 - Et forbedret pensjonssystem"
+ * (https://www.regjeringen.no/no/dokumenter/nou-2022-7/id2918654/?ch=10#kap9-1):
+ * "aldersgrensen for ubetinget rett til alderspensjon som i dag (2024) er 67 år,
+ *  kalles 'normert pensjoneringsalder', med 'normalderen' som kortform"
+ */
+@Service
+class NormAlderService(
+    private val generelleDataHolder: GenerelleDataHolder
+) {
+    fun normAlder(foedselDato: LocalDate) = Alder(aar = 67, maaneder = 0)
+
+    fun normAlder(pid: Pid) =
+        normAlder(generelleDataHolder.getPerson(pid).foedselDato)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/sak/SakService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/sak/SakService.kt
@@ -1,0 +1,12 @@
+package no.nav.pensjon.simulator.sak
+
+import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDatoCombo
+import no.nav.pensjon.simulator.sak.client.SakClient
+import no.nav.pensjon.simulator.person.Pid
+import org.springframework.stereotype.Service
+
+@Service
+class SakService(private val client: SakClient) {
+
+    fun personVirkningDato(pid: Pid): FoersteVirkningDatoCombo = client.fetchPersonVirkningDato(pid)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/sak/client/SakClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/sak/client/SakClient.kt
@@ -1,0 +1,8 @@
+package no.nav.pensjon.simulator.sak.client
+
+import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDatoCombo
+import no.nav.pensjon.simulator.person.Pid
+
+interface SakClient {
+    fun fetchPersonVirkningDato(pid: Pid): FoersteVirkningDatoCombo
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/sak/client/pen/PenSakClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/sak/client/pen/PenSakClient.kt
@@ -1,0 +1,76 @@
+package no.nav.pensjon.simulator.sak.client.pen
+
+import mu.KotlinLogging
+import no.nav.pensjon.simulator.common.client.ExternalServiceClient
+import no.nav.pensjon.simulator.core.domain.regler.PenPerson
+import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDatoCombo
+import no.nav.pensjon.simulator.sak.client.SakClient
+import no.nav.pensjon.simulator.sak.client.pen.acl.PenSakSpec
+import no.nav.pensjon.simulator.person.Pid
+import no.nav.pensjon.simulator.tech.security.egress.EgressAccess
+import no.nav.pensjon.simulator.tech.security.egress.config.EgressService
+import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.tech.web.CustomHttpHeaders
+import no.nav.pensjon.simulator.tech.web.EgressException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
+@Component
+class PenSakClient(
+    @Value("\${ps.pen.url}") baseUrl: String,
+    @Value("\${ps.web-client.retry-attempts}") retryAttempts: String,
+    webClientBuilder: WebClient.Builder,
+    private val traceAid: TraceAid
+) : ExternalServiceClient(retryAttempts), SakClient {
+
+    private val log = KotlinLogging.logger {}
+    private val webClient = webClientBuilder.baseUrl(baseUrl).build()
+
+    override fun fetchPersonVirkningDato(pid: Pid): FoersteVirkningDatoCombo {
+        val uri = "$BASE_PATH/$PATH"
+
+        return try {
+            webClient
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .headers(::setHeaders)
+                .bodyValue(PenSakSpec(pid.value))
+                .retrieve()
+                .bodyToMono(FoersteVirkningDatoCombo::class.java)
+                .retryWhen(retryBackoffSpec(uri))
+                .block()
+                ?: FoersteVirkningDatoCombo(PenPerson(), emptyList(), emptyList())
+            // NB: No mapping of response; it is assumed that PEN returns regler-compatible response body
+        } catch (e: WebClientRequestException) {
+            throw EgressException("Failed calling $uri", e)
+        } catch (e: WebClientResponseException) {
+            throw EgressException(e.responseBodyAsString, e)
+        }
+    }
+
+    override fun service() = service
+
+    override fun toString(e: EgressException, uri: String) = "Failed calling $uri"
+
+    private fun setHeaders(headers: HttpHeaders) {
+        with(EgressAccess.token(service).value) {
+            headers.setBearerAuth(this)
+            log.debug { "Token: $this" }
+        }
+
+        headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
+    }
+
+    companion object {
+        private const val BASE_PATH = "api"
+        private const val PATH = "v1/simulering/person-virkningsdato"
+        private val service = EgressService.PENSJONSFAGLIG_KJERNE
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/sak/client/pen/acl/PenSakSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/sak/client/pen/acl/PenSakSpec.kt
@@ -1,0 +1,5 @@
+package no.nav.pensjon.simulator.sak.client.pen.acl
+
+data class PenSakSpec(
+    val pid: String
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/search/IntegerAttempt.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/search/IntegerAttempt.kt
@@ -1,0 +1,5 @@
+package no.nav.pensjon.simulator.search
+
+fun interface IntegerAttempt<T : ValueAssessment> {
+    fun tryValue(value: Int): T
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/search/IntegerDiscriminator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/search/IntegerDiscriminator.kt
@@ -1,0 +1,5 @@
+package no.nav.pensjon.simulator.search
+
+fun interface IntegerDiscriminator {
+    fun valueIsGood(value: Int): Boolean
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/search/SearchForMinimum.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/search/SearchForMinimum.kt
@@ -1,0 +1,77 @@
+package no.nav.pensjon.simulator.search
+
+/**
+ * Searches for the lowest integer that satisfies a given 'discriminator' function.
+ * If the function returns 'true', it means the current value is satisfactory, but there may be other satisfactory lower values, so the search tries lower values.
+ * If the function returns 'false', it means the current value is not satisfactory, so the search tries higher values.
+ * The candidate values are in the range [0, max].
+ * The search is binary and recursive.
+ */
+class SearchForMinimum(private val discriminator: IntegerDiscriminator) {
+
+    fun search(max: Int): Int {
+        return nextState(
+            SearchState(
+                min = 0,
+                current = max / 2,
+                max = max,
+                lastBadValue = -9, // some negative value (outside the search range)
+                lastGoodValue = max + 9 // some positive value outside the search range
+            )
+        ).lastGoodValue
+    }
+
+    private fun nextState(state: SearchState): SearchState {
+        if (state.lastGoodValue - state.lastBadValue < 2) {
+            // Search range is at its smallest size, and the satisfactory value can be picked out
+            return SearchState(lastGoodValue = state.lastGoodValue)
+        }
+
+        if (state.lastGoodValue == state.min) {
+            // Search has reached lower limit, and that value is satisfactory
+            return SearchState(lastGoodValue = state.lastGoodValue)
+        }
+
+        if (state.lastBadValue == state.max) {
+            // Search has reached upper limit without finding a satisfactory value
+            return SearchState(lastGoodValue = NO_MATCH_RESULT)
+        }
+
+        val tryLower = discriminator.valueIsGood(state.current) // current value is satisfactory, but we want the lowest satisfactory value
+
+        return if (tryLower) {
+            // Search the lower half search range:
+            nextState(
+                SearchState(
+                    min = state.min,
+                    current = if (state.current - state.min < 2) state.min else (state.min + state.current) / 2,
+                    max = state.current,
+                    lastBadValue = state.lastBadValue,
+                    lastGoodValue = state.current
+                )
+            )
+        } else {
+            // Search the upper half search range:
+            nextState(
+                SearchState(
+                    min = state.current,
+                    current = if (state.max - state.current < 2) state.max else (state.current + state.max) / 2,
+                    max = state.max,
+                    lastBadValue = state.current,
+                    lastGoodValue = state.lastGoodValue
+                )
+            )
+        }
+    }
+
+    private data class SearchState(
+        val min: Int = 0,
+        val current: Int = 0,
+        val max: Int = 0,
+        val lastBadValue: Int = 0,
+        val lastGoodValue: Int)
+
+    private companion object {
+        private const val NO_MATCH_RESULT = -1
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/search/SmallestValueSearch.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/search/SmallestValueSearch.kt
@@ -1,0 +1,82 @@
+package no.nav.pensjon.simulator.search
+
+/**
+ * Searches for the smallest integer that satisfies a given 'discriminator' function.
+ * The candidate values are in the range [0, max].
+ * The search is binary and recursive.
+ * Associated with each integer is an object of type T;
+ * T is the result of the discriminator function for the corresponding integer value.
+ */
+class SmallestValueSearch<T : ValueAssessment>(
+    private val discriminator: IntegerAttempt<T>,
+    private val max: Int) {
+
+    fun search(): T? =
+        nextState(
+            SearchState(
+                min = 0,
+                current = max / 2,
+                max = max,
+                lastBadValue = -9, // some negative value (outside the search range)
+                lastGoodValue = max + 9 // some positive value outside the search range
+            )
+        ).lastGoodObject
+
+    private fun nextState(state: SearchState<T>): SearchState<T> {
+        if (state.lastGoodValue - state.lastBadValue < 2) {
+            // Search range is at its smallest size, and the good value can be picked out
+            return SearchState(lastGoodValue = state.lastGoodValue, lastGoodObject = state.lastGoodObject)
+        }
+
+        if (state.lastGoodValue == state.min) {
+            // Search has reached lower limit, and that value is good
+            return SearchState(lastGoodValue = state.lastGoodValue, lastGoodObject = state.lastGoodObject)
+        }
+
+        if (state.lastBadValue == state.max) {
+            // Search has reached upper limit without finding a good value
+            return SearchState(lastGoodValue = NO_MATCH_RESULT)
+        }
+
+        val currentAssessment = discriminator.tryValue(state.current)
+        val trySmaller = currentAssessment.valueIsGood // current value is good, but we want the smallest good value
+
+        return if (trySmaller) {
+            // Search the lower half search range:
+            nextState(
+                SearchState(
+                    min = state.min,
+                    current = if (state.current - state.min < 2) state.min else (state.min + state.current) / 2,
+                    max = state.current,
+                    lastBadValue = state.lastBadValue,
+                    lastGoodValue = state.current,
+                    lastGoodObject = currentAssessment
+                )
+            )
+        } else {
+            // Search the upper half search range:
+            nextState(
+                SearchState(
+                    min = state.current,
+                    current = if (state.max - state.current < 2) state.max else (state.current + state.max) / 2,
+                    max = state.max,
+                    lastBadValue = state.current,
+                    lastGoodValue = state.lastGoodValue,
+                    lastGoodObject = state.lastGoodObject
+                )
+            )
+        }
+    }
+
+    private data class SearchState<T>(
+        val min: Int = 0,
+        val current: Int = 0,
+        val max: Int = 0,
+        val lastBadValue: Int = 0,
+        val lastGoodValue: Int,
+        val lastGoodObject: T? = null)
+
+    private companion object {
+        private const val NO_MATCH_RESULT = -1
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/search/ValueAssessment.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/search/ValueAssessment.kt
@@ -1,0 +1,5 @@
+package no.nav.pensjon.simulator.search
+
+interface ValueAssessment {
+    val valueIsGood: Boolean
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/uttak/UttakUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/uttak/UttakUtil.kt
@@ -1,0 +1,97 @@
+package no.nav.pensjon.simulator.uttak
+
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.search.IntegerDiscriminator
+import no.nav.pensjon.simulator.search.SearchForMinimum
+import no.nav.pensjon.simulator.tech.time.DateUtil.MAANEDER_PER_AAR
+import java.time.LocalDate
+
+// SimulatorPensjonTidUtil + SimulatorUttaksalderUtil
+object UttakUtil {
+    /**
+     * Antall år fra alder når alderspensjonen tidligst kan tas ut til alder der alle har ubetinget rett til å ta ut minsteytelsen.
+     * Før 2026 var disse alderne henholdsvis 62 og 67 år.
+     * F.o.m. 2026 vil alderne være dynamiske, men differansen vil være den samme (5 år).
+     */
+    const val ANTALL_AAR_MELLOM_NEDRE_ALDERSGRENSE_OG_NORMALDER = 5
+
+    /**
+     * Antall måneder fra alder når alderspensjonen tidligst kan tas ut til alder der alle har ubetinget rett til å ta ut minsteytelsen.
+     * Før 2026 var disse alderne henholdsvis 62 og 67 år.
+     * F.o.m. 2026 vil alderne være dynamiske, men differansen vil være den samme (5 år).
+     */
+    private const val ANTALL_KANDIDAT_MAANEDER = ANTALL_AAR_MELLOM_NEDRE_ALDERSGRENSE_OG_NORMALDER * MAANEDER_PER_AAR
+
+    val indexedUttakGrader = mapOf(
+        UttakGradKode.P_80 to 0,
+        UttakGradKode.P_60 to 1,
+        UttakGradKode.P_50 to 2,
+        UttakGradKode.P_40 to 3,
+        UttakGradKode.P_20 to 4
+    )
+
+    /**
+     * Uttaksdato er første dag i måneden etter "aldersdato".
+     * "aldersdato" er datoen da aldersinnehaveren har en gitt alder (aldersdato = fødselsdato + alder)
+     */
+    fun uttakDato(foedselDato: LocalDate, uttakAlder: Alder): LocalDate =
+        foedselDato.plusYears(uttakAlder.aar.toLong())
+            .plusMonths((uttakAlder.maaneder + 1).toLong())
+            .withDayOfMonth(1)
+
+    // In PEN used by SimulatorLavesteUttaksalderFinder (TMU)
+    fun forsteUttakDato(
+        foedselDato: LocalDate,
+        tidligstUttakAlder: Alder,
+        maxAlder: Alder,
+        discriminator: IntegerDiscriminator
+    ): LocalDate {
+        val antallKandidatMaaneder = maxAlder.antallMaanederEtter(tidligstUttakAlder)
+        val antallMaaneder = SearchForMinimum(discriminator).search(antallKandidatMaaneder)
+        val tilleggMaaneder = if (antallMaaneder < 0) ANTALL_KANDIDAT_MAANEDER else antallMaaneder
+        return uttakDato(foedselDato, tidligstUttakAlder).plusMonths(tilleggMaaneder.toLong())
+    }
+
+    fun uttakDatoKandidat(foedselDato: LocalDate, lavesteUttakAlder: Alder, antallMaaneder: Int): LocalDate =
+        uttakDato(foedselDato, lavesteUttakAlder).plusMonths(antallMaaneder.toLong())
+
+    //fun alderForrigeMaaned(alder: UttaksalderAlderDto) = Alder(alder.aar, alder.maaneder).minusMaaneder(1)
+
+    /*V4 *
+     * Finner høyeste sluttalder (til og med) for gradert uttak.
+     * Det er alderen man har måneden før startalder for helt uttak.
+     * /
+    fun gradertUttakMaxTomAlder(spec: DatobasertUttakSpec, alderIfNotGradert: Alder): Alder {
+        val alder: UttaksalderAlderDto = heltUttakFomAlder(spec, alderIfNotGradert)
+
+        if (alder.aar < 0) {
+            throw InvalidArgumentException("Ugyldig alder for helt uttak (f.o.m. = ${spec.gradertUttak?.heltUttakFom}) => år = ${alder.aar}")
+        }
+
+        return alderForrigeMaaned(alder)
+    }
+*/
+    /**
+     * Gets a map of indexed uttaksgrader, excluding uttaksgrader greater than the given maxUttakGrad.
+     * The index starts at zero.
+     * Index zero represents the greatest uttaksgrad in the map.
+     * The greatest index represents the smallest uttaksgrad (20 %).
+     */
+    fun indexedUttakGradSubmap(maxUttakGrad: UttakGradKode): Map<Int, UttakGradKode> {
+        val indexShift = indexedUttakGrader[maxUttakGrad] ?: 0
+
+        return indexedUttakGrader
+            .filter { it.value >= indexShift }
+            .map { (grad, index) -> index - indexShift to grad }
+            .toMap()
+    }
+    /*V4
+        private fun heltUttakFomAlder(spec: DatobasertUttakSpec, alderIfNotGradert: Alder): UttaksalderAlderDto =
+            spec.gradertUttak?.let {
+                with(alderDato(spec.foedselDato, it.heltUttakFom).alder) {
+                    UttaksalderAlderDto(aar = this.aar, maaneder = this.maaneder)
+                }
+            } ?: dto(alderIfNotGradert)
+    */
+}

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/krav/KravUtilTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/krav/KravUtilTest.kt
@@ -2,10 +2,10 @@ package no.nav.pensjon.simulator.core.krav
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import no.nav.pensjon.simulator.core.SimuleringSpec
-import no.nav.pensjon.simulator.core.domain.Land
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.domain.SimuleringType
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.trygd.UtlandPeriode
 import java.time.LocalDate
 
@@ -41,13 +41,13 @@ private fun simuleringSpecMedOverlappendeUtlandPerioder(): SimuleringSpec =
             UtlandPeriode(
                 fom = LocalDate.of(2001, 1, 15), // overlapper uttaksperiode 2001...
                 tom = LocalDate.of(2001, 9, 15), // ...1.aug.-15.sept. (1 hel måned)
-                land = Land.AUS,
+                land = LandkodeEnum.AUS,
                 arbeidet = false
             ),
             UtlandPeriode(
                 fom = LocalDate.of(2001, 5, 15), // overlapper uttaksperiode 2001...
                 tom = LocalDate.of(2001, 12, 15), // ...1.aug.-15.des. (4 hele måneder)
-                land = Land.AUS,
+                land = LandkodeEnum.AUS,
                 arbeidet = true
             )
         )
@@ -61,6 +61,7 @@ private fun simuleringSpec(utlandPeriodeListe: MutableList<UtlandPeriode>) =
         foersteUttakDato = LocalDate.of(2001, 8, 1), // => uttaksperiode 2001 = 1.aug.-31.des.
         heltUttakDato = null,
         pid = null,
+        foedselDato = null,
         avdoed = null,
         isTpOrigSimulering = false,
         simulerForTp = false,

--- a/src/test/kotlin/no/nav/pensjon/simulator/uttak/UttakUtilTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/uttak/UttakUtilTest.kt
@@ -1,0 +1,35 @@
+package no.nav.pensjon.simulator.uttak
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+
+class UttakUtilTest : FunSpec({
+
+    test("indexedUttakGradSubmap for 80 prosent inkluderer alle uttaksgrader") {
+        val map = UttakUtil.indexedUttakGradSubmap(UttakGradKode.P_80)
+
+        map.size shouldBe 5
+        map[0] shouldBe UttakGradKode.P_80
+        map[1] shouldBe UttakGradKode.P_60
+        map[2] shouldBe UttakGradKode.P_50
+        map[3] shouldBe UttakGradKode.P_40
+        map[4] shouldBe UttakGradKode.P_20
+    }
+
+    test("indexedUttakGradSubmap for 50 prosent inkluderer uttaksgradene 50, 40 og 20 prosent") {
+        val map = UttakUtil.indexedUttakGradSubmap(UttakGradKode.P_50)
+
+        map.size shouldBe 3
+        map[0] shouldBe UttakGradKode.P_50
+        map[1] shouldBe UttakGradKode.P_40
+        map[2] shouldBe UttakGradKode.P_20
+    }
+
+    test("indexedUttakGradSubmap for 20 prosent inkluderer bare uttaksgraden 20 prosent") {
+        val map = UttakUtil.indexedUttakGradSubmap(UttakGradKode.P_20)
+
+        map.size shouldBe 1
+        map[0] shouldBe UttakGradKode.P_20
+    }
+})


### PR DESCRIPTION
Kopiert (og omorganisert) kode fra PEN for å støtte simulering for pensjonskalkulator-backend (innloggede brukere født 1963 eller senere).

Det nye endepunktet er i `NavAlderspensjonController` (prefiks "Nav", siden tjenesten er myntet på NAV-klient og ikke TPO).

Koden inkluderer NAU-logikk ('nært angitt uttak') for å finne alternativt uttak ved for lav opptjening.

Mangler som kommer i andre PR-er:

- Nødvendige PEN-tjenester
- Enhetstester