### PR TITLE
PEK-551 Complete support for 'personlig simulering'

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/Pre2025OffentligAfpUttakGrad.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/Pre2025OffentligAfpUttakGrad.kt
@@ -1,0 +1,81 @@
+package no.nav.pensjon.simulator.core.afp.offentlig.pre2025
+
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.legacy.util.DateUtil.fromLocalDate
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.krav.KravService
+import no.nav.pensjon.simulator.normalder.NormAlderService
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+/**
+ * Uttaksgrader relatert til 'pre-2025' avtalefestet pensjon (AFP) i offentlig sektor
+ * (dvs. 'gammel' offentlig AFP, som erstattes av ny ordning fra 2025).
+ */
+@Component
+class Pre2025OffentligAfpUttakGrad(
+    private val kravService: KravService,
+    private val normAlderService: NormAlderService
+) {
+    // SimulerAFPogAPCommand.finnUttaksgradListe
+    fun uttakGradListe(
+        spec: SimuleringSpec,
+        forrigeAlderspensjonBeregningResultat: AbstraktBeregningsResultat?,
+        foedselDato: LocalDate
+    ): MutableList<Uttaksgrad> {
+        val ubetingetUttakDato: LocalDate = ubetingetUttakDato(foedselDato)
+
+        if (forrigeAlderspensjonBeregningResultat == null) {
+            return mutableListOf(uttakGrad(fom = ubetingetUttakDato, grad = 100, tom = null))
+        }
+
+        val eksisterendeKravhode: Kravhode? =
+            forrigeAlderspensjonBeregningResultat.kravId?.let(kravService::fetchKravhode)
+
+        val uttakGradListe: MutableList<Uttaksgrad> = mutableListOf()
+        uttakGradListe.addAll(copy(eksisterendeKravhode?.uttaksgradListe.orEmpty()))
+        spec.foersteUttakDato?.let { replaceNullTom(uttakGradListe, it.minusDays(1)) }
+
+        val foersteTom: LocalDate = ubetingetUttakDato.minusDays(1)
+        uttakGradListe.add(uttakGrad(fom = spec.foersteUttakDato, grad = 0, tom = foersteTom))
+        uttakGradListe.add(uttakGrad(fom = ubetingetUttakDato, grad = 100, tom = null))
+        return uttakGradListe
+    }
+
+    private fun ubetingetUttakDato(foedselDato: LocalDate): LocalDate =
+        with(normAlderService.normAlder(foedselDato)) {
+            foedselDato
+                .plusYears(this.aar.toLong())
+                .plusMonths(this.maaneder.toLong() + 1)
+                .withDayOfMonth(1)
+        }
+
+    private companion object {
+        // SimulerAFPogAPCommandHelper.makeCopyOfUttaksgradList
+        private fun copy(liste: List<Uttaksgrad>): List<Uttaksgrad> {
+            val copy: MutableList<Uttaksgrad> = mutableListOf()
+            liste.forEach { copy.add(Uttaksgrad(it)) }
+            return copy
+        }
+
+        // SimulerAFPogAPCommandHelper.updateUttaksgradWithTomDateNull
+        private fun replaceNullTom(uttaksgrader: List<Uttaksgrad>, tom: LocalDate) {
+            uttaksgrader.forEach {
+                if (it.tomDato == null) {
+                    it.tomDato = fromLocalDate(tom)
+                    it.finishInit()
+                }
+            }
+        }
+
+        // SimulerAFPogAPCommandHelper.createUttaksgrad
+        private fun uttakGrad(fom: LocalDate?, grad: Int, tom: LocalDate?) =
+            Uttaksgrad().apply {
+                fomDato = fromLocalDate(fom)
+                uttaksgrad = grad
+                tomDato = fromLocalDate(tom)
+            }.also { it.finishInit() }
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgrad.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgrad.kt
@@ -15,38 +15,38 @@ import java.time.LocalDate
  * (dvs. 'gammel' offentlig AFP, som erstattes av ny ordning fra 2025).
  */
 @Component
-class Pre2025OffentligAfpUttakGrad(
+class Pre2025OffentligAfpUttaksgrad(
     private val kravService: KravService,
     private val normAlderService: NormAlderService
 ) {
     // SimulerAFPogAPCommand.finnUttaksgradListe
-    fun uttakGradListe(
+    fun uttaksgradListe(
         spec: SimuleringSpec,
         forrigeAlderspensjonBeregningResultat: AbstraktBeregningsResultat?,
-        foedselDato: LocalDate
+        foedselsdato: LocalDate
     ): MutableList<Uttaksgrad> {
-        val ubetingetUttakDato: LocalDate = ubetingetUttakDato(foedselDato)
+        val ubetingetUttakDato: LocalDate = ubetingetUttakDato(foedselsdato)
 
         if (forrigeAlderspensjonBeregningResultat == null) {
-            return mutableListOf(uttakGrad(fom = ubetingetUttakDato, grad = 100, tom = null))
+            return mutableListOf(uttaksgrad(fom = ubetingetUttakDato, grad = 100, tom = null))
         }
 
         val eksisterendeKravhode: Kravhode? =
             forrigeAlderspensjonBeregningResultat.kravId?.let(kravService::fetchKravhode)
 
-        val uttakGradListe: MutableList<Uttaksgrad> = mutableListOf()
-        uttakGradListe.addAll(copy(eksisterendeKravhode?.uttaksgradListe.orEmpty()))
-        spec.foersteUttakDato?.let { replaceNullTom(uttakGradListe, it.minusDays(1)) }
+        val uttaksgradListe: MutableList<Uttaksgrad> = mutableListOf()
+        uttaksgradListe.addAll(copy(eksisterendeKravhode?.uttaksgradListe.orEmpty()))
+        spec.foersteUttakDato?.let { replaceNullTom(uttaksgradListe, it.minusDays(1)) }
 
         val foersteTom: LocalDate = ubetingetUttakDato.minusDays(1)
-        uttakGradListe.add(uttakGrad(fom = spec.foersteUttakDato, grad = 0, tom = foersteTom))
-        uttakGradListe.add(uttakGrad(fom = ubetingetUttakDato, grad = 100, tom = null))
-        return uttakGradListe
+        uttaksgradListe.add(uttaksgrad(fom = spec.foersteUttakDato, grad = 0, tom = foersteTom))
+        uttaksgradListe.add(uttaksgrad(fom = ubetingetUttakDato, grad = 100, tom = null))
+        return uttaksgradListe
     }
 
-    private fun ubetingetUttakDato(foedselDato: LocalDate): LocalDate =
-        with(normAlderService.normAlder(foedselDato)) {
-            foedselDato
+    private fun ubetingetUttakDato(foedselsdato: LocalDate): LocalDate =
+        with(normAlderService.normAlder(foedselsdato)) {
+            foedselsdato
                 .plusYears(this.aar.toLong())
                 .plusMonths(this.maaneder.toLong() + 1)
                 .withDayOfMonth(1)
@@ -61,8 +61,8 @@ class Pre2025OffentligAfpUttakGrad(
         }
 
         // SimulerAFPogAPCommandHelper.updateUttaksgradWithTomDateNull
-        private fun replaceNullTom(uttaksgrader: List<Uttaksgrad>, tom: LocalDate) {
-            uttaksgrader.forEach {
+        private fun replaceNullTom(uttaksgradListe: List<Uttaksgrad>, tom: LocalDate) {
+            uttaksgradListe.forEach {
                 if (it.tomDato == null) {
                     it.tomDato = fromLocalDate(tom)
                     it.finishInit()
@@ -71,7 +71,7 @@ class Pre2025OffentligAfpUttakGrad(
         }
 
         // SimulerAFPogAPCommandHelper.createUttaksgrad
-        private fun uttakGrad(fom: LocalDate?, grad: Int, tom: LocalDate?) =
+        private fun uttaksgrad(fom: LocalDate?, grad: Int, tom: LocalDate?) =
             Uttaksgrad().apply {
                 fomDato = fromLocalDate(fom)
                 uttaksgrad = grad

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/endring/EndringPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/endring/EndringPersongrunnlag.kt
@@ -22,6 +22,7 @@ import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isBeforeByDay
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isDateInPeriod
 import no.nav.pensjon.simulator.core.person.PersongrunnlagMapper
 import no.nav.pensjon.simulator.core.person.eps.EpsService
+import no.nav.pensjon.simulator.core.person.eps.EpsService.Companion.EPS_GRUNNBELOEP_MULTIPLIER
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.util.toLocalDate
 import no.nav.pensjon.simulator.krav.KravService
@@ -282,7 +283,7 @@ class EndringPersongrunnlag(
         // Assuming kopiertFraGammeltKrav and registerKilde are not used
         private fun epsInntektsgrunnlag(grunnbeloep: Int, inntektFom: LocalDate) =
             Inntektsgrunnlag().apply {
-                belop = grunnbeloep * 3
+                belop = EPS_GRUNNBELOEP_MULTIPLIER * grunnbeloep
                 bruk = true
                 fom = fromLocalDate(inntektFom)
                 tom = null

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/endring/EndringUttakGrad.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/endring/EndringUttakGrad.kt
@@ -1,0 +1,98 @@
+package no.nav.pensjon.simulator.core.endring
+
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
+import no.nav.pensjon.simulator.core.legacy.util.DateUtil.fromLocalDate
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.krav.KravService
+import org.springframework.stereotype.Controller
+import java.time.LocalDate
+
+/**
+ * Uttaksgrader relatert til simulering av endring av alderspensjon.
+ */
+@Controller
+class EndringUttakGrad(private val kravService: KravService) {
+
+    // SimulerEndringAvAPCommand.finnUttaksgradListe
+    fun uttakGradListe(spec: SimuleringSpec, forrigeAlderspensjonKravhodeId: Long?): MutableList<Uttaksgrad> {
+        val eksisterendeUttakGradListe: List<Uttaksgrad> =
+            forrigeAlderspensjonKravhodeId?.let(kravService::fetchKravhode)?.uttaksgradListe.orEmpty()
+
+        return newUttakGradListe(eksisterendeUttakGradListe, spec)
+    }
+
+    private companion object {
+        private const val HELT_UTTAK_GRAD = 100
+
+        // SimulerEndringAvAPCommandHelper.createUttaksgradListe
+        private fun newUttakGradListe(
+            eksisterendeListe: List<Uttaksgrad>,
+            spec: SimuleringSpec
+        ): MutableList<Uttaksgrad> {
+            val uttakGrad: Int = spec.uttakGrad.value.toInt()
+            val gradert: Boolean = uttakGrad < HELT_UTTAK_GRAD
+            val foersteUttakFom: LocalDate = spec.foersteUttakDato!!
+            val andreUttakFom: LocalDate? = if (gradert) spec.heltUttakDato else null
+
+            return uttakGraderSomStarterFoerDato(eksisterendeListe, foersteUttakFom).apply {
+                add(foersteUttak(fom = foersteUttakFom, uttakGrad = uttakGrad, andreUttakFom = andreUttakFom))
+
+                if (gradert) {
+                    add(heltUttak(fom = andreUttakFom))
+                }
+            }
+        }
+
+        // Extracted from SimulerEndringAvAPCommandHelper.createUttaksgradListe
+        private fun uttakGraderSomStarterFoerDato(
+            uttakGradListe: List<Uttaksgrad>,
+            dato: LocalDate
+        ): MutableList<Uttaksgrad> {
+            val filtrertListe: MutableList<Uttaksgrad> = mutableListOf()
+
+            uttakGradListe.forEach {
+                inkluderHvisFomFoerDato(uttakGrad = it, dato = dato, targetList = filtrertListe)
+            }
+
+            return filtrertListe
+        }
+
+        // Extracted from SimulerEndringAvAPCommandHelper.createUttaksgradListe
+        private fun inkluderHvisFomFoerDato(uttakGrad: Uttaksgrad, dato: LocalDate?, targetList: MutableList<Uttaksgrad>) {
+            if (uttakGrad.fomDato?.before(fromLocalDate(dato)) == true) {
+                // NB: A difference from SimulerEndringAvAPCommandHelper is that here the copying of Uttaksgrad
+                // is done within the 'if' statement - this avoids unnecessary copying
+                Uttaksgrad(uttakGrad).also {
+                    begrensTomDato(it, dato) // <--- NB: side-effect
+                    targetList.add(it)
+                }
+            }
+        }
+
+        // Extracted from SimulerEndringAvAPCommandHelper.createUttaksgradListe
+        private fun begrensTomDato(grad: Uttaksgrad, maxTomDato: LocalDate?) {
+            if (grad.tomDato == null || grad.tomDato!!.after(fromLocalDate(maxTomDato))) { //TODO should this be maxTom minus 1 day?
+                grad.tomDato = maxTomDato?.let { fromLocalDate(it.minusDays(1)) }
+            }
+        }
+
+        // Extracted from SimulerEndringAvAPCommandHelper.createUttaksgradListe
+        private fun foersteUttak(
+            fom: LocalDate,
+            uttakGrad: Int,
+            andreUttakFom: LocalDate?
+        ) = Uttaksgrad(
+            fomDato = fromLocalDate(fom),
+            tomDato = fromLocalDate(andreUttakFom?.minusDays(1)),
+            uttaksgrad = uttakGrad
+        )
+
+        // Extracted from SimulerEndringAvAPCommandHelper.createUttaksgradListe
+        private fun heltUttak(fom: LocalDate?) =
+            Uttaksgrad(
+                fomDato = fromLocalDate(fom),
+                tomDato = null,
+                uttaksgrad = HELT_UTTAK_GRAD
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeCreator.kt
@@ -1,9 +1,8 @@
 package no.nav.pensjon.simulator.core.krav
 
-import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagPersonSpec
-import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagService
-import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagSpec
 import no.nav.pensjon.simulator.core.SimulatorContext
+import no.nav.pensjon.simulator.core.afp.offentlig.pre2025.Pre2025OffentligAfpPersongrunnlag
+import no.nav.pensjon.simulator.core.afp.offentlig.pre2025.Pre2025OffentligAfpUttakGrad
 import no.nav.pensjon.simulator.core.beholdning.BeholdningUpdater
 import no.nav.pensjon.simulator.core.beholdning.BeholdningUtil.SISTE_GYLDIGE_OPPTJENING_AAR
 import no.nav.pensjon.simulator.core.beregn.InntektType
@@ -23,6 +22,7 @@ import no.nav.pensjon.simulator.core.domain.regler.kode.OpptjeningTypeCti
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravlinje
 import no.nav.pensjon.simulator.core.endring.EndringPersongrunnlag
+import no.nav.pensjon.simulator.core.endring.EndringUttakGrad
 import no.nav.pensjon.simulator.core.exception.BrukerFoedtFoer1943Exception
 import no.nav.pensjon.simulator.core.krav.KravUtil.utlandMaanederInnenforAaret
 import no.nav.pensjon.simulator.core.krav.KravUtil.utlandMaanederInnenforRestenAvAaret
@@ -35,7 +35,7 @@ import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isBeforeByDay
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isFirstDayOfMonth
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.monthOfYearRange1To12
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.yearUserTurnsGivenAge
-import no.nav.pensjon.simulator.core.person.PersongrunnlagMapper
+import no.nav.pensjon.simulator.core.person.PersongrunnlagService
 import no.nav.pensjon.simulator.core.person.eps.EpsService
 import no.nav.pensjon.simulator.core.result.OpptjeningType
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
@@ -43,7 +43,6 @@ import no.nav.pensjon.simulator.core.util.PeriodeUtil.findValidForYear
 import no.nav.pensjon.simulator.core.util.toLocalDate
 import no.nav.pensjon.simulator.generelt.GenerelleDataHolder
 import no.nav.pensjon.simulator.krav.KravService
-import no.nav.pensjon.simulator.person.Pid
 import no.nav.pensjon.simulator.tech.time.DateUtil.MAANEDER_PER_AAR
 import no.nav.pensjon.simulator.tech.time.DateUtil.foersteDag
 import no.nav.pensjon.simulator.tech.time.DateUtil.sisteDag
@@ -63,73 +62,80 @@ import kotlin.streams.toList
 @Component
 class KravhodeCreator(
     private val context: SimulatorContext,
-    private val beholdningService: BeholdningerMedGrunnlagService,
     private val beholdningUpdater: BeholdningUpdater,
     private val epsService: EpsService,
-    private val persongrunnlagMapper: PersongrunnlagMapper,
+    private val persongrunnlagService: PersongrunnlagService,
     private val generelleDataHolder: GenerelleDataHolder,
     private val kravService: KravService,
     private val ufoereService: UfoeretrygdUtbetalingService,
     private val endringPersongrunnlag: EndringPersongrunnlag,
+    private val endringUttakGrad: EndringUttakGrad,
+    private val pre2025OffentligAfpPersongrunnlag: Pre2025OffentligAfpPersongrunnlag,
+    private val pre2025OffentligAfpUttakGrad: Pre2025OffentligAfpUttakGrad
 ) {
     // OpprettKravhodeHelper.opprettKravhode
     // Personer will be undefined in forenklet simulering (anonymous)
     fun opprettKravhode(
-        spec: KravhodeSpec,
+        kravhodeSpec: KravhodeSpec,
         person: PenPerson?,
-        virkningsdatoGrunnlagListe: List<ForsteVirkningsdatoGrunnlag>
+        virkningDatoGrunnlagListe: List<ForsteVirkningsdatoGrunnlag>
     ): Kravhode {
-        val simulatorInput = spec.simulatorInput
-        val forrigeAlderBeregningsresultat = spec.forrigeAlderspensjonBeregningResult
-        val grunnbeloep = spec.grunnbeloep
-        val gjelderEndring = simulatorInput.gjelderEndring()
-        val gjelderAfpOffentligPre2025 = simulatorInput.gjelderPre2025OffentligAfp()
+        val spec = kravhodeSpec.simulatorInput
+        val forrigeAlderspensjonBeregningResultat = kravhodeSpec.forrigeAlderspensjonBeregningResult
+        val grunnbeloep = kravhodeSpec.grunnbeloep
+        val gjelderEndring = spec.gjelderEndring()
+        val gjelderPre2025OffentligAfp = spec.gjelderPre2025OffentligAfp()
 
         val kravhode = Kravhode().apply {
             kravFremsattDato = Date()
-            onsketVirkningsdato = fromLocalDate(oensketVirkningDato(simulatorInput))
+            onsketVirkningsdato = fromLocalDate(oensketVirkningDato(spec))
             gjelder = null
             sakId = null
             sakType = SakType.ALDER
-            regelverkTypeEnum = finnRegelverkType(simulatorInput)
+            regelverkTypeEnum = regelverkType(spec.foedselAar)
         }
 
-        addSoekerGrunnlagToKrav(simulatorInput, kravhode, person, forrigeAlderBeregningsresultat, grunnbeloep)
-        addEpsGrunnlagToKrav(simulatorInput, kravhode, forrigeAlderBeregningsresultat, grunnbeloep)
+        addSoekerGrunnlagToKravhode(spec, kravhode, person, forrigeAlderspensjonBeregningResultat, grunnbeloep)
+        addEpsGrunnlagToKrav(spec, kravhode, forrigeAlderspensjonBeregningResultat, grunnbeloep)
 
-        if (kravTilsierBoddEllerArbeidetUtenlands(forrigeAlderBeregningsresultat)) {
+        if (kravTilsierBoddEllerArbeidetUtenlands(forrigeAlderspensjonBeregningResultat)) {
             kravhode.boddEllerArbeidetIUtlandet = true
         } else {
-            kravhode.boddEllerArbeidetIUtlandet = harUtenlandsopphold(simulatorInput.utlandAntallAar, emptyList())
+            kravhode.boddEllerArbeidetIUtlandet = harUtenlandsopphold(spec.utlandAntallAar, emptyList())
         }
 
         // NB: Next line requires avdød persongrunnlag to be fetched above
-        val avdodGrunnlag = kravhode.hentPersongrunnlagForRolle(grunnlagsrolle = GrunnlagsrolleEnum.AVDOD, checkBruk = false)
+        val avdoedGrunnlag: Persongrunnlag? =
+            kravhode.hentPersongrunnlagForRolle(grunnlagsrolle = GrunnlagsrolleEnum.AVDOD, checkBruk = false)
 
         kravhode.boddArbeidUtlandAvdod =
-            avdodGrunnlag?.let { harUtenlandsopphold(simulatorInput.avdoed?.antallAarUtenlands, it.trygdetidPerioder) }
-                ?: false
-        addForsteVirkningsdatoGrunnlagToKrav(kravhode, virkningsdatoGrunnlagListe)
-        kravhode.uttaksgradListe = alderspensjonUttaksgrader(simulatorInput)
+            avdoedGrunnlag?.let {
+                harUtenlandsopphold(
+                    antallAarUtenlands = spec.avdoed?.antallAarUtenlands,
+                    trygdetidPeriodeListe = it.trygdetidPerioder
+                )
+            } == true
+
+        addFoersteVirkningDatoGrunnlagToKravhode(kravhode, virkningDatoGrunnlagListe)
 
         kravhode.uttaksgradListe =
             when {
-                gjelderAfpOffentligPre2025 -> afpOffentligPre2025Uttaksgrader(
-                    simulatorInput,
-                    forrigeAlderBeregningsresultat
+                gjelderPre2025OffentligAfp -> pre2025OffentligAfpUttakGradListe(
+                    spec,
+                    forrigeAlderspensjonBeregningResultat
                 )
 
-                gjelderEndring -> endringUttaksgrader(simulatorInput, forrigeAlderBeregningsresultat)
-                else -> alderspensjonUttaksgrader(simulatorInput)
+                gjelderEndring -> endringUttakGradListe(spec, forrigeAlderspensjonBeregningResultat)
+                else -> alderspensjonUttakGradListe(spec)
             }
 
-        addKravlinjerToKrav(kravhode)
+        addKravlinjerToKravhode(kravhode)
         settGenerelleFelter(kravhode)
-        updateOnsketVirkAndUtbetalingsgrad(simulatorInput, kravhode)
+        updateOensketVirkningAndUtbetalingGrad(spec, kravhode)
         return kravhode
     }
 
-    private fun updateOnsketVirkAndUtbetalingsgrad(spec: SimuleringSpec, kravhode: Kravhode) {
+    private fun updateOensketVirkningAndUtbetalingGrad(spec: SimuleringSpec, kravhode: Kravhode) {
         if (spec.erAnonym) return
 
         val persongrunnlag = kravhode.hentPersongrunnlagForSoker()
@@ -161,20 +167,34 @@ class KravhodeCreator(
         kravhode.persongrunnlagListe.forEach { it.sisteGyldigeOpptjeningsAr = sisteGyldigeOpptjeningAar }
     }
 
-    private fun addKravlinjerToKrav(kravhode: Kravhode) {
+    private fun addKravlinjerToKravhode(kravhode: Kravhode) {
         kravhode.kravlinjeListe =
-            mutableListOf(norskKravlinje(KravlinjeTypeEnum.AP, kravhode.hentPersongrunnlagForSoker().penPerson!!))
-        val avdodGrunnlag = kravhode.hentPersongrunnlagForRolle(GrunnlagsrolleEnum.AVDOD, false)
+            mutableListOf(
+                norskKravlinje(
+                    kravlinjeType = KravlinjeTypeEnum.AP,
+                    person = kravhode.hentPersongrunnlagForSoker().penPerson!!
+                )
+            )
 
-        if (avdodGrunnlag != null) {
-            kravhode.kravlinjeListe.add(norskKravlinje(KravlinjeTypeEnum.GJR, avdodGrunnlag.penPerson!!))
+        val avdoedGrunnlag: Persongrunnlag? = kravhode.hentPersongrunnlagForRolle(
+            grunnlagsrolle = GrunnlagsrolleEnum.AVDOD,
+            checkBruk = false
+        )
+
+        avdoedGrunnlag?.penPerson?.let {
+            kravhode.kravlinjeListe.add(
+                norskKravlinje(
+                    kravlinjeType = KravlinjeTypeEnum.GJR,
+                    person = it
+                )
+            )
         }
     }
 
     // OpprettKravHodeHelper.leggTilForstevirkningsdatoGrunnlag
-    private fun addForsteVirkningsdatoGrunnlagToKrav(
+    private fun addFoersteVirkningDatoGrunnlagToKravhode(
         kravhode: Kravhode,
-        virkningsdatoGrunnlagListe: List<ForsteVirkningsdatoGrunnlag>
+        virkningDatoGrunnlagListe: List<ForsteVirkningsdatoGrunnlag>
     ) {
         //TODO inspect this code:
         kravhode.persongrunnlagListe.forEach {
@@ -183,21 +203,21 @@ class KravhodeCreator(
         }
 
         kravhode.persongrunnlagListe.forEach {
-            addForsteVirkningsdatoGrunnlagToPersongrunnlag(
-                it,
-                virkningsdatoGrunnlagListe
+            addFoersteVirkningDatoGrunnlagToPersongrunnlag(
+                persongrunnlag = it,
+                virkningDatoGrunnlagListe
             )
         }
     }
 
     // OpprettKravHodeHelper.leggTilForstevirkningsdatoGrunnlag
-    private fun addForsteVirkningsdatoGrunnlagToPersongrunnlag(
+    private fun addFoersteVirkningDatoGrunnlagToPersongrunnlag(
         persongrunnlag: Persongrunnlag,
-        virkningsdatoGrunnlagListe: List<ForsteVirkningsdatoGrunnlag>
+        virkningDatoGrunnlagListe: List<ForsteVirkningsdatoGrunnlag>
     ) {
         if ((persongrunnlag.penPerson?.penPersonId ?: 0) <= 0) return
 
-        virkningsdatoGrunnlagListe.forEach(persongrunnlag.forsteVirkningsdatoGrunnlagListe::add)
+        virkningDatoGrunnlagListe.forEach(persongrunnlag.forsteVirkningsdatoGrunnlagListe::add)
     }
 
     // OpprettKravHodeHelper.isBoddArbeidUtlandTrueOnKravHode + findKravHode
@@ -219,7 +239,7 @@ class KravhodeCreator(
         forrigeResultat: AbstraktBeregningsResultat?,
         grunnbeloep: Int
     ) {
-        //ANON AfpPersongrunnlag(context).opprettPersongrunnlagForEps(spec, kravhode, forrigeResultat, grunnbeloep)
+        pre2025OffentligAfpPersongrunnlag.opprettEpsGrunnlag(spec, kravhode, forrigeResultat, grunnbeloep)
         // TODO Optimize this call chain when forrigeAlderBeregningsresultat = null:
         //    KravhodeCreator.addPre2025OffentligAfpEpsGrunnlagToKrav (this method)
         // -> AfpPersongrunnlag.opprettPersongrunnlagForEps(4)
@@ -272,70 +292,26 @@ class KravhodeCreator(
     }
     */
 
-    private fun finnRegelverkType(spec: SimuleringSpec): RegelverkTypeEnum {
-        /*ANON? val pid = spec.fnr
-
-     val foedselAar: Int = if (pid != null) {
-         Pid.get4DigitYearOfBirth(pid.toString())
-     } else {
-         spec.fodselsar
-     }*/
-        val foedselAar = spec.foedselAar
-
-        if (foedselAar < 1943) {
-            throw BrukerFoedtFoer1943Exception("FPEN028 - Kan ikke sett regelverktype - Fødselsår < 1943")
-        }
-
-        if (foedselAar <= 1953) {
-            return RegelverkTypeEnum.N_REG_G_OPPTJ
-        }
-
-        if (foedselAar <= 1962) {
-            return RegelverkTypeEnum.N_REG_G_N_OPPTJ
-        }
-
-        return RegelverkTypeEnum.N_REG_N_OPPTJ
-    }
-
     // SimulerFleksibelAPCommand.opprettPersongrunnlagForBruker
     private fun opprettSokergrunnlag(
         spec: SimuleringSpec,
         kravhode: Kravhode,
-        person: PenPerson?
+        person: PenPerson? // null if anonym
     ): Kravhode {
         if (spec.erAnonym) {
             kravhode.persongrunnlagListe.add(anonymSoekerGrunnlag(spec))
             return kravhode
         }
 
-        val response: Kravhode = addSokerPersongrunnlagToKravForNormalSimulering(spec, kravhode, person!!)
+        val response: Kravhode = persongrunnlagService.addSoekerGrunnlagToKravhode(spec, kravhode, person!!)
         beholdningUpdater.updateBeholdningFromEksisterendePersongrunnlag(kravhode)
         return response
-    }
-
-    // OpprettKravHodeHelper.opprettPersongrunnlagForBruker
-    fun addSokerPersongrunnlagToKravForNormalSimulering(
-        spec: SimuleringSpec,
-        kravhode: Kravhode,
-        person: PenPerson
-    ): Kravhode {
-        val persongrunnlag = persongrunnlagMapper.mapToPersongrunnlag(person, spec)
-        kravhode.persongrunnlagListe.add(persongrunnlag)
-
-        addBeholdningerOgGrunnlagToPersongrunnlag(
-            persongrunnlag,
-            kravhode,
-            pid = person.pid!!,
-            hentBeholdninger = false
-        )
-
-        return kravhode
     }
 
     // SimulerFleksibelAPCommand.opprettPersongrunnlagForBrukerForenkletSimulering
     private fun anonymSoekerGrunnlag(spec: SimuleringSpec) =
         Persongrunnlag().apply {
-            penPerson = PenPerson().apply { penPersonId = FORENKLET_SIMULERING_PERSON_ID }
+            penPerson = PenPerson().apply { penPersonId = ANONYM_PERSON_ID }
             fodselsdato = legacyFoersteDag(spec.foedselAar)
             antallArUtland = spec.utlandAntallAar
             statsborgerskapEnum = norge
@@ -364,52 +340,9 @@ class KravhodeCreator(
             else -> SivilstandEnum.UGIF
         }
 
-    // OpprettKravHodeHelper.oppdaterGrunnlagMedBeholdninger
-    private fun addBeholdningerOgGrunnlagToPersongrunnlag(
-        persongrunnlag: Persongrunnlag,
-        kravhode: Kravhode,
-        pid: Pid,
-        hentBeholdninger: Boolean
-    ) {
-        with(beholdningService.getBeholdningerMedGrunnlag(beholdningSpec(pid, kravhode))) {
-            persongrunnlag.opptjeningsgrunnlagListe = opptjeningGrunnlagListe.toMutableList()
-            persongrunnlag.omsorgsgrunnlagListe = omsorgGrunnlagListe.toMutableList()
-            persongrunnlag.inntektsgrunnlagListe = inntektGrunnlagListe.toMutableList()
-            persongrunnlag.dagpengegrunnlagListe = dagpengerGrunnlagListe.toMutableList()
-            persongrunnlag.forstegangstjenestegrunnlag = foerstegangstjeneste
-
-            if (hentBeholdninger) {
-                beholdningListe.filterIsInstance<Pensjonsbeholdning>().forEach(persongrunnlag.beholdninger::add)
-            }
-        }
-    }
-
-    private fun beholdningSpec(pid: Pid, kravhode: Kravhode) =
-        BeholdningerMedGrunnlagSpec(
-            pid,
-            hentPensjonspoeng = true,
-            hentGrunnlagForOpptjeninger = true,
-            hentBeholdninger = false,
-            harUfoeretrygdKravlinje = kravhode.isUforetrygd(),
-            regelverkType = kravhode.regelverkTypeEnum,
-            sakType = kravhode.sakType?.let { SakTypeEnum.valueOf(it.name) },
-            personSpecListe = kravhode.persongrunnlagListe.map(::personligBeholdningSpec),
-            soekerSpec = kravhode.hentPersongrunnlagForSoker().let(::personligBeholdningSpec)
-        )
-
-    private fun personligBeholdningSpec(persongrunnlag: Persongrunnlag) =
-        BeholdningerMedGrunnlagPersonSpec(
-            pid = persongrunnlag.penPerson?.pid!!,
-            sisteGyldigeOpptjeningAar = persongrunnlag.sisteGyldigeOpptjeningsAr,
-            isGrunnlagRolleSoeker = persongrunnlag.findPersonDetaljIPersongrunnlag(
-                GrunnlagsrolleEnum.SOKER,
-                true
-            ) != null
-        )
-
     // OpprettKravHodeHelper.opprettPersongrunnlag
-    private fun addSoekerGrunnlagToKrav(
-        simulatorInput: SimuleringSpec,
+    private fun addSoekerGrunnlagToKravhode(
+        spec: SimuleringSpec,
         kravhode: Kravhode,
         person: PenPerson?,
         forrigeAlderspensjonBeregningResultat: AbstraktBeregningsResultat?,
@@ -417,61 +350,60 @@ class KravhodeCreator(
     ) {
         val updatedKravhode: Kravhode =
             when {
-                /*ANON
-                simulatorInput.gjelderAfpOffentligPre2025() -> person?.let {
-                    AfpPersongrunnlag(context).opprettSokerGrunnlag(
+                spec.gjelderPre2025OffentligAfp() -> person?.let {
+                    pre2025OffentligAfpPersongrunnlag.opprettSoekerGrunnlag(
                         it,
-                        simulatorInput,
-                        kravhode,
-                        forrigeAlderspensjonBeregningsresultat
-                    )
-                } ?: kravhode
-*/
-                simulatorInput.gjelderEndring() -> person?.let {
-                    endringPersongrunnlag.opprettSoekerGrunnlag(
-                        it,
-                        simulatorInput,
+                        spec,
                         kravhode,
                         forrigeAlderspensjonBeregningResultat
                     )
                 } ?: kravhode
 
-                else -> opprettSokergrunnlag(simulatorInput, kravhode, person)
+                spec.gjelderEndring() -> person?.let {
+                    endringPersongrunnlag.opprettSoekerGrunnlag(
+                        it,
+                        spec,
+                        kravhode,
+                        forrigeAlderspensjonBeregningResultat
+                    )
+                } ?: kravhode
+
+                else -> opprettSokergrunnlag(spec, kravhode, person)
             }
 
         val persongrunnlag = updatedKravhode.hentPersongrunnlagForSoker()
-        val brukFremtidigInntekt = simulatorInput.fremtidigInntektListe.isNotEmpty()
-        val inntekter: MutableList<Inntekt>
+        val brukFremtidigInntekt = spec.fremtidigInntektListe.isNotEmpty()
+        val inntektListe: MutableList<Inntekt>
 
         if (brukFremtidigInntekt) {
-            val gjeldendeAr = SISTE_GYLDIGE_OPPTJENING_AAR + 1
-            val sisteOpptjeningsAr = MAX_OPPTJENING_ALDER + simulatorInput.foedselAar
-            val fom = foersteDag(gjeldendeAr)
+            val gjeldendeAar = SISTE_GYLDIGE_OPPTJENING_AAR + 1
+            val sisteOpptjeningAar = MAX_OPPTJENING_ALDER + spec.foedselAar
+            val fom = foersteDag(gjeldendeAar)
 
             val inntektsgrunnlagList =
-                ArrayList(fjernForventetArbeidsinntektFraInntektsgrunnlag(persongrunnlag.inntektsgrunnlagListe))
+                ArrayList(fjernForventetArbeidsinntektFraInntektGrunnlag(persongrunnlag.inntektsgrunnlagListe))
                     .also {
                         it.addAll(
                             inntektsgrunnlagListeFraFremtidigeInntekter(
-                                simulatorInput,
-                                gjeldendeAr,
-                                sisteOpptjeningsAr,
+                                spec,
+                                gjeldendeAar,
+                                sisteOpptjeningAar,
                                 fom
                             )
                         )
                     }
 
             persongrunnlag.inntektsgrunnlagListe = inntektsgrunnlagList
-            inntekter = inntekter(inntektsgrunnlagList)
+            inntektListe = inntektListe(inntektsgrunnlagList)
         } else {
-            inntekter = aarligeInntekterFraDagensDato(simulatorInput, grunnbeloep, person?.fodselsdato)
+            inntektListe = aarligeInntekterFraDagensDato(spec, grunnbeloep, person?.fodselsdato)
             persongrunnlag.inntektsgrunnlagListe =
-                opprettInntektsgrunnlagForSoeker(simulatorInput, persongrunnlag.inntektsgrunnlagListe)
+                opprettInntektGrunnlagForSoeker(spec, persongrunnlag.inntektsgrunnlagListe)
         }
 
         persongrunnlag.opptjeningsgrunnlagListe =
             oppdaterOpptjeningsgrunnlagFraInntekter(
-                inntekter,
+                inntektListe,
                 persongrunnlag.opptjeningsgrunnlagListe,
                 persongrunnlag.fodselsdato.toLocalDate()
             )
@@ -480,21 +412,21 @@ class KravhodeCreator(
     private fun addEpsGrunnlagToKrav(
         spec: SimuleringSpec,
         kravhode: Kravhode,
-        forrigeAlderspensjonBeregningResult: AbstraktBeregningsResultat?,
+        forrigeAlderspensjonBeregningResultat: AbstraktBeregningsResultat?,
         grunnbeloep: Int
     ) {
         when {
             spec.gjelderPre2025OffentligAfp() -> addPre2025OffentligAfpEpsGrunnlagToKrav(
                 spec,
                 kravhode,
-                forrigeAlderspensjonBeregningResult,
+                forrigeAlderspensjonBeregningResultat,
                 grunnbeloep
             )
 
             spec.gjelderEndring() -> addEndringEpsGrunnlagToKrav(
                 spec,
                 kravhode,
-                forrigeAlderspensjonBeregningResult,
+                forrigeAlderspensjonBeregningResultat,
                 grunnbeloep
             )
 
@@ -511,7 +443,7 @@ class KravhodeCreator(
 
         for (inntekt in inntektListe) {
             if (inntekt.beloep > 0L) {
-                grunnlagListe.add(opptjeningsgrunnlag(inntekt))
+                grunnlagListe.add(opptjeningGrunnlag(inntekt))
             }
         }
 
@@ -640,39 +572,47 @@ class KravhodeCreator(
         }
     }
 
-    private fun afpOffentligPre2025Uttaksgrader(
-        simulatorInput: SimuleringSpec,
+    private fun pre2025OffentligAfpUttakGradListe(
+        spec: SimuleringSpec,
         forrigeResultat: AbstraktBeregningsResultat?
     ): MutableList<Uttaksgrad> =
-        mutableListOf() //ANON AfpUttaksgrad(context).uttaksgrader(simulatorInput, forrigeResultat, fodselsdato(simulatorInput))
+        pre2025OffentligAfpUttakGrad.uttakGradListe(spec, forrigeResultat, foedselDato(spec))
 
-    private fun endringUttaksgrader(
-        simulatorInput: SimuleringSpec,
+    private fun endringUttakGradListe(
+        spec: SimuleringSpec,
         forrigeResultat: AbstraktBeregningsResultat?
     ): MutableList<Uttaksgrad> =
-        mutableListOf() //ANON EndringUttaksgrad(context).uttaksgrader(simulatorInput, forrigeResultat?.kravId)
+        endringUttakGrad.uttakGradListe(spec, forrigeResultat?.kravId)
 
     private companion object {
         private const val MAX_ALDER = 80
         private const val MAX_OPPTJENING_ALDER = 75
         private const val MAX_UTTAKSGRAD = 100
-        private const val FORENKLET_SIMULERING_PERSON_ID = -1L
+        private const val ANONYM_PERSON_ID = -1L
         private val norge = LandkodeEnum.NOR
+
+        private fun regelverkType(foedselAar: Int): RegelverkTypeEnum =
+            when {
+                foedselAar < 1943 -> throw BrukerFoedtFoer1943Exception("Kan ikke sette regelverktype - fødselsår < 1943")
+                foedselAar <= 1953 -> RegelverkTypeEnum.N_REG_G_OPPTJ
+                foedselAar <= 1962 -> RegelverkTypeEnum.N_REG_G_N_OPPTJ
+                else -> RegelverkTypeEnum.N_REG_N_OPPTJ
+            }
 
         // OpprettKravHodeHelper.finnUttaksgradListe
         // -> SimulerFleksibelAPCommand.finnUttaksgradListe
-        private fun alderspensjonUttaksgrader(spec: SimuleringSpec): MutableList<Uttaksgrad> {
-            val uttaksgrader = mutableListOf(angittUttaksgrad(spec))
+        private fun alderspensjonUttakGradListe(spec: SimuleringSpec): MutableList<Uttaksgrad> {
+            val uttakGradListe = mutableListOf(angittUttakGrad(spec))
 
             if (erGradertUttak(spec)) {
-                uttaksgrader.add(helUttaksgrad(spec.heltUttakDato))
+                uttakGradListe.add(heltUttakGrad(spec.heltUttakDato))
             }
 
-            return uttaksgrader
+            return uttakGradListe
         }
 
         // SimulerFleksibelAPCommand.createUttaksgradChosenByUser
-        private fun angittUttaksgrad(spec: SimuleringSpec) =
+        private fun angittUttakGrad(spec: SimuleringSpec) =
             Uttaksgrad().apply {
                 fomDato = fromLocalDate(spec.foersteUttakDato)
                 uttaksgrad = spec.uttakGrad.value.toInt()
@@ -699,8 +639,8 @@ class KravhodeCreator(
                 inntekt = nextInntekt
             }
 
-            val sistePeriodeAntallManeder = MAANEDER_PER_AAR - inntekt.fom.monthValue
-            return aarligInntekt.add(periodevisInntekt(inntekt, sistePeriodeAntallManeder))
+            val sistePeriodeAntallMaaneder = MAANEDER_PER_AAR - inntekt.fom.monthValue
+            return aarligInntekt.add(periodevisInntekt(inntekt, sistePeriodeAntallMaaneder))
         }
 
         private fun addFremtidigInntektAtStartOfEachYear(
@@ -714,16 +654,14 @@ class KravhodeCreator(
             while (inntektIterator.hasNext()) {
                 currentInntekt = inntektIterator.next()
 
-                if (sammeAr(currentInntekt, gjeldendeInntekt) || starterAretEtter(
-                        currentInntekt,
-                        gjeldendeInntekt
-                    ) && starterJanuar(currentInntekt)
+                if (sammeAar(currentInntekt, gjeldendeInntekt)
+                    || starterAaretEtter(currentInntekt, gjeldendeInntekt) && starterJanuar(currentInntekt)
                 ) {
                     gjeldendeInntekt = currentInntekt
-                } else if (starterAretEtter(currentInntekt, gjeldendeInntekt) && !starterJanuar(currentInntekt)
-                    || currentInntekt.fom.year > aretEtter(gjeldendeInntekt)
+                } else if (starterAaretEtter(currentInntekt, gjeldendeInntekt) && !starterJanuar(currentInntekt)
+                    || currentInntekt.fom.year > aaretEtter(gjeldendeInntekt)
                 ) {
-                    val firstOfYear = foersteDag(aretEtter(gjeldendeInntekt))
+                    val firstOfYear = foersteDag(aaretEtter(gjeldendeInntekt))
                     val nyInntekt = FremtidigInntekt(gjeldendeInntekt.aarligInntektBeloep, firstOfYear)
                     inntektIterator.previous()
                     inntektIterator.add(nyInntekt)
@@ -731,11 +669,11 @@ class KravhodeCreator(
                 }
             }
 
-            val lastYearWithFremtidigInntekt = gjeldendeInntekt.fom.year
+            val sisteFremtidigInntektAar = gjeldendeInntekt.fom.year
 
-            if (lastYearWithFremtidigInntekt < sisteOpptjeningAar) {
-                addFremtidigInntektForHvertArInntilSisteOpptjeningsar(
-                    lastYearWithFremtidigInntekt,
+            if (sisteFremtidigInntektAar < sisteOpptjeningAar) {
+                addFremtidigInntektForHvertAarInntilSisteOpptjeningAar(
+                    sisteFremtidigInntektAar,
                     sisteOpptjeningAar,
                     inntektIterator,
                     gjeldendeInntekt
@@ -743,16 +681,17 @@ class KravhodeCreator(
             }
         }
 
-        private fun addFremtidigInntektForHvertArInntilSisteOpptjeningsar(
-            sisteAarMedFremtidigInntekt: Int,
-            sisteOpptjeningAar: Int, fremtidigInntektIterator: MutableListIterator<FremtidigInntekt>,
+        private fun addFremtidigInntektForHvertAarInntilSisteOpptjeningAar(
+            sisteFremtidigInntektAar: Int,
+            sisteOpptjeningAar: Int,
+            fremtidigInntektIterator: MutableListIterator<FremtidigInntekt>,
             gjeldendeFremtidigInntekt: FremtidigInntekt
         ) {
-            for (ar in sisteAarMedFremtidigInntekt + 1..sisteOpptjeningAar) {
+            for (aar in sisteFremtidigInntektAar + 1..sisteOpptjeningAar) {
                 fremtidigInntektIterator.add(
                     FremtidigInntekt(
                         aarligInntektBeloep = gjeldendeFremtidigInntekt.aarligInntektBeloep,
-                        fom = foersteDag(ar)
+                        fom = foersteDag(aar)
                     )
                 )
             }
@@ -773,51 +712,56 @@ class KravhodeCreator(
                 }
         }
 
-        private fun fjernForventetArbeidsinntektFraInntektsgrunnlag(grunnlagListe: List<Inntektsgrunnlag>) =
+        private fun fjernForventetArbeidsinntektFraInntektGrunnlag(grunnlagListe: List<Inntektsgrunnlag>) =
             grunnlagListe.filter { it.bruk && it.inntektType!!.kode != InntektType.FPI.name }
 
-        private fun opprettInntektsgrunnlagForSoeker(
+        private fun opprettInntektGrunnlagForSoeker(
             spec: SimuleringSpec,
             existingInntektsgrunnlagList: MutableList<Inntektsgrunnlag>
         ): MutableList<Inntektsgrunnlag> {
-            val inntektsgrunnlagListe: MutableList<Inntektsgrunnlag> = mutableListOf()
+            val inntektGrunnlagListe: MutableList<Inntektsgrunnlag> = mutableListOf()
 
             // Inntekt frem til første uttak
             if (isAfterToday(spec.foersteUttakDato) && spec.forventetInntektBeloep > 0) {
-                val beloep = spec.forventetInntektBeloep
-                val fom = LocalDate.now()
-                val tom = getRelativeDateByDays(spec.foersteUttakDato, -1)
-                inntektsgrunnlagListe.add(inntektsgrunnlagForSoekerOrEps(beloep, fom, tom))
+                inntektGrunnlagListe.add(
+                    inntektsgrunnlagForSoekerOrEps(
+                        beloep = spec.forventetInntektBeloep,
+                        fom = LocalDate.now(),
+                        tom = getRelativeDateByDays(spec.foersteUttakDato, -1)
+                    )
+                )
             }
 
             val isHeltUttak = spec.uttakGrad == UttakGradKode.P_100
             val inntektUnderGradertUttak: Int = spec.inntektUnderGradertUttakBeloep
 
             if (!isHeltUttak && inntektUnderGradertUttak > 0) {
-                val beloep = inntektUnderGradertUttak
-                val fom = spec.foersteUttakDato
-                val tom = getRelativeDateByDays(spec.heltUttakDato, -1)
-                inntektsgrunnlagListe.add(inntektsgrunnlagForSoekerOrEps(beloep, fom, tom))
+                inntektGrunnlagListe.add(
+                    inntektsgrunnlagForSoekerOrEps(
+                        beloep = inntektUnderGradertUttak,
+                        fom = spec.foersteUttakDato,
+                        tom = getRelativeDateByDays(spec.heltUttakDato, -1)
+                    )
+                )
             }
 
             val antallArInntektEtterHeltUttak: Int = spec.inntektEtterHeltUttakAntallAar ?: 0
 
             if (spec.inntektEtterHeltUttakBeloep > 0 && antallArInntektEtterHeltUttak > 0) {
-                val beloep = spec.inntektEtterHeltUttakBeloep
                 val fom = if (isHeltUttak) spec.foersteUttakDato else spec.heltUttakDato
                 val tom = getRelativeDateByDays(getRelativeDateByYear(fom, antallArInntektEtterHeltUttak), -1)
-                inntektsgrunnlagListe.add(inntektsgrunnlagForSoekerOrEps(beloep, fom!!, tom))
+                inntektGrunnlagListe.add(inntektsgrunnlagForSoekerOrEps(spec.inntektEtterHeltUttakBeloep, fom!!, tom))
             }
 
-            inntektsgrunnlagListe.addAll(existingInntektsgrunnlagList.filter {
+            inntektGrunnlagListe.addAll(existingInntektsgrunnlagList.filter {
                 it.bruk && !isForventetPensjongivendeInntekt(it)
             })
 
-            return inntektsgrunnlagListe
+            return inntektGrunnlagListe
         }
 
         private fun isForventetPensjongivendeInntekt(grunnlag: Inntektsgrunnlag): Boolean =
-            grunnlag.inntektType?.let { it.kode == InntektType.FPI.name } ?: false
+            grunnlag.inntektType?.let { it.kode == InntektType.FPI.name } == true
 
         private fun calculateGrunnbelopForhold(
             aar: Int,
@@ -825,22 +769,22 @@ class KravhodeCreator(
             veietGrunnbeloepListe: List<VeietSatsResultat>,
             grunnbeloep: Int
         ): Double {
-            val innevarendeAar = LocalDate.now().year
+            val innevaerendeAar = LocalDate.now().year
 
-            return if (spec.erAnonym && aar < innevarendeAar)
+            return if (spec.erAnonym && aar < innevaerendeAar)
                 findValidForYear(veietGrunnbeloepListe, aar)?.let { it.verdi / grunnbeloep } ?: 1.0
             else
                 1.0
         }
 
-        private fun oensketVirkningDato(simulatorInput: SimuleringSpec) =
-            if (simulatorInput.erAnonym) null else finnOensketVirkningDato(simulatorInput)
+        private fun oensketVirkningDato(spec: SimuleringSpec) =
+            if (spec.erAnonym)
+                null
+            else
+                spec.heltUttakDato ?: spec.foersteUttakDato
 
-        private fun finnOensketVirkningDato(simulatorInput: SimuleringSpec) =
-            simulatorInput.heltUttakDato ?: simulatorInput.foersteUttakDato
-
-        private fun inntekter(inntektsgrunnlagList: MutableList<Inntektsgrunnlag>) =
-            inntektsgrunnlagList.map {
+        private fun inntektListe(grunnlagListe: MutableList<Inntektsgrunnlag>) =
+            grunnlagListe.map {
                 Inntekt(
                     beloep = it.belop.toLong(),
                     inntektAar = getYear(it.fom)
@@ -853,13 +797,13 @@ class KravhodeCreator(
             sisteOpptjeningAar: Int,
             fom: LocalDate
         ): List<Inntektsgrunnlag> {
-            val fremtidigeInntekter = spec.fremtidigInntektListe
+            val fremtidigInntektListe = spec.fremtidigInntektListe
 
-            if (fremtidigeInntekter.isEmpty() || doesNotHaveFremtidigInntektBeforeFom(spec, fom)) {
-                fremtidigeInntekter.add(FremtidigInntekt(aarligInntektBeloep = 0, fom = fom))
+            if (fremtidigInntektListe.isEmpty() || doesNotHaveFremtidigInntektBeforeFom(spec, fom)) {
+                fremtidigInntektListe.add(FremtidigInntekt(aarligInntektBeloep = 0, fom = fom))
             }
 
-            val sortedFremtidigeInntekter = fremtidigeInntekter.toMutableList()
+            val sortedFremtidigeInntekter = fremtidigInntektListe.toMutableList()
             sortedFremtidigeInntekter.sortBy { it.fom }
             validateSortedFremtidigeInntekter(sortedFremtidigeInntekter)
             addFremtidigInntektAtStartOfEachYear(sortedFremtidigeInntekter, sisteOpptjeningAar)
@@ -874,10 +818,10 @@ class KravhodeCreator(
             aar: Int
         ): Inntektsgrunnlag {
             val arligeInntekter = inntektListe.filter { it.fom.year == aar }
-            return inntektsgrunnlagForAret(aar, arligeInntekter)
+            return inntektGrunnlagForAaret(aar, arligeInntekter)
         }
 
-        private fun inntektsgrunnlagForAret(aar: Int, aaretsInntektListe: List<FremtidigInntekt>) =
+        private fun inntektGrunnlagForAaret(aar: Int, aaretsInntektListe: List<FremtidigInntekt>) =
             Inntektsgrunnlag().apply {
                 fom = fromLocalDate(foersteDag(aar))
                 tom = fromLocalDate(sisteDag(aar))
@@ -904,7 +848,7 @@ class KravhodeCreator(
                 land = Land.NOR
             }
 
-        private fun opptjeningsgrunnlag(inntekt: Inntekt) =
+        private fun opptjeningGrunnlag(inntekt: Inntekt) =
             Opptjeningsgrunnlag().apply {
                 ar = inntekt.inntektAar
                 pi = inntekt.beloep.toInt()
@@ -912,7 +856,7 @@ class KravhodeCreator(
                 bruk = true
             }
 
-        private fun helUttaksgrad(fom: LocalDate?) =
+        private fun heltUttakGrad(fom: LocalDate?) =
             Uttaksgrad().apply {
                 fomDato = fromLocalDate(fom)
                 uttaksgrad = MAX_UTTAKSGRAD
@@ -924,27 +868,33 @@ class KravhodeCreator(
                 .multiply(BigInteger.valueOf(periodOfMonths.toLong()))
                 .divide(BigInteger.valueOf(MAANEDER_PER_AAR.toLong()))
 
-        private fun doesNotHaveFremtidigInntektBeforeFom(simulatorInput: SimuleringSpec, fom: LocalDate) =
-            simulatorInput.fremtidigInntektListe.none { isBeforeByDay(it.fom, fom, true) }
+        private fun doesNotHaveFremtidigInntektBeforeFom(spec: SimuleringSpec, fom: LocalDate) =
+            spec.fremtidigInntektListe.none { isBeforeByDay(it.fom, fom, true) }
 
-        private fun harUtenlandsopphold(antallAarUtenlands: Int?, trygdetidperioder: List<TTPeriode>) =
-            if (antallAarUtenlands == null) containsTrygdetidAbroad(trygdetidperioder) else antallAarUtenlands > 0
+        private fun foedselDato(spec: SimuleringSpec): LocalDate =
+            spec.foedselDato ?: foersteDag(spec.foedselAar)
 
-        private fun containsTrygdetidAbroad(trygdetidPeriodeListe: List<TTPeriode>) =
+        private fun harUtenlandsopphold(antallAarUtenlands: Int?, trygdetidPeriodeListe: List<TTPeriode>) =
+            if (antallAarUtenlands == null)
+                containsTrygdetidUtenlands(trygdetidPeriodeListe)
+            else
+                antallAarUtenlands > 0
+
+        private fun containsTrygdetidUtenlands(trygdetidPeriodeListe: List<TTPeriode>) =
             trygdetidPeriodeListe.any { it.land!!.kode != Land.NOR.name }
 
         private fun erGradertUttak(spec: SimuleringSpec) = spec.uttakGrad != UttakGradKode.P_100
 
-        private fun sammeAr(inntekt1: FremtidigInntekt, inntekt2: FremtidigInntekt) =
-            inntekt1.fom.year == inntekt2.fom.year
+        private fun sammeAar(a: FremtidigInntekt, b: FremtidigInntekt) =
+            a.fom.year == b.fom.year
 
         private fun starterJanuar(inntekt: FremtidigInntekt) =
             inntekt.fom.monthValue == 1
 
-        private fun starterAretEtter(fremtidigInntekt: FremtidigInntekt, inntekt: FremtidigInntekt) =
-            fremtidigInntekt.fom.year == aretEtter(inntekt)
+        private fun starterAaretEtter(fremtidigInntekt: FremtidigInntekt, inntekt: FremtidigInntekt) =
+            fremtidigInntekt.fom.year == aaretEtter(inntekt)
 
-        private fun aretEtter(inntekt: FremtidigInntekt) =
+        private fun aaretEtter(inntekt: FremtidigInntekt) =
             inntekt.fom.year + 1
 
         private fun legacyFoersteDag(aar: Int) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagService.kt
@@ -19,13 +19,8 @@ class PersongrunnlagService(
     private val persongrunnlagMapper: PersongrunnlagMapper
 ) {
     // OpprettKravHodeHelper.opprettPersongrunnlagForBruker
-    fun addSoekerGrunnlagToKravhode(
-        spec: SimuleringSpec,
-        kravhode: Kravhode,
-        person: PenPerson
-    ): Kravhode {
+    fun getPersongrunnlagForSoeker(spec: SimuleringSpec, kravhode: Kravhode, person: PenPerson): Persongrunnlag {
         val persongrunnlag = persongrunnlagMapper.mapToPersongrunnlag(person, spec)
-        kravhode.persongrunnlagListe.add(persongrunnlag)
 
         addBeholdningerMedGrunnlagToPersongrunnlag(
             persongrunnlag,
@@ -34,7 +29,7 @@ class PersongrunnlagService(
             hentBeholdninger = false
         )
 
-        return kravhode
+        return persongrunnlag
     }
 
     // OpprettKravHodeHelper.oppdaterGrunnlagMedBeholdninger

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagService.kt
@@ -1,0 +1,83 @@
+package no.nav.pensjon.simulator.core.person
+
+import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagPersonSpec
+import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagService
+import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagSpec
+import no.nav.pensjon.simulator.core.domain.regler.PenPerson
+import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.SakTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Pensjonsbeholdning
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.person.Pid
+import org.springframework.stereotype.Service
+
+@Service
+class PersongrunnlagService(
+    private val beholdningService: BeholdningerMedGrunnlagService,
+    private val persongrunnlagMapper: PersongrunnlagMapper
+) {
+    // OpprettKravHodeHelper.opprettPersongrunnlagForBruker
+    fun addSoekerGrunnlagToKravhode(
+        spec: SimuleringSpec,
+        kravhode: Kravhode,
+        person: PenPerson
+    ): Kravhode {
+        val persongrunnlag = persongrunnlagMapper.mapToPersongrunnlag(person, spec)
+        kravhode.persongrunnlagListe.add(persongrunnlag)
+
+        addBeholdningerMedGrunnlagToPersongrunnlag(
+            persongrunnlag,
+            kravhode,
+            pid = person.pid!!,
+            hentBeholdninger = false
+        )
+
+        return kravhode
+    }
+
+    // OpprettKravHodeHelper.oppdaterGrunnlagMedBeholdninger
+    private fun addBeholdningerMedGrunnlagToPersongrunnlag(
+        persongrunnlag: Persongrunnlag,
+        kravhode: Kravhode,
+        pid: Pid,
+        hentBeholdninger: Boolean
+    ) {
+        with(beholdningService.getBeholdningerMedGrunnlag(beholdningSpec(pid, kravhode))) {
+            persongrunnlag.opptjeningsgrunnlagListe = opptjeningGrunnlagListe.toMutableList()
+            persongrunnlag.omsorgsgrunnlagListe = omsorgGrunnlagListe.toMutableList()
+            persongrunnlag.inntektsgrunnlagListe = inntektGrunnlagListe.toMutableList()
+            persongrunnlag.dagpengegrunnlagListe = dagpengerGrunnlagListe.toMutableList()
+            persongrunnlag.forstegangstjenestegrunnlag = foerstegangstjeneste
+
+            if (hentBeholdninger) {
+                beholdningListe.filterIsInstance<Pensjonsbeholdning>().forEach(persongrunnlag.beholdninger::add)
+            }
+        }
+    }
+
+    private fun beholdningSpec(pid: Pid, kravhode: Kravhode) =
+        BeholdningerMedGrunnlagSpec(
+            pid,
+            hentPensjonspoeng = true,
+            hentGrunnlagForOpptjeninger = true,
+            hentBeholdninger = false,
+            harUfoeretrygdKravlinje = kravhode.isUforetrygd(),
+            regelverkType = kravhode.regelverkTypeEnum,
+            sakType = kravhode.sakType?.let { SakTypeEnum.valueOf(it.name) },
+            personSpecListe = kravhode.persongrunnlagListe.map(::personligBeholdningSpec),
+            soekerSpec = kravhode.hentPersongrunnlagForSoker().let(::personligBeholdningSpec)
+        )
+
+    private fun personligBeholdningSpec(persongrunnlag: Persongrunnlag) =
+        BeholdningerMedGrunnlagPersonSpec(
+            pid = persongrunnlag.penPerson?.pid!!,
+            sisteGyldigeOpptjeningAar = persongrunnlag.sisteGyldigeOpptjeningsAr,
+
+            isGrunnlagRolleSoeker = persongrunnlag.findPersonDetaljIPersongrunnlag(
+                grunnlagsrolle = GrunnlagsrolleEnum.SOKER,
+                checkBruk = true
+            ) != null
+        )
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/person/eps/EpsService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/person/eps/EpsService.kt
@@ -17,14 +17,14 @@ import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.util.toLocalDate
 import no.nav.pensjon.simulator.person.PersonService
 import no.nav.pensjon.simulator.tech.time.DateUtil.foersteDag
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.*
 
 /**
  * Functionality related to 'ektefelle/partner/samboer' (EPS).
  */
-@Component
+@Service
 class EpsService(
     private val personService: PersonService,
     private val persongrunnlagMapper: PersongrunnlagMapper
@@ -68,13 +68,13 @@ class EpsService(
     private fun foedselDato(spec: SimuleringSpec): LocalDate =
         spec.pid?.let(personService::person)?.fodselsdato.toLocalDate() ?: foersteDag(spec.foedselAar)
 
-    private companion object {
-        private const val GRUNNBELOP_MULTIPLIER = 3 // larger than 2 (due to 2G income limit for EPS)
+    companion object {
+        const val EPS_GRUNNBELOEP_MULTIPLIER = 3 // greater than 2 (due to 2G income limit for EPS)
 
         // OpprettKravHodeHelper.createInntektsgrunnlagForBrukerOrEps (special EPS variant)
         private fun epsInntektsgrunnlag(grunnbeloep: Int, foersteUttakAar: Int) =
             Inntektsgrunnlag().apply {
-                belop = GRUNNBELOP_MULTIPLIER * grunnbeloep
+                belop = EPS_GRUNNBELOEP_MULTIPLIER * grunnbeloep
                 fom = fromLocalDate(foersteDag(foersteUttakAar))
                 tom = null
                 grunnlagKilde = GrunnlagKildeCti(GrunnlagKilde.BRUKER.name)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/person/eps/EpsService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/person/eps/EpsService.kt
@@ -32,7 +32,7 @@ class EpsService(
     private val log = KotlinLogging.logger {}
 
     // OpprettKravHodeHelper.opprettPersongrunnlagForEPS
-    fun addAlderspensjonEpsGrunnlagToKrav(spec: SimuleringSpec, kravhode: Kravhode, grunnbeloep: Int) {
+    fun addPersongrunnlagForEpsToKravhode(spec: SimuleringSpec, kravhode: Kravhode, grunnbeloep: Int) {
         if (EnumSet.of(SimuleringType.ALDER_M_GJEN, SimuleringType.ENDR_ALDER_M_GJEN).contains(spec.type)) {
             //TODO createPersongrunnlagInCaseOfGjenlevenderett(simulering, kravhode)
             with("Simulering for gjenlevende is not supported") {


### PR DESCRIPTION
Skrur på gjenværende funksjonalitet for simulering (opprettelse av uttaksgrader og persongrunnlag).
La til `EndringUttakGrad` for simulering av 'endring av AP'.
La til `Pre2025OffentligAfpUttakGrad` for simulering av gammel ("pre-2025") offentlig AFP.

Trakk ut persongrunnlag-funksjoner i en egen klasse: `PersongrunnlagService`.