### PR TITLE
PEK-555 Add support for client credentials tokens

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/security/ApiAuthenticationManagerResolver.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/security/ApiAuthenticationManagerResolver.kt
@@ -1,0 +1,26 @@
+package no.nav.pensjon.simulator.tech.security
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.AuthenticationManagerResolver
+import org.springframework.security.authentication.ProviderManager
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+import org.springframework.security.web.util.matcher.RequestMatcher
+
+class ApiAuthenticationManagerResolver(
+    entraProvider: ProviderManager,
+    maskinportenProvider: ProviderManager
+) : AuthenticationManagerResolver<HttpServletRequest> {
+    private val managerMap: Map<RequestMatcher, AuthenticationManager> =
+        mapOf(
+            AntPathRequestMatcher("/api/nav/**") to entraProvider,
+            AntPathRequestMatcher("/api/tpo/**") to maskinportenProvider,
+            AntPathRequestMatcher("/api/v4/simuler-alderspensjon") to maskinportenProvider,
+            AntPathRequestMatcher("/api/v1/simuler-folketrygdbeholdning") to maskinportenProvider,
+            AntPathRequestMatcher("/api/v1/tidligst-mulig-uttak") to maskinportenProvider
+        )
+
+    override fun resolve(request: HttpServletRequest?): AuthenticationManager =
+        managerMap.entries.firstOrNull { it.key.matches(request) }?.value
+            ?: throw IllegalArgumentException("Unable to resolve AuthenticationManager")
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/security/ApiAuthenticationManagerResolver.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/security/ApiAuthenticationManagerResolver.kt
@@ -14,7 +14,7 @@ class ApiAuthenticationManagerResolver(
     private val managerMap: Map<RequestMatcher, AuthenticationManager> =
         mapOf(
             AntPathRequestMatcher("/api/nav/**") to entraProvider,
-            AntPathRequestMatcher("/api/tpo/**") to maskinportenProvider,
+            AntPathRequestMatcher("/api/tpo/**") to entraProvider,
             AntPathRequestMatcher("/api/v4/simuler-alderspensjon") to maskinportenProvider,
             AntPathRequestMatcher("/api/v1/simuler-folketrygdbeholdning") to maskinportenProvider,
             AntPathRequestMatcher("/api/v1/tidligst-mulig-uttak") to maskinportenProvider

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/security/ingress/TokenAudienceValidator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/security/ingress/TokenAudienceValidator.kt
@@ -8,23 +8,19 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult.failu
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult.success
 import org.springframework.security.oauth2.jwt.Jwt
 
-class TokenScopeValidator(val scope: String) : OAuth2TokenValidator<Jwt> {
+class TokenAudienceValidator(val audience: String) : OAuth2TokenValidator<Jwt> {
 
     private val log = KotlinLogging.logger {}
 
     override fun validate(token: Jwt): OAuth2TokenValidatorResult =
-        validate(tokenScope = token.getClaimAsString(CLAIM_NAME) ?: "")
+        validate(token.audience.orEmpty())
 
-    private fun validate(tokenScope: String): OAuth2TokenValidatorResult =
-        if (tokenScope == scope)
+    private fun validate(audiences: List<String>): OAuth2TokenValidatorResult =
+        if (audiences.contains(audience))
             success()
         else
-            "Invalid $CLAIM_NAME: $tokenScope".let {
+            "Invalid audience claim: ${audiences.joinToString()}".let {
                 log.warn { it }
                 failure(OAuth2Error(it))
             }
-
-    private companion object {
-        private const val CLAIM_NAME = "scope"
-    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,11 @@
 spring.main.banner-mode=off
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${MASKINPORTEN_ISSUER:https://test.maskinporten.no/}
 server.error.include-message=always
 
 azure-app.client-id=${AZURE_APP_CLIENT_ID:b9c95cee-76d7-43ba-82e9-d6011f623b9a}
+azure.openid.config.issuer=${AZURE_OPENID_CONFIG_ISSUER:https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0}
 azure.openid-config.token-endpoint=${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT:https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/oauth2/v2.0/token}
+
+maskinporten.issuer=${MASKINPORTEN_ISSUER:https://test.maskinporten.no/}
 
 management.endpoint.health.probes.enabled=true
 management.endpoint.prometheus.enabled=true

--- a/src/test/kotlin/no/nav/pensjon/simulator/tech/security/ApiAuthenticationManagerResolverTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/tech/security/ApiAuthenticationManagerResolverTest.kt
@@ -21,10 +21,21 @@ class ApiAuthenticationManagerResolverTest : FunSpec({
         authenticationManager.authenticate(entraAuthentication).isAuthenticated shouldBe true
     }
 
-    test("resolve uses Maskinporten when path is /api/tpo/**") {
+    test("resolve uses Entra ID when path is /api/tpo/**") {
+        val (entraProvider, entraAuthentication) = arrangeAuth(isAuthenticated = true)
+        val (maskinportenProvider, _) = arrangeAuth(isAuthenticated = false)
+        val request = arrangeRequest(path = "/api/tpo/service1")
+        val resolver = ApiAuthenticationManagerResolver(entraProvider, maskinportenProvider)
+
+        val authenticationManager = resolver.resolve(request)
+
+        authenticationManager.authenticate(entraAuthentication).isAuthenticated shouldBe true
+    }
+
+    test("resolve uses Maskinporten when path is /api/v4/simuler-alderspensjon") {
         val (entraProvider, _) = arrangeAuth(isAuthenticated = false)
         val (maskinportenProvider, maskinportenAuthentication) = arrangeAuth(isAuthenticated = true)
-        val request = arrangeRequest(path = "/api/tpo/service1")
+        val request = arrangeRequest(path = "/api/v4/simuler-alderspensjon")
         val resolver = ApiAuthenticationManagerResolver(entraProvider, maskinportenProvider)
 
         val authenticationManager = resolver.resolve(request)

--- a/src/test/kotlin/no/nav/pensjon/simulator/tech/security/ApiAuthenticationManagerResolverTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/tech/security/ApiAuthenticationManagerResolverTest.kt
@@ -1,0 +1,51 @@
+package no.nav.pensjon.simulator.tech.security
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import jakarta.servlet.http.HttpServletRequest
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.springframework.security.authentication.ProviderManager
+import org.springframework.security.core.Authentication
+
+class ApiAuthenticationManagerResolverTest : FunSpec({
+
+    test("resolve uses Entra ID when path is /api/nav/**") {
+        val (entraProvider, entraAuthentication) = arrangeAuth(isAuthenticated = true)
+        val (maskinportenProvider, _) = arrangeAuth(isAuthenticated = false)
+        val request = arrangeRequest(path = "/api/nav/service1")
+        val resolver = ApiAuthenticationManagerResolver(entraProvider, maskinportenProvider)
+
+        val authenticationManager = resolver.resolve(request)
+
+        authenticationManager.authenticate(entraAuthentication).isAuthenticated shouldBe true
+    }
+
+    test("resolve uses Maskinporten when path is /api/tpo/**") {
+        val (entraProvider, _) = arrangeAuth(isAuthenticated = false)
+        val (maskinportenProvider, maskinportenAuthentication) = arrangeAuth(isAuthenticated = true)
+        val request = arrangeRequest(path = "/api/tpo/service1")
+        val resolver = ApiAuthenticationManagerResolver(entraProvider, maskinportenProvider)
+
+        val authenticationManager = resolver.resolve(request)
+
+        authenticationManager.authenticate(maskinportenAuthentication).isAuthenticated shouldBe true
+    }
+})
+
+private fun arrangeAuth(isAuthenticated: Boolean): Pair<ProviderManager, Authentication> {
+    val authentication = mock(Authentication::class.java).also {
+        `when`(it.isAuthenticated).thenReturn(isAuthenticated)
+    }
+
+    val provider = mock(ProviderManager::class.java).also {
+        `when`(it.authenticate(authentication)).thenReturn(authentication)
+    }
+
+    return Pair(provider, authentication)
+}
+
+private fun arrangeRequest(path: String): HttpServletRequest =
+    mock(HttpServletRequest::class.java).also {
+        `when`(it.servletPath).thenReturn(path)
+    }

--- a/src/test/kotlin/no/nav/pensjon/simulator/tech/security/ingress/TokenAudienceValidatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/tech/security/ingress/TokenAudienceValidatorTest.kt
@@ -1,0 +1,29 @@
+package no.nav.pensjon.simulator.tech.security.ingress
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.security.oauth2.jwt.Jwt
+
+class TokenAudienceValidatorTest : FunSpec({
+
+    test("validate has no errors when audience is valid") {
+        val validatorResult = TokenAudienceValidator(audience = "audience1").validate(jwt(audience = "audience1"))
+        validatorResult.hasErrors() shouldBe false
+    }
+
+    test("validate has errors when audience is invalid") {
+        val validatorResult = TokenAudienceValidator(audience = "audience1").validate(jwt(audience = "bad"))
+        validatorResult.hasErrors() shouldBe true
+    }
+
+    test("validate has errors when audience claim is missing") {
+        val validatorResult = TokenAudienceValidator(audience = "audience1").validate(jwt(claims = mapOf("x" to "y")))
+        validatorResult.hasErrors() shouldBe true
+    }
+})
+
+private fun jwt(audience: String) =
+    jwt(claims = mapOf("aud" to audience))
+
+private fun jwt(claims: Map<String, Any>) =
+    Jwt("j.w.t", null, null, mapOf("k" to "v"), claims)

--- a/src/test/kotlin/no/nav/pensjon/simulator/tech/security/ingress/TokenScopeValidatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/tech/security/ingress/TokenScopeValidatorTest.kt
@@ -1,0 +1,29 @@
+package no.nav.pensjon.simulator.tech.security.ingress
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.security.oauth2.jwt.Jwt
+
+class TokenScopeValidatorTest : FunSpec({
+
+    test("validate has no errors when scope is valid") {
+        val validatorResult = TokenScopeValidator(scope = "scope1").validate(jwt(scope = "scope1"))
+        validatorResult.hasErrors() shouldBe false
+    }
+
+    test("validate has errors when scope is invalid") {
+        val validatorResult = TokenScopeValidator(scope = "scope1").validate(jwt(scope = "bad"))
+        validatorResult.hasErrors() shouldBe true
+    }
+
+    test("validate has errors when scope claim is missing") {
+        val validatorResult = TokenScopeValidator(scope = "scope1").validate(jwt(claims = mapOf("x" to "y")))
+        validatorResult.hasErrors() shouldBe true
+    }
+})
+
+private fun jwt(scope: String) =
+    jwt(claims = mapOf("scope" to scope))
+
+private fun jwt(claims: Map<String, Any>) =
+    Jwt("j.w.t", null, null, mapOf("k" to "v"), claims)


### PR DESCRIPTION
Simulatoren skal støtte kall med client credentials-token (Entra ID) fra PEN og kalkulator-backend for simulering.
Dette kommer i tillegg til eksisterende støtte for kall med maskinporten-token fra TPO-er.

Kallene fra PEN er for å støtte simulering V1, V2 og V3 (gamle tjenester for TPO-er). Disse kallene vil ha path `/api/tpo/**`.

Kallene fra kalkulator-backend er for simulering for personer logget inn på Nav. Disse kallene vil ha path `/api/nav/**`.