### PR TITLE
PEK-831 Use dataForespoersel in sporingslogg

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/Sporing.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/Sporing.kt
@@ -10,5 +10,6 @@ data class Sporing(
     val tema: String,
     val behandlingGrunnlag: String,
     val uthentingTidspunkt: LocalDateTime,
+    val dataForespoersel: String,
     val leverteData: String
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/SporingsloggService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/SporingsloggService.kt
@@ -18,7 +18,7 @@ class SporingsloggService(
     /**
      * Log using fire-and-forget async call
      */
-    fun log(pid: Pid, leverteData: String) {
+    fun log(pid: Pid, dataForespoersel: String, leverteData: String) {
         CoroutineScope(Dispatchers.Default).launch(SecurityCoroutineContext()) {
             val organisasjonsnummer = organisasjonsnummerProvider.provideOrganisasjonsnummer()
 
@@ -29,6 +29,7 @@ class SporingsloggService(
                     tema = "PEK",
                     behandlingGrunnlag = "B353",
                     uthentingTidspunkt = LocalDateTime.now(),
+                    dataForespoersel,
                     leverteData
                 )
             )

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/client/samhandling/acl/SamhandlingSporing.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/client/samhandling/acl/SamhandlingSporing.kt
@@ -6,5 +6,6 @@ data class SamhandlingSporing(
     val tema: String,
     val behandlingsGrunnlag: String,
     val uthentingsTidspunkt: String,
+    val dataForespoersel: String,
     val leverteData: String
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/client/samhandling/acl/SamhandlingSporingMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/client/samhandling/acl/SamhandlingSporingMapper.kt
@@ -11,6 +11,7 @@ object SamhandlingSporingMapper {
             tema = source.tema,
             behandlingsGrunnlag = source.behandlingGrunnlag,
             uthentingsTidspunkt = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(source.uthentingTidspunkt),
+            dataForespoersel = source.dataForespoersel,
             leverteData = source.leverteData
         )
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/web/SporingInterceptor.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/web/SporingInterceptor.kt
@@ -42,9 +42,9 @@ class SporingInterceptor(private val service: SporingsloggService) : HandlerInte
     ) {
         val inData = copy(request.rawData)
         val outData = copy(response.rawData)
-        val inLog: String = if (inData.isEmpty()) request.request.requestURI else String(inData)
-        val outLog: String = if (outData.isEmpty()) response.response.status.toString() else String(outData)
-        service.log(pid, leverteData = "In:${inLog}Out:$outLog")
+        val dataForespoersel: String = if (inData.isEmpty()) request.request.requestURI else String(inData)
+        val leverteData: String = if (outData.isEmpty()) response.response.status.toString() else String(outData)
+        service.log(pid, dataForespoersel, leverteData)
     }
 
     private fun copy(bytes: ByteArray) =
@@ -61,7 +61,7 @@ class SporingInterceptor(private val service: SporingsloggService) : HandlerInte
         val data = copy(request.rawData)
 
         if (data.isNotEmpty()) {
-            service.log(pid, "In:${String(data)}")
+            service.log(pid, dataForespoersel = String(data), leverteData = "(no data)")
         }
     }
 
@@ -69,7 +69,7 @@ class SporingInterceptor(private val service: SporingsloggService) : HandlerInte
         val data = copy(response.rawData)
 
         if (data.isNotEmpty()) {
-            service.log(pid, "Out:${String(data)}")
+            service.log(pid, dataForespoersel = "(no data)", leverteData = String(data))
         }
     }
 }


### PR DESCRIPTION
Forvalteren av sporingsloggen etterlyste bruk av feltet `dataForespoersel` (ref. [springslogg-dok](https://sikkerhet.nav.no/docs/sikker-utvikling/sporingslogg)).
Endringen gjør at mottatt forespørsel fra TPO logges i `dataForespoersel` og returnerte data logges i `leverteData`.