### PR TITLE
Add separate scope for Aksio

### DIFF
--- a/.nais/api/apiendpoints.yaml
+++ b/.nais/api/apiendpoints.yaml
@@ -10,10 +10,11 @@ spec:
   krakend: pensjonssimulator
   auth:
     name: maskinporten
-    debug: true
+    debug: false
     cache: true
     scopes:
       - nav:pensjonssimulator:simulering
+      - nav:pensjon/simulering.read
   endpoints:
     - path: /pensjonssimulator/v4/simuler-alderspensjon
       method: POST

--- a/.nais/deploy-dev.yml
+++ b/.nais/deploy-dev.yml
@@ -48,13 +48,19 @@ spec:
         - name: "simulering"
           enabled: true
           product: "pensjonssimulator"
+          consumers:
+            - orgno: "889640782" # Nav (NB: dev only)
+            - orgno: "938708606" # KLP
+            - orgno: "982583462" # SPK
+            - orgno: "931936492" # Storebrand Pensjonstjenester
+        - name: simulering.read
+          enabled: true
+          product: pensjon
+          separator: "/"
           delegationSource: altinn
           consumers:
             - orgno: "889640782" # Nav (NB: dev only)
             - orgno: "927613298" # Aksio
-            - orgno: "938708606" # KLP
-            - orgno: "982583462" # SPK
-            - orgno: "931936492" # Storebrand Pensjonstjenester
   accessPolicy:
     inbound:
       rules:

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>no.nav.pensjon</groupId>
     <artifactId>pensjonssimulator</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <properties>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/doc/OpenApiConfiguration.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/doc/OpenApiConfiguration.kt
@@ -19,8 +19,8 @@ open class OpenApiConfiguration {
             .info(
                 Info()
                     .title("Pensjonssimulator API")
-                    .description("For å kunne bruke tjenestene må scope i autentiseringen mot Maskinporten settes til nav:pensjonssimulator:simulering. Dette er simuleringstjenester for tjenestepensjonsordninger i offentlig sektor, og benyttes for å kunne simulere alderspensjon fra folketrygden for brukere med tjenestepensjonsforhold.")
-                    .version("v1.0.0")
+                    .description("For å kunne bruke tjenestene må scope i autentiseringen mot Maskinporten settes til nav:pensjonssimulator:simulering (hvis delegering ikke brukes) eller nav:pensjon/simulering.read (hvis delegering brukes). Dette er simuleringstjenester for tjenestepensjonsordninger i offentlig sektor, og benyttes for å kunne simulere alderspensjon fra folketrygden for brukere med tjenestepensjonsforhold.")
+                    .version("v1.1.0")
             ).components(
                 Components()
                     .addSecuritySchemes(


### PR DESCRIPTION
Aksio bruker [Maskinporten-delegering](https://docs.digdir.no/docs/Maskinporten/maskinporten_func_delegering).
For å støtte dette brukes `delegationSource`, noe som krever at scope bruker "/" som separator.
Et eget scope for Aksio er dermed opprettet.

Skrur også av `debug`, da vi ikke har hatt bruk for dette.

Tilhørende PR for API-dok: [Oppdatering etter at simulering2025 støtter delegering](https://github.com/navikt/pensjon-ekstern-api/pull/19)