### PR TITLE
PEK-551 Henter beholdning etc

### DIFF
--- a/.nais/deploy-dev.yml
+++ b/.nais/deploy-dev.yml
@@ -48,7 +48,6 @@ spec:
         - name: "simulering"
           enabled: true
           product: "pensjonssimulator"
-          delegationSource: altinn
           consumers:
             - orgno: "889640782" # Nav (NB: dev only)
             - orgno: "938708606" # KLP

--- a/.nais/deploy-dev.yml
+++ b/.nais/deploy-dev.yml
@@ -48,6 +48,7 @@ spec:
         - name: "simulering"
           enabled: true
           product: "pensjonssimulator"
+          delegationSource: altinn
           consumers:
             - orgno: "889640782" # Nav (NB: dev only)
             - orgno: "927613298" # Aksio

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/BeholdningerMedGrunnlagResult.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/BeholdningerMedGrunnlagResult.kt
@@ -1,0 +1,16 @@
+package no.nav.pensjon.simulator.beholdning
+
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.*
+
+/**
+ * Corresponds with BeholdningerMedGrunnlagResult in PEN.
+ * Any changes to this class must be aligned with PEN.
+ */
+data class BeholdningerMedGrunnlagResult(
+    val beholdningListe: List<Beholdning>,
+    val opptjeningGrunnlagListe: List<Opptjeningsgrunnlag>,
+    val inntektGrunnlagListe: List<Inntektsgrunnlag>,
+    val dagpengerGrunnlagListe: List<Dagpengegrunnlag>,
+    val omsorgGrunnlagListe: List<Omsorgsgrunnlag>,
+    val foerstegangstjeneste: Forstegangstjeneste?
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/BeholdningerMedGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/BeholdningerMedGrunnlagService.kt
@@ -1,0 +1,11 @@
+package no.nav.pensjon.simulator.beholdning
+
+import no.nav.pensjon.simulator.beholdning.client.BeholdningClient
+import org.springframework.stereotype.Component
+
+@Component
+class BeholdningerMedGrunnlagService(private val client: BeholdningClient) {
+
+    fun getBeholdningerMedGrunnlag(spec: BeholdningerMedGrunnlagSpec): BeholdningerMedGrunnlagResult =
+        client.fetchBeholdningerMedGrunnlag(spec)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/BeholdningerMedGrunnlagSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/BeholdningerMedGrunnlagSpec.kt
@@ -1,0 +1,26 @@
+package no.nav.pensjon.simulator.beholdning
+
+import no.nav.pensjon.simulator.core.domain.regler.enum.RegelverkTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.SakTypeEnum
+import no.nav.pensjon.simulator.person.Pid
+
+/**
+ * Specifies input to the 'beholdninger med grunnlag' service.
+ */
+data class BeholdningerMedGrunnlagSpec(
+    val pid: Pid,
+    val hentPensjonspoeng: Boolean,
+    val hentGrunnlagForOpptjeninger: Boolean,
+    val hentBeholdninger: Boolean,
+    val harUfoeretrygdKravlinje: Boolean,
+    val regelverkType: RegelverkTypeEnum?,
+    val sakType: SakTypeEnum?,
+    val personSpecListe: List<BeholdningerMedGrunnlagPersonSpec>,
+    val soekerSpec: BeholdningerMedGrunnlagPersonSpec
+)
+
+data class BeholdningerMedGrunnlagPersonSpec(
+    val pid: Pid,
+    val sisteGyldigeOpptjeningAar: Int,
+    val isGrunnlagRolleSoeker: Boolean
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/FolketrygdBeholdningService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/FolketrygdBeholdningService.kt
@@ -4,7 +4,6 @@ import no.nav.pensjon.simulator.beholdning.client.BeholdningClient
 import org.springframework.stereotype.Component
 
 @Component
-
 class FolketrygdBeholdningService(private val client: BeholdningClient) {
 
     fun simulerFolketrygdBeholdning(spec: FolketrygdBeholdningSpec): FolketrygdBeholdning =

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/client/BeholdningClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/client/BeholdningClient.kt
@@ -1,9 +1,13 @@
 package no.nav.pensjon.simulator.beholdning.client
 
+import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagResult
+import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagSpec
 import no.nav.pensjon.simulator.beholdning.FolketrygdBeholdning
 import no.nav.pensjon.simulator.beholdning.FolketrygdBeholdningSpec
 
 interface BeholdningClient {
+
+    fun fetchBeholdningerMedGrunnlag(spec: BeholdningerMedGrunnlagSpec): BeholdningerMedGrunnlagResult
 
     fun simulerFolketrygdBeholdning(spec: FolketrygdBeholdningSpec): FolketrygdBeholdning
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/client/pen/PenBeholdningClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/client/pen/PenBeholdningClient.kt
@@ -9,9 +9,7 @@ import no.nav.pensjon.simulator.tech.web.CustomHttpHeaders
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.beholdning.*
 import no.nav.pensjon.simulator.beholdning.client.BeholdningClient
-import no.nav.pensjon.simulator.beholdning.client.pen.acl.PenFolketrygdBeholdningResult
-import no.nav.pensjon.simulator.beholdning.client.pen.acl.PenFolketrygdBeholdningResultMapper
-import no.nav.pensjon.simulator.beholdning.client.pen.acl.PenFolketrygdBeholdningSpecMapper
+import no.nav.pensjon.simulator.beholdning.client.pen.acl.*
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -33,8 +31,34 @@ class PenBeholdningClient(
 
     override fun service() = service
 
+    override fun fetchBeholdningerMedGrunnlag(spec: BeholdningerMedGrunnlagSpec): BeholdningerMedGrunnlagResult {
+        val uri = "$BASE_PATH/$BEHOLDNINGER_MED_GRUNNLAG_PATH"
+        val dto = PenBeholdningerMedGrunnlagSpecMapper.toDto(spec)
+        log.debug { "POST to URI: '$uri' with body '$dto'" }
+
+        return try {
+            webClient
+                .post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .headers(::setHeaders)
+                .bodyValue(dto)
+                .retrieve()
+                .bodyToMono(BeholdningerMedGrunnlagResult::class.java)
+                .retryWhen(retryBackoffSpec(uri))
+                .block()
+                ?: emptyBeholdningerMedGrunnlagResult()
+            // NB: No mapping of response; it is assumed that PEN returns regler-compatible response body
+        } catch (e: WebClientRequestException) {
+            throw EgressException("Failed calling $uri", e)
+        } catch (e: WebClientResponseException) {
+            throw EgressException(e.responseBodyAsString, e)
+        }
+    }
+
     override fun simulerFolketrygdBeholdning(spec: FolketrygdBeholdningSpec): FolketrygdBeholdning {
-        val uri = "$BASE_PATH/$PATH"
+        val uri = "$LEGACY_BASE_PATH/$FOLKETRYGDBEHOLDNING_PATH"
         val dto = PenFolketrygdBeholdningSpecMapper.toDto(spec)
         log.debug { "POST to URI: '$uri' with body '$dto'" }
 
@@ -51,7 +75,7 @@ class PenBeholdningClient(
                 .retryWhen(retryBackoffSpec(uri))
                 .block()
                 ?.let(PenFolketrygdBeholdningResultMapper::fromDto)
-                ?: nullResult()
+                ?: emptyFolketrygdBeholdning()
         } catch (e: WebClientRequestException) {
             throw EgressException("Failed calling $uri", e)
         } catch (e: WebClientResponseException) {
@@ -66,12 +90,27 @@ class PenBeholdningClient(
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 
-    companion object {
-        private const val BASE_PATH = "pen/springapi"
-        private const val PATH = "simulering/v1/simuler-folketrygdbeholdning"
+    private companion object {
+        private const val BASE_PATH = "pen/api"
+        private const val LEGACY_BASE_PATH = "pen/springapi"
+        private const val BEHOLDNINGER_MED_GRUNNLAG_PATH = "beholdning/v1/beholdninger-med-grunnlag"
+        private const val FOLKETRYGDBEHOLDNING_PATH = "simulering/v1/simuler-folketrygdbeholdning"
 
         private val service = EgressService.PENSJONSFAGLIG_KJERNE
 
-        private fun nullResult() = FolketrygdBeholdning(emptyList())
+        private fun emptyFolketrygdBeholdning() =
+            FolketrygdBeholdning(
+                pensjonBeholdningPeriodeListe = emptyList()
+            )
+
+        private fun emptyBeholdningerMedGrunnlagResult() =
+            BeholdningerMedGrunnlagResult(
+                beholdningListe = emptyList(),
+                opptjeningGrunnlagListe = emptyList(),
+                inntektGrunnlagListe = emptyList(),
+                dagpengerGrunnlagListe = emptyList(),
+                omsorgGrunnlagListe = emptyList(),
+                foerstegangstjeneste = null
+            )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/client/pen/acl/PenBeholdningerMedGrunnlagSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/client/pen/acl/PenBeholdningerMedGrunnlagSpec.kt
@@ -1,0 +1,30 @@
+package no.nav.pensjon.simulator.beholdning.client.pen.acl
+
+import no.nav.pensjon.simulator.core.domain.regler.enum.RegelverkTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.SakTypeEnum
+
+/**
+ * Corresponds with BeholdningerMedGrunnlagSpec in PEN (API provider).
+ * Any changes to this class must be aligned with PEN.
+ */
+data class PenBeholdningerMedGrunnlagSpec(
+    val pid: String,
+    val hentPensjonspoeng: Boolean,
+    val hentGrunnlagForOpptjeninger: Boolean,
+    val hentBeholdninger: Boolean,
+    val harUfoeretrygdKravlinje: Boolean,
+    val regelverkType: RegelverkTypeEnum?,
+    val sakType: SakTypeEnum?,
+    val personSpecListe: List<PenBeholdningerMedGrunnlagPersonSpec>,
+    val soekerSpec: PenBeholdningerMedGrunnlagPersonSpec
+)
+
+/**
+ * Corresponds with BeholdningerMedGrunnlagPersonSpec in PEN (API provider).
+ * Any changes to this class must be aligned with PEN.
+ */
+data class PenBeholdningerMedGrunnlagPersonSpec(
+    val pid: String,
+    val sisteGyldigeOpptjeningAar: Int,
+    val isGrunnlagRolleSoeker: Boolean
+)

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/client/pen/acl/PenBeholdningerMedGrunnlagSpecMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/client/pen/acl/PenBeholdningerMedGrunnlagSpecMapper.kt
@@ -1,0 +1,31 @@
+package no.nav.pensjon.simulator.beholdning.client.pen.acl
+
+import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagSpec
+import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagPersonSpec
+
+/**
+ * Maps a 'beholdninger med grunnlag' specification object from domain variant to DTO variant.
+ * The DTO (data transfer object) is used in calls to PEN.
+ */
+object PenBeholdningerMedGrunnlagSpecMapper {
+
+    fun toDto(source: BeholdningerMedGrunnlagSpec) =
+        PenBeholdningerMedGrunnlagSpec(
+            pid = source.pid.value,
+            hentPensjonspoeng = source.hentPensjonspoeng,
+            hentGrunnlagForOpptjeninger = source.hentGrunnlagForOpptjeninger,
+            hentBeholdninger = source.hentBeholdninger,
+            harUfoeretrygdKravlinje = source.harUfoeretrygdKravlinje,
+            regelverkType = source.regelverkType,
+            sakType = source.sakType,
+            personSpecListe = source.personSpecListe.map(::personligBeholdningSpec),
+            soekerSpec = source.soekerSpec.let(::personligBeholdningSpec)
+        )
+
+    private fun personligBeholdningSpec(source: BeholdningerMedGrunnlagPersonSpec) =
+        PenBeholdningerMedGrunnlagPersonSpec(
+            pid = source.pid.value,
+            sisteGyldigeOpptjeningAar = source.sisteGyldigeOpptjeningAar,
+            isGrunnlagRolleSoeker = source.isGrunnlagRolleSoeker
+        )
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/Pre2025OffentligAfpPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/Pre2025OffentligAfpPersongrunnlag.kt
@@ -14,6 +14,7 @@ import no.nav.pensjon.simulator.core.domain.regler.kode.InntektTypeCti
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.krav.KravhodeCreator
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil
+import no.nav.pensjon.simulator.core.person.eps.EpsService
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.util.toDate
 import no.nav.pensjon.simulator.krav.KravService
@@ -24,8 +25,9 @@ import java.util.*
 // Corresponds to SimulerAFPogAPCommand (persongrunnlag part)
 @Component
 class Pre2025OffentligAfpPersongrunnlag(
-    val kravhodeCreator: KravhodeCreator,
-    val kravService: KravService
+    private val kravhodeCreator: KravhodeCreator,
+    private val kravService: KravService,
+    private val epsService: EpsService
 ) {
     // SimulerAFPogAPCommand.opprettPersongrunnlagForBruker
     fun opprettSoekerGrunnlag(
@@ -117,7 +119,7 @@ class Pre2025OffentligAfpPersongrunnlag(
     // AbstraktSimulerAPFra2011Command.opprettPersongrunnlagForEPS
     // -> OpprettKravHodeHelper.opprettPersongrunnlagForEPS
     private fun opprettEpsPersongrunnlag(spec: SimuleringSpec, kravhode: Kravhode, grunnbeloep: Int) {
-        kravhodeCreator.addAlderspensjonEpsGrunnlagToKrav(spec, kravhode, grunnbeloep)
+        epsService.addAlderspensjonEpsGrunnlagToKrav(spec, kravhode, grunnbeloep)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/endring/EndringPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/endring/EndringPersongrunnlag.kt
@@ -1,0 +1,437 @@
+package no.nav.pensjon.simulator.core.endring
+
+import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagPersonSpec
+import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagService
+import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagSpec
+import no.nav.pensjon.simulator.core.SimulatorContext
+import no.nav.pensjon.simulator.core.beholdning.BeholdningUtil.SISTE_GYLDIGE_OPPTJENING_AAR
+import no.nav.pensjon.simulator.core.domain.Avdoed
+import no.nav.pensjon.simulator.core.domain.SimuleringType
+import no.nav.pensjon.simulator.core.domain.regler.PenPerson
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsInformasjon
+import no.nav.pensjon.simulator.core.domain.regler.enum.*
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.*
+import no.nav.pensjon.simulator.core.domain.regler.kode.GrunnlagKildeCti
+import no.nav.pensjon.simulator.core.domain.regler.kode.InntektTypeCti
+import no.nav.pensjon.simulator.core.domain.regler.kode.OpptjeningTypeCti
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.krav.Inntekt
+import no.nav.pensjon.simulator.core.legacy.util.DateUtil.fromLocalDate
+import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isBeforeByDay
+import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isDateInPeriod
+import no.nav.pensjon.simulator.core.person.PersongrunnlagMapper
+import no.nav.pensjon.simulator.core.person.eps.EpsService
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.core.util.toLocalDate
+import no.nav.pensjon.simulator.krav.KravService
+import no.nav.pensjon.simulator.person.Pid
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.util.*
+
+/**
+ * Handles persongrunnlag in context of 'endring av alderspensjon'.
+ * Corresponds to SimulerEndringAvAPCommand (persongrunnlag part) in PEN
+ */
+@Component
+class EndringPersongrunnlag(
+    private val context: SimulatorContext,
+    private val kravService: KravService,
+    private val beholdningService: BeholdningerMedGrunnlagService,
+    private val epsService: EpsService,
+    private val persongrunnlagMapper: PersongrunnlagMapper
+) {
+    // SimulerEndringAvAPCommand.opprettPersongrunnlagForBruker
+    fun opprettSoekerGrunnlag(
+        person: PenPerson,
+        spec: SimuleringSpec,
+        endringKravhode: Kravhode,
+        forrigeAlderspensjonBeregningResultat: AbstraktBeregningsResultat?
+    ): Kravhode {
+        val eksisterendeKravhode: Kravhode? =
+            forrigeAlderspensjonBeregningResultat?.kravId?.let(kravService::fetchKravhode)
+        val soekerGrunnlag: Persongrunnlag? = eksisterendeKravhode?.hentPersongrunnlagForSoker()?.let(::Persongrunnlag)
+
+        soekerGrunnlag?.apply {
+            bosattLandEnum = LandkodeEnum.NOR
+            inngangOgEksportGrunnlag = InngangOgEksportGrunnlag().apply { fortsattMedlemFT = true }
+            sisteGyldigeOpptjeningsAr = SISTE_GYLDIGE_OPPTJENING_AAR
+            opptjeningsgrunnlagListe = opptjeningGrunnlagListe(spec, endringKravhode, person)
+            spec.flyktning?.let { flyktning = it }
+            adjustPersonDetaljer(this, spec)
+        }?.also {
+            endringKravhode.persongrunnlagListe.add(it)
+        }
+
+        return endringKravhode
+    }
+
+    // SimulerEndringAvAPCommand.opprettPersongrunnlagForEPS
+    fun opprettEpsGrunnlag(
+        spec: SimuleringSpec,
+        endringKravhode: Kravhode,
+        forrigeAlderspensjonBeregningResultat: AbstraktBeregningsResultat?,
+        grunnbeloep: Int
+    ): Kravhode {
+        if (spec.isTpOrigSimulering) {
+            addEpsToPersongrunnlag(endringKravhode, spec, grunnbeloep)
+            return endringKravhode
+        }
+
+        val eksisterendeKravhode: Kravhode? =
+            forrigeAlderspensjonBeregningResultat?.kravId?.let(kravService::fetchKravhode)
+
+        eksisterendeKravhode?.persongrunnlagListe?.let {
+            addEpsToPersongrunnlag(
+                endringPersongrunnlagListe = endringKravhode.persongrunnlagListe,
+                eksisterendePersongrunnlagListe = it,
+                spec,
+                beregningInfo = forrigeAlderspensjonBeregningResultat.hentBeregningsinformasjon(),
+                grunnbeloep
+            )
+        }
+
+        return endringKravhode
+    }
+
+    // SimulerEndringAvAPCommand.oppdaterOpptjeningsgrunnlagFraInntektListe
+    // -> AbstraktSimulerAPFra2011Command.oppdaterOpptjeningsgrunnlagFraInntektListe
+    // -> OpprettKravHodeHelper.oppdaterOpptjeningsgrunnlagFraInntektListe
+    private fun oppdaterOpptjeningsgrunnlagFraInntekt(
+        opprinneligOpptjeningsgrunnlagListe: List<Opptjeningsgrunnlag>,
+        inntektListe: List<Inntekt>,
+        foedselDato: LocalDate?
+    ): MutableList<Opptjeningsgrunnlag> {
+        val opptjeningType = OpptjeningTypeCti(OpptjeningtypeEnum.PPI.name)
+
+        var inntektsbasertOpptjeningsgrunnlagListe: MutableList<Opptjeningsgrunnlag> =
+            inntektListe
+                .filter { it.beloep > 0 }
+                .map { opptjeningsgrunnlag(it, opptjeningType) }
+                .toMutableList()
+
+        inntektsbasertOpptjeningsgrunnlagListe =
+            context.beregnPoengtallBatch(inntektsbasertOpptjeningsgrunnlagListe, foedselDato)
+        return komplettOpptjeningsgrunnlag(opprinneligOpptjeningsgrunnlagListe, inntektsbasertOpptjeningsgrunnlagListe)
+    }
+
+    // SimulerEndringAvAPCommand.doOpprettPersongrunnlagForEPS
+    private fun addEpsToPersongrunnlag(
+        endringPersongrunnlagListe: MutableList<Persongrunnlag>,
+        eksisterendePersongrunnlagListe: List<Persongrunnlag>,
+        spec: SimuleringSpec,
+        beregningInfo: BeregningsInformasjon?,
+        grunnbeloep: Int,
+    ) {
+        eksisterendePersongrunnlagListe.forEach {
+            addEpsToPersongrunnlag(
+                endringPersongrunnlagListe,
+                eksisterendePersongrunnlag = it,
+                spec,
+                beregningInfo,
+                foersteUttakDato = spec.foersteUttakDato,
+                grunnbeloep
+            )
+        }
+    }
+
+    // Extracted from SimulerEndringAvAPCommand.doOpprettPersongrunnlagForEPS
+    private fun addEpsToPersongrunnlag(
+        endringPersongrunnlagListe: MutableList<Persongrunnlag>,
+        eksisterendePersongrunnlag: Persongrunnlag,
+        spec: SimuleringSpec,
+        beregningInfo: BeregningsInformasjon?,
+        foersteUttakDato: LocalDate?,
+        grunnbeloep: Int
+    ) {
+        if (avdoedIsValid(eksisterendePersongrunnlag, foersteUttakDato)) {
+            endringPersongrunnlagListe.add(relevantPersongrunnlag(eksisterendePersongrunnlag))
+        } else if (epsIsValid(eksisterendePersongrunnlag, foersteUttakDato)) {
+            endringPersongrunnlagListe.add(
+                epsPersongrunnlag(
+                    eksisterendePersongrunnlag,
+                    spec,
+                    beregningInfo,
+                    foersteUttakDato,
+                    grunnbeloep
+                )
+            )
+        }
+    }
+
+    private fun epsPersongrunnlag(
+        eksisterendeEps: Persongrunnlag,
+        spec: SimuleringSpec,
+        beregningInfo: BeregningsInformasjon?,
+        foersteUttakDato: LocalDate?,
+        grunnbeloep: Int
+    ): Persongrunnlag =
+        relevantPersongrunnlag(eksisterendeEps).also {
+            if (spec.type == SimuleringType.ENDR_ALDER_M_GJEN) {
+                convertEpsToAvdoed(it, spec.avdoed!!) // assuming non-null avdoed
+            } else if (shouldAddInntektGrunnlagForEps(beregningInfo)) {
+                addInntektGrunnlagForEps(it, foersteUttakDato, grunnbeloep)
+            }
+        }
+
+    // AbstraktSimulerAPFra2011Command.opprettPersongrunnlagForEPS
+    // -> OpprettKravHodeHelper.opprettPersongrunnlagForEPS
+    private fun addEpsToPersongrunnlag(kravhode: Kravhode, spec: SimuleringSpec, grunnbeloep: Int) {
+        //kravhodeCreator.addAlderspensjonEpsGrunnlagToKrav(spec, kravhode, grunnbeloep)
+        epsService.addAlderspensjonEpsGrunnlagToKrav(spec, kravhode, grunnbeloep)
+    }
+
+    // SimulerEndringAvAPCommand.updateOpptjeningsgrunnlagOnPersongrunnlag
+    private fun opptjeningGrunnlagListe(
+        spec: SimuleringSpec,
+        kravhode: Kravhode,
+        person: PenPerson
+    ): MutableList<Opptjeningsgrunnlag> {
+        val pid = spec.pid
+        val foedselDato = person.fodselsdato.toLocalDate()
+
+        if (pid == null || foedselDato == null)
+            return mutableListOf()
+
+        val persongrunnlag: Persongrunnlag = persongrunnlagMapper.mapToPersongrunnlag(person, spec)
+
+        // NB: The original code in SimulerEndringAvAPCommand in PEN used
+        // "midlertidig persongrunnlag - skal kun benyttes til å hente opptjeningsgrunnlag fra POPP"
+        // This is not necessary when using the data-minimised variant of 'fetchBeholdningerMedGrunnlag'
+        // (which does not use 'kravhode')
+
+        return beholdningService.getBeholdningerMedGrunnlag(beholdningSpec(pid, persongrunnlag, kravhode))
+            .opptjeningGrunnlagListe.toMutableList()
+    }
+
+    // SimulerEndringAvAPCommandHelper.convertEpsToAvdod
+    private fun convertEpsToAvdoed(eps: Persongrunnlag, avdoed: Avdoed) {
+        eps.dodsdato = fromLocalDate(avdoed.doedDato)
+        eps.personDetaljListe = mutableListOf(personDetalj(avdoed))
+        eps.arligPGIMinst1G = avdoed.harInntektOver1G
+        eps.medlemIFolketrygdenSiste3Ar = avdoed.erMedlemAvFolketrygden
+
+        eps.opptjeningsgrunnlagListe = oppdaterOpptjeningsgrunnlagFraInntekt(
+            opprinneligOpptjeningsgrunnlagListe = eps.opptjeningsgrunnlagListe,
+            inntektListe = mutableListOf(inntekt(avdoed)),
+            foedselDato = eps.fodselsdato.toLocalDate()
+        )
+    }
+
+    private companion object {
+
+        private fun beholdningSpec(pid: Pid, persongrunnlag: Persongrunnlag, kravhode: Kravhode) =
+            BeholdningerMedGrunnlagSpec(
+                pid,
+                hentPensjonspoeng = true,
+                hentGrunnlagForOpptjeninger = true,
+                hentBeholdninger = false,
+                harUfoeretrygdKravlinje = kravhode.isUforetrygd(),
+                regelverkType = kravhode.regelverkTypeEnum,
+                sakType = kravhode.sakType?.let { SakTypeEnum.valueOf(it.name) },
+                personSpecListe = listOf(persongrunnlag.let(::personligBeholdningSpec)), //TODO redundant?
+                soekerSpec = persongrunnlag.let(::personligBeholdningSpec)
+            )
+
+        private fun personligBeholdningSpec(persongrunnlag: Persongrunnlag) =
+            BeholdningerMedGrunnlagPersonSpec(
+                pid = persongrunnlag.penPerson?.pid!!,
+                sisteGyldigeOpptjeningAar = persongrunnlag.sisteGyldigeOpptjeningsAr,
+                isGrunnlagRolleSoeker = persongrunnlag.findPersonDetaljIPersongrunnlag(
+                    grunnlagsrolle = GrunnlagsrolleEnum.SOKER,
+                    checkBruk = true
+                ) != null
+            )
+
+        // Extracted from SimulerEndringAvAPCommand.doOpprettPersongrunnlagForEPS
+        private fun avdoedIsValid(persongrunnlag: Persongrunnlag, foersteUttakDato: LocalDate?): Boolean =
+            foersteUttakDato?.let { isPersonDetaljValid(persongrunnlag, it, GrunnlagsrolleEnum.AVDOD) } == true
+
+        // Extracted from SimulerEndringAvAPCommand.doOpprettPersongrunnlagForEPS
+        private fun epsIsValid(persongrunnlag: Persongrunnlag, foersteUttakDato: LocalDate?): Boolean =
+            foersteUttakDato?.let {
+                isPersonDetaljValid(
+                    persongrunnlag,
+                    it,
+                    GrunnlagsrolleEnum.EKTEF,
+                    GrunnlagsrolleEnum.PARTNER,
+                    GrunnlagsrolleEnum.SAMBO
+                )
+            } == true
+
+        // SimulerEndringAvAPCommandHelper.shouldAddInntektgrunnlagForEPS
+        private fun shouldAddInntektGrunnlagForEps(info: BeregningsInformasjon?) =
+            info?.let { it.epsOver2G || it.epsMottarPensjon } == true
+
+        // SimulerEndringAvAPCommandHelper.addInntektgrunnlagForEPS
+        private fun addInntektGrunnlagForEps(eps: Persongrunnlag, foersteUttakDato: LocalDate?, grunnbeloep: Int) {
+            val inntektFom: LocalDate = findFomDatoInntekt(foersteUttakDato)
+            eps.inntektsgrunnlagListe.add(epsInntektsgrunnlag(grunnbeloep, inntektFom))
+        }
+
+        // SimulerEndringAvAPCommandHelper.findFomDatoInntekt
+        private fun findFomDatoInntekt(foersteUttakDato: LocalDate?): LocalDate {
+            //val dato = if (isBeforeToday(foersteUttakDato)) foersteUttakDato else LocalDate.now()
+            val now = LocalDate.now()
+            val dato = foersteUttakDato?.let { if (it.isBefore(now)) it else now } ?: now
+            return LocalDate.of(dato.year, 1, 1)
+        }
+
+        // SimulerEndringAvAPCommandHelper.createInntektsgrunnlagForEPS
+        // Assuming kopiertFraGammeltKrav and registerKilde are not used
+        private fun epsInntektsgrunnlag(grunnbeloep: Int, inntektFom: LocalDate) =
+            Inntektsgrunnlag().apply {
+                belop = grunnbeloep * 3
+                bruk = true
+                fom = fromLocalDate(inntektFom)
+                tom = null
+                grunnlagKilde = GrunnlagKildeCti(GrunnlagkildeEnum.BRUKER.name)
+                inntektType = InntektTypeCti(InntekttypeEnum.FPI.name) // Forventet pensjongivende inntekt
+            }
+
+        // Extracted from OpprettKravHodeHelper.oppdaterOpptjeningsgrunnlagFraInntektListe
+        private fun opptjeningsgrunnlag(inntekt: Inntekt, type: OpptjeningTypeCti) =
+            Opptjeningsgrunnlag().apply {
+                ar = inntekt.inntektAar
+                pi = inntekt.beloep.toInt()
+                opptjeningType = type
+            }
+
+        // Extracted from SimulerEndringAvAPCommandHelper.convertEpsToAvdod
+        private fun inntekt(avdoed: Avdoed) =
+            Inntekt(
+                inntektAar = LocalDate.now().year - 1,
+                beloep = avdoed.inntektFoerDoed.toLong()
+            )
+
+        // Extracted from SimulerEndringAvAPCommandHelper.convertEpsToAvdod
+        private fun personDetalj(avdoed: Avdoed) =
+            PersonDetalj().apply {
+                bruk = true
+                rolleFomDato = fromLocalDate(avdoed.doedDato)
+                grunnlagsrolleEnum = GrunnlagsrolleEnum.AVDOD
+                grunnlagKildeEnum = GrunnlagkildeEnum.BRUKER
+            }
+
+        // SimulerEndringAvAPCommandHelper.isPersonDetaljValid
+        private fun isPersonDetaljValid(
+            persongrunnlag: Persongrunnlag,
+            virkningDato: LocalDate,
+            vararg roller: GrunnlagsrolleEnum
+        ): Boolean {
+            roller.forEach {
+                val personDetalj = persongrunnlag.findPersonDetaljWithRolleForPeriode(
+                    rolle = it,
+                    fromLocalDate(virkningDato),
+                    checkBruk = true
+                )
+
+                if (isValidInFuture(personDetalj)) {
+                    return true
+                }
+            }
+
+            return false
+        }
+
+        // Extracted from OpprettKravHodeHelper.oppdaterOpptjeningsgrunnlagFraInntektListe
+        private fun komplettOpptjeningsgrunnlag(
+            opprinneligListe: List<Opptjeningsgrunnlag>,
+            inntektBasertListe: MutableList<Opptjeningsgrunnlag>
+        ): MutableList<Opptjeningsgrunnlag> {
+            val grunnlagKilde = GrunnlagKildeCti(GrunnlagkildeEnum.BRUKER.name)
+            val komplettListe: MutableList<Opptjeningsgrunnlag> = opprinneligListe.toMutableList()
+
+            inntektBasertListe.forEach {
+                it.bruk = true
+                it.grunnlagKilde = grunnlagKilde
+                komplettListe.add(it)
+            }
+
+            return komplettListe
+        }
+
+        // SimulerEndringAvAPCommandHelper.createPersongrunnlagWithValidPersonDetaljer + filterAndUpdateInntektsgrunnlaglistOnPersongrunnlag
+        private fun relevantPersongrunnlag(source: Persongrunnlag) =
+            Persongrunnlag(source).apply {
+                inntektsgrunnlagListe =
+                    inntektsgrunnlagListe.filter { it.bruk && it.inntektType?.kode != InntekttypeEnum.FPI.name }
+                        .toMutableList()
+                personDetaljListe = personDetaljListe.filter { it.bruk && it.rolleTomDato == null }.toMutableList()
+                // NB: In the original code (SimulerEndringAvAPCommandHelper.createPersongrunnlagWithValidPersonDetaljer)
+                // the PersonDetalj objects are copied twice: new Persongrunnlag(...) and then new PersonDetalj(...)
+                // which seems unnecessary
+            }
+
+        // SimulerEndringAvAPCommandHelper.updatePersongrunnlagForBruker
+        private fun adjustPersonDetaljer(soekerGrunnlag: Persongrunnlag, spec: SimuleringSpec) {
+            val medGjenlevenderett: Boolean = spec.type == SimuleringType.ENDR_ALDER_M_GJEN
+
+            if (medGjenlevenderett) {
+                val enke: PersonDetalj = enke(soekerGrunnlag) ?: enke(spec.avdoed?.doedDato)
+                soekerGrunnlag.personDetaljListe =
+                    mutableListOf(enke) // only a single persondetalj is used when gjenlevenderett
+            } else {
+                removeIrrelevantPersonDetaljer(soekerGrunnlag)
+            }
+        }
+
+        // Extracted from SimulerEndringAvAPCommandHelper.updatePersongrunnlagForBruker
+        private fun removeIrrelevantPersonDetaljer(soekerGrunnlag: Persongrunnlag) {
+            val iterator = soekerGrunnlag.personDetaljListe.iterator()
+
+            while (iterator.hasNext()) {
+                with(iterator.next()) {
+                    if (this.bruk.not() || isValidInPast(this)) {
+                        iterator.remove()
+                    }
+                }
+            }
+        }
+
+        // Extracted from SimulerEndringAvAPCommandHelper.updatePersongrunnlagForBruker
+        private fun enke(persongrunnlag: Persongrunnlag): PersonDetalj? {
+            persongrunnlag.personDetaljListe.forEach {
+                if (it.bruk && isEnke(it) && isValidToday(it)) {
+                    return it
+                }
+            }
+
+            return null
+        }
+
+        // Extracted from SimulerEndringAvAPCommandHelper.updatePersongrunnlagForBruker
+        private fun enke(fom: LocalDate?) =
+            PersonDetalj().apply {
+                grunnlagKildeEnum = GrunnlagkildeEnum.BRUKER
+                grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
+                sivilstandTypeEnum = SivilstandEnum.ENKE
+                rolleFomDato = fromLocalDate(fom)
+                bruk = true
+            }
+
+        // Extracted from SimulerEndringAvAPCommandHelper.updatePersongrunnlagForBruker
+        private fun isEnke(detalj: PersonDetalj) =
+            detalj.sivilstandTypeEnum == SivilstandEnum.ENKE
+
+        // Extracted from SimulerEndringAvAPCommandHelper.updatePersongrunnlagForBruker
+        private fun isValidInPast(detalj: PersonDetalj): Boolean =
+            detalj.rolleTomDato?.let { isBeforeByDay(it, LocalDate.now(), false) } == true
+
+        // Extracted from SimulerEndringAvAPCommandHelper.updatePersongrunnlagForBruker
+        private fun isValidToday(detalj: PersonDetalj) =
+            isDateInPeriod(
+                Date(),
+                detalj.virkFom,
+                detalj.virkTom
+            ) // NB: Here virkFom|Tom is used (not rolleFom|TomDato)
+        // The relationship between virk- and rolle-dato is described in https://confluence.adeo.no/pages/viewpage.action?pageId=282132550
+        // ("Løsningsbeskrivelse - P17 - Periodisering av persongrunnlag - utbedring av periodebegrep i Familieforhold (PK-52707)")
+        // and in https://jira.adeo.no/browse/PKDRAGE-3031
+
+        // Extracted from SimulerEndringAvAPCommandHelper.isPersonDetaljValid
+        private fun isValidInFuture(detalj: PersonDetalj?) =
+            detalj?.let { it.rolleTomDato == null } == true
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/person/eps/EpsService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/person/eps/EpsService.kt
@@ -1,0 +1,88 @@
+package no.nav.pensjon.simulator.core.person.eps
+
+import mu.KotlinLogging
+import no.nav.pensjon.simulator.core.beregn.InntektType
+import no.nav.pensjon.simulator.core.domain.GrunnlagKilde
+import no.nav.pensjon.simulator.core.domain.SimuleringType
+import no.nav.pensjon.simulator.core.domain.SivilstatusType
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Inntektsgrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.kode.GrunnlagKildeCti
+import no.nav.pensjon.simulator.core.domain.regler.kode.InntektTypeCti
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.legacy.util.DateUtil.fromLocalDate
+import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isBeforeDay
+import no.nav.pensjon.simulator.core.person.PersongrunnlagMapper
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.core.util.toLocalDate
+import no.nav.pensjon.simulator.person.PersonService
+import no.nav.pensjon.simulator.tech.time.DateUtil.foersteDag
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.util.*
+
+/**
+ * Functionality related to 'ektefelle/partner/samboer' (EPS).
+ */
+@Component
+class EpsService(
+    private val personService: PersonService,
+    private val persongrunnlagMapper: PersongrunnlagMapper
+) {
+    private val log = KotlinLogging.logger {}
+
+    // OpprettKravHodeHelper.opprettPersongrunnlagForEPS
+    fun addAlderspensjonEpsGrunnlagToKrav(spec: SimuleringSpec, kravhode: Kravhode, grunnbeloep: Int) {
+        if (EnumSet.of(SimuleringType.ALDER_M_GJEN, SimuleringType.ENDR_ALDER_M_GJEN).contains(spec.type)) {
+            //TODO createPersongrunnlagInCaseOfGjenlevenderett(simulering, kravhode)
+            with("Simulering for gjenlevende is not supported") {
+                log.error { this }
+                throw RuntimeException(this)
+            }
+        } else if (erEps(spec.sivilstatus)) {
+            kravhode.persongrunnlagListe.add(persongrunnlagBasedOnSivilstatus(spec, grunnbeloep))
+        }
+    }
+
+    // OpprettKravHodeHelper.createPersongrunnlagBasedOnSivilstatus
+    private fun persongrunnlagBasedOnSivilstatus(spec: SimuleringSpec, grunnbeloep: Int): Persongrunnlag {
+        val grunnlag = persongrunnlagMapper.mapToEpsPersongrunnlag(
+            sivilstatus = spec.sivilstatus,
+            foedselsdato = foedselDato(spec)
+        )
+
+        if (spec.epsHarInntektOver2G) {
+            val today = LocalDate.now()
+
+            val foersteUttakDato: LocalDate =
+                spec.foersteUttakDato?.let { if (isBeforeDay(it, today)) it else today } ?: today
+
+            grunnlag.inntektsgrunnlagListe.add(
+                epsInntektsgrunnlag(grunnbeloep, foersteUttakAar = foersteUttakDato.year)
+            )
+        }
+
+        return grunnlag
+    }
+
+    private fun foedselDato(spec: SimuleringSpec): LocalDate =
+        spec.pid?.let(personService::person)?.fodselsdato.toLocalDate() ?: foersteDag(spec.foedselAar)
+
+    private companion object {
+        private const val GRUNNBELOP_MULTIPLIER = 3 // larger than 2 (due to 2G income limit for EPS)
+
+        // OpprettKravHodeHelper.createInntektsgrunnlagForBrukerOrEps (special EPS variant)
+        private fun epsInntektsgrunnlag(grunnbeloep: Int, foersteUttakAar: Int) =
+            Inntektsgrunnlag().apply {
+                belop = GRUNNBELOP_MULTIPLIER * grunnbeloep
+                fom = fromLocalDate(foersteDag(foersteUttakAar))
+                tom = null
+                grunnlagKilde = GrunnlagKildeCti(GrunnlagKilde.BRUKER.name)
+                inntektType = InntektTypeCti(InntektType.FPI.name)
+                bruk = true
+            }
+
+        private fun erEps(sivilstatus: SivilstatusType) =
+            EnumSet.of(SivilstatusType.GIFT, SivilstatusType.REPA, SivilstatusType.SAMB).contains(sivilstatus)
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/person/PersonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/person/PersonService.kt
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Service
 @Service
 class PersonService(private val client: PersonClient) {
 
+    fun person(pid: Pid): PenPerson? =
+        personListe(listOf(pid))[pid]
+
     fun personListe(pidListe: List<Pid>): Map<Pid, PenPerson> =
         client.fetchPersonerVedPid(pidListe)
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/time/DateUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/time/DateUtil.kt
@@ -12,6 +12,12 @@ object DateUtil {
     fun toLocalDate(dateTime: ZonedDateTime): LocalDate =
         dateTime.withZoneSameInstant(ZoneId.of(TIME_ZONE_ID)).toLocalDate()
 
+    fun foersteDag(aar: Int) =
+        LocalDate.of(aar, 1, 1)
+
+    fun sisteDag(aar: Int) =
+        LocalDate.of(aar, 12, 31)
+
     fun foersteDagNesteMaaned(dato: LocalDate): LocalDate =
         dato
             .plusMonths(1)


### PR DESCRIPTION
Skrur på mer funksjonalitet i `KravhodeCreator` for simulering (henter beholding, kravhode, uføredata fra PEN).
La til `EndringPersongrunnlag` for simulering av 'endring av AP'.
Trakk ut EPS-funksjoner i en egen klasse: `EpsService`.