### PR TITLE
PEK-612 stoppe simulering hvis tp-ordning ikke tilknyttet angitt bruk…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,5 +238,11 @@
             <version>1.3.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito.kotlin</groupId>
+            <artifactId>mockito-kotlin</artifactId>
+            <version>5.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/kotlin/no/nav/pensjon/simulator/common/api/ControllerBase.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/common/api/ControllerBase.kt
@@ -71,11 +71,10 @@ abstract class ControllerBase(
 
             if (tilknytningService?.erPersonTilknyttetTjenestepensjonsordning(pid, organisasjonsnummer) == false) {
                 log.warn { "Brukeren er ikke tilknyttet angitt TP-leverandør $organisasjonsnummer" }
-                //TODO uncomment to enforce policy
-    //            throw ResponseStatusException(
-    //                HttpStatus.FORBIDDEN,
-    //                "Call ID: ${traceAid.callId()} | Error: Brukeren er ikke tilknyttet angitt TP-leverandør"
-    //            )
+                throw ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "Call ID: ${traceAid.callId()} | Error: Brukeren er ikke tilknyttet angitt TP-leverandør"
+                )
             }
         }
     }

--- a/src/test/kotlin/no/nav/pensjon/simulator/common/api/ControllerBaseTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/common/api/ControllerBaseTest.kt
@@ -1,0 +1,56 @@
+package no.nav.pensjon.simulator.common.api
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.generelt.organisasjon.Organisasjonsnummer
+import no.nav.pensjon.simulator.generelt.organisasjon.OrganisasjonsnummerProvider
+import no.nav.pensjon.simulator.person.Pid
+import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.web.server.ResponseStatusException
+
+class ControllerBaseTest : FunSpec({
+
+    val pid = Pid("12906498357")
+
+    test("verifiser at testVerifiserAtBrukerTilknyttetTpLeverandoer ikke kaster exception naar bruker tilknyttet TpLeverandoer") {
+        val tilknytning = mock<TilknytningService>()
+        val orgNrProvider = mock<OrganisasjonsnummerProvider>()
+        val controller = TestController(mock(), orgNrProvider, tilknytning)
+
+        whenever(orgNrProvider.provideOrganisasjonsnummer()).thenReturn(Organisasjonsnummer("123456789"))
+        whenever(tilknytning.erPersonTilknyttetTjenestepensjonsordning(any(), any())).thenReturn(true)
+
+        controller.testVerifiserAtBrukerTilknyttetTpLeverandoer(pid)
+    }
+
+    test("should throw ResponseStatusException with correct message") {
+        val traceAid = mock<TraceAid>()
+        val controller = TestController(traceAid, mock(), mock())
+
+        whenever(traceAid.callId()).thenReturn("123-124")
+
+        val exception =
+            shouldThrow<ResponseStatusException> { controller.testVerifiserAtBrukerTilknyttetTpLeverandoer(pid) }
+
+        exception.reason shouldBe "Call ID: 123-124 | Error: Brukeren er ikke tilknyttet angitt TP-leverandør"
+        exception.statusCode shouldBe org.springframework.http.HttpStatus.FORBIDDEN
+
+    }
+})
+
+class TestController(
+    traceAid: TraceAid,
+    organisasjonsnummerProvider: OrganisasjonsnummerProvider,
+    tilknytningService: TilknytningService
+) :
+    ControllerBase(traceAid, organisasjonsnummerProvider, tilknytningService) {
+
+    fun testVerifiserAtBrukerTilknyttetTpLeverandoer(pid: Pid) = verifiserAtBrukerTilknyttetTpLeverandoer(pid)
+
+    override fun errorMessage(): String = "error from TestController"
+}


### PR DESCRIPTION
- Fullfører TP-sjekk ved å returnere 403 Forbidden.
- Ekstra tester for TP-sjekk logikken
- Ta i bruk mockito-kotlin laget spesielt for å forenkle bruk av Mockito med Kotlin