### PR TITLE
JSON-format dates, specify timezone in unit test

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/viapen/acl/v3/TpoSimuleringResultV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/viapen/acl/v3/TpoSimuleringResultV3.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.simulator.alderspensjon.api.tpo.viapen.acl.v3
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import java.time.LocalDate
 
 /**
@@ -34,6 +35,7 @@ data class TpoPensjonPeriodeV3(
 
 // PensjonsbeholdningPeriodeV3 in PEN
 data class TpoPensjonBeholdningPeriodeV3(
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "CET")
     val datoFom: LocalDate? = null,
     val garantipensjonsbeholdning: Double? = null,
     val garantitilleggsbeholdning: Double? = null,
@@ -52,12 +54,15 @@ data class TpoGarantipensjonNivaaV3(
 // UttaksgradV3 in PEN
 data class TpoUttakGradV3(
     val uttaksgrad: Int? = null,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "CET")
     val fomDato: LocalDate? = null,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "CET")
     val tomDato: LocalDate? = null
 )
 
 // SimulertBeregningsinformasjonV3 in PEN
 data class TpoBeregningInformasjonV3(
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "CET")
     val datoFom: LocalDate? = null,
     val uttaksgrad: Double? = null,
 

--- a/src/test/kotlin/no/nav/pensjon/simulator/sak/client/pen/PenSakClientTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/sak/client/pen/PenSakClientTest.kt
@@ -22,6 +22,7 @@ import org.springframework.security.authentication.TestingAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.reactive.function.client.WebClient
 import java.time.LocalDate
+import java.util.TimeZone
 
 class PenSakClientTest : FunSpec({
     var server: MockWebServer? = null
@@ -37,6 +38,7 @@ class PenSakClientTest : FunSpec({
 
         server = MockWebServer().also { it.start() }
         baseUrl = server.let { "http://localhost:${it.port}" }
+        TimeZone.setDefault(TimeZone.getTimeZone("CET"))
     }
 
     afterSpec {
@@ -74,9 +76,6 @@ class PenSakClientTest : FunSpec({
 
 object PenPersonVirkningDatoResponse {
 
-    // NB: In PEN response: "virkningsdato": "2020-02-01T00:00:00+0100" (i.e. midnight)
-    // Using this value causes tests run on GitHub to fail, due to Finnish timezone
-    // (2020-02-01T00:00:00+0100 becomes 2020-01-31:23:00:00 Finnish time)
     @Language("json")
     const val BODY = """{
     "person": {
@@ -98,7 +97,7 @@ object PenPersonVirkningDatoResponse {
     ],
     "forsteVirkningsdatoGrunnlagListe": [
         {
-            "virkningsdato": "2020-02-01T12:00:00+0100",
+            "virkningsdato": "2020-02-01T00:00:00+0100",
             "kravFremsattDato": "2019-11-14T12:00:00+0100",
             "bruker": {
                 "penPersonId": 123456


### PR DESCRIPTION
Endring 1: Angir tidssone i tester som inkluderer datoer med tid 00:00:00, da disse ellers vil feile når testene kjøres på GitHub i Finland (tiden blir da 23:00:00 dagen før).

Endring 2: Angir JSON-format på datoer i V3-responsen.