### PR TITLE
PEK-551 Update response for pensjonskalkulator calls

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimuleringFacade.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimuleringFacade.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.simulator.alderspensjon.alternativ
 
 import no.nav.pensjon.simulator.alderspensjon.convert.SimulatorOutputConverter.pensjon
 import no.nav.pensjon.simulator.core.SimulatorCore
+import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableException
 import no.nav.pensjon.simulator.core.exception.RegelmotorFeilException
 import no.nav.pensjon.simulator.core.exception.RegelmotorValideringException
 import no.nav.pensjon.simulator.core.exception.UtilstrekkeligOpptjeningException
@@ -51,11 +52,9 @@ class SimuleringFacade(
                     inkluderPensjonHvisUbetinget
                 )
         } catch (e: RegelmotorValideringException) {
-            //throw SimuleringException("simuler alderspensjon 1963+ feilet", e)
-            throw RuntimeException("simuler alderspensjon 1963+ feilet", e)
+            throw ImplementationUnrecoverableException("simuler alderspensjon 1963+ feilet", e)
         } catch (e: RegelmotorFeilException) {
-            //throw SimuleringException("simuler alderspensjon 1963+ feilet", e)
-            throw RuntimeException("simuler alderspensjon 1963+ feilet", e)
+            throw ImplementationUnrecoverableException("simuler alderspensjon 1963+ feilet", e)
         }
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
@@ -30,7 +30,8 @@ data class SimulertAarligAlderspensjon(
 class SimulertAlderspensjonFraFolketrygden(
     val datoFom: LocalDate,
     val delytelseListe: List<SimulertDelytelse>,
-    val uttakGrad: Int
+    val uttakGrad: Int,
+    val maanedligBeloep: Int
 )
 
 data class SimulertPrivatAfp(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/NavAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/NavAlderspensjonController.kt
@@ -79,7 +79,6 @@ class NavAlderspensjonController(
         countCall(FUNCTION_ID)
 
         return try {
-            throw ImplementationUnrecoverableException("outer", IllegalArgumentException("inner"))
             val foedselsdato: LocalDate = generelleDataHolder.getPerson(Pid(specV3.pid)).foedselDato
             val spec: SimuleringSpec = fromNavSimuleringSpecV3(specV3, foedselsdato)
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/NavAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/NavAlderspensjonController.kt
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import mu.KotlinLogging
 import no.nav.pensjon.simulator.alderspensjon.alternativ.SimuleringFacade
 import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertPensjonEllerAlternativ
-import no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.result.NavSimuleringResultMapperV3.mapNavSimuleringResultV3
+import no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.result.NavSimuleringResultMapperV3.toDto
 import no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.result.NavSimuleringResultV3
 import no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.spec.NavSimuleringSpecMapperV3.fromNavSimuleringSpecV3
 import no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.spec.NavSimuleringSpecV3
@@ -71,7 +71,7 @@ class NavAlderspensjonController(
             val result: SimulertPensjonEllerAlternativ =
                 service.simulerAlderspensjon(spec, inkluderPensjonHvisUbetinget = false)
 
-            mapNavSimuleringResultV3(result)
+            toDto(result)
         } catch (e: EgressException) {
             handle(e)!!
         } catch (e: BadRequestException) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
@@ -9,20 +9,21 @@ import no.nav.pensjon.simulator.core.beholdning.OpptjeningGrunnlag
  */
 object NavSimuleringResultMapperV3 {
 
-    fun mapNavSimuleringResultV3(source: SimulertPensjonEllerAlternativ?) =
+    fun toDto(source: SimulertPensjonEllerAlternativ?) =
         NavSimuleringResultV3(
-            alderspensjon = source?.pensjon?.alderspensjon.orEmpty().map(::alderspensjon),
-            afpPrivat = source?.pensjon?.privatAfp.orEmpty().map(::privatAfp),
-            afpOffentliglivsvarig = source?.pensjon?.livsvarigOffentligAfp.orEmpty().map(::livsvarigOffentligAfp),
+            alderspensjonListe = source?.pensjon?.alderspensjon.orEmpty().map(::alderspensjon),
+            alderspensjonMaanedsbeloep = maanedsbeloep(source?.pensjon?.alderspensjonFraFolketrygden.orEmpty()),
+            privatAfpListe = source?.pensjon?.privatAfp.orEmpty().map(::privatAfp),
+            livsvarigOffentligAfpListe = source?.pensjon?.livsvarigOffentligAfp.orEmpty().map(::livsvarigOffentligAfp),
             vilkaarsproeving = vilkaarsproevingResultat(source?.alternativ),
-            harNokTrygdetidForGarantipensjon = source?.pensjon?.harNokTrygdetidForGarantipensjon,
+            tilstrekkeligTrygdetidForGarantipensjon = source?.pensjon?.harNokTrygdetidForGarantipensjon,
             trygdetid = source?.pensjon?.trygdetid ?: 0,
             opptjeningGrunnlagListe = source?.pensjon?.opptjeningGrunnlagListe.orEmpty().map(::opptjeningGrunnlag)
         )
 
     private fun alderspensjon(source: SimulertAarligAlderspensjon) =
-        SimulertAlderspensjonV3(
-            alder = source.alderAar,
+        NavAlderspensjonV3(
+            alderAar = source.alderAar,
             beloep = source.beloep,
             inntektspensjon = source.inntektspensjon,
             garantipensjon = source.garantipensjon,
@@ -30,39 +31,45 @@ object NavSimuleringResultMapperV3 {
             pensjonBeholdningFoerUttak = source.pensjonBeholdningFoerUttak
         )
 
+    private fun maanedsbeloep(source: List<SimulertAlderspensjonFraFolketrygden>) =
+        NavMaanedsbeloepV3(
+            gradertUttakBeloep = source.firstOrNull { it.uttakGrad != 100 }?.maanedligBeloep,
+            heltUttakBeloep = source.firstOrNull { it.uttakGrad == 100 }?.maanedligBeloep ?: 0
+        )
+
     private fun privatAfp(source: SimulertPrivatAfp) =
-        SimulertPrivatAfpV3(
-            alder = source.alderAar,
+        NavPrivatAfpV3(
+            alderAar = source.alderAar,
             beloep = source.beloep
         )
 
     private fun livsvarigOffentligAfp(source: SimulertLivsvarigOffentligAfp) =
-        SimulertLivsvarigOffentligAfpV3(
-            alder = source.alderAar,
+        NavLivsvarigOffentligAfpV3(
+            alderAar = source.alderAar,
             beloep = source.beloep
         )
 
     private fun vilkaarsproevingResultat(source: SimulertAlternativ?) =
-        VilkaarsproevingResultatV3(
+        NavVilkaarsproevingResultatV3(
             vilkaarErOppfylt = source == null,
             alternativ = source?.let(::alternativ)
         )
 
     private fun opptjeningGrunnlag(source: OpptjeningGrunnlag) =
-        SimulatorOpptjeningGrunnlagV3(
+        NavOpptjeningGrunnlagV3(
             aar = source.aar,
-            pensjonsgivendeInntekt = source.pensjonsgivendeInntekt
+            pensjonsgivendeInntektBeloep = source.pensjonsgivendeInntekt
         )
 
     private fun alternativ(source: SimulertAlternativ) =
-        AlternativtResultatV3(
-            gradertUttaksalder = source.gradertUttakAlder?.let(::alder),
+        NavAlternativtResultatV3(
+            gradertUttakAlder = source.gradertUttakAlder?.let(::alder),
             uttaksgrad = source.uttakGrad.value.toInt(),
-            heltUttaksalder = alder(source.heltUttakAlder)
+            heltUttakAlder = alder(source.heltUttakAlder)
         )
 
     private fun alder(source: SimulertUttakAlder) =
-        AlderV3(
+        NavAlderV3(
             aar = source.alder.aar,
             maaneder = source.alder.maaneder
         )

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
@@ -14,7 +14,8 @@ data class NavSimuleringResultV3(
     val vilkaarsproeving: NavVilkaarsproevingResultatV3,
     val tilstrekkeligTrygdetidForGarantipensjon: Boolean?,
     val trygdetid: Int,
-    val opptjeningGrunnlagListe: List<NavOpptjeningGrunnlagV3>
+    val opptjeningGrunnlagListe: List<NavOpptjeningGrunnlagV3>,
+    val error: NavSimuleringErrorV3? = null
 )
 
 // no.nav.pensjon.pen.domain.api.simulering.dto.SimulertAlderspensjon
@@ -54,6 +55,12 @@ data class NavVilkaarsproevingResultatV3(
 data class NavOpptjeningGrunnlagV3(
     val aar: Int,
     val pensjonsgivendeInntektBeloep: Int
+)
+
+@JsonInclude(NON_NULL)
+data class NavSimuleringErrorV3(
+    val exception: String?,
+    val message: String
 )
 
 @JsonInclude(NON_NULL)

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
@@ -3,22 +3,24 @@ package no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.result
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
 
-// SimuleringsresultatAlderspensjon1963Plus
+// Corresponds to SimulatorPersonligSimuleringResult in pensjonskalulator-backend
+// (and previously to SimuleringsresultatAlderspensjon1963Plus in PEN)
 @JsonInclude(NON_NULL)
 data class NavSimuleringResultV3(
-    val alderspensjon: List<SimulertAlderspensjonV3>,
-    val afpPrivat: List<SimulertPrivatAfpV3>,
-    val afpOffentliglivsvarig: List<SimulertLivsvarigOffentligAfpV3>,
-    val vilkaarsproeving: VilkaarsproevingResultatV3,
-    val harNokTrygdetidForGarantipensjon: Boolean?,
+    val alderspensjonListe: List<NavAlderspensjonV3>,
+    val alderspensjonMaanedsbeloep: NavMaanedsbeloepV3?,
+    val privatAfpListe: List<NavPrivatAfpV3>,
+    val livsvarigOffentligAfpListe: List<NavLivsvarigOffentligAfpV3>,
+    val vilkaarsproeving: NavVilkaarsproevingResultatV3,
+    val tilstrekkeligTrygdetidForGarantipensjon: Boolean?,
     val trygdetid: Int,
-    val opptjeningGrunnlagListe: List<SimulatorOpptjeningGrunnlagV3>
+    val opptjeningGrunnlagListe: List<NavOpptjeningGrunnlagV3>
 )
 
 // no.nav.pensjon.pen.domain.api.simulering.dto.SimulertAlderspensjon
 @JsonInclude(NON_NULL)
-data class SimulertAlderspensjonV3(
-    val alder: Int,
+data class NavAlderspensjonV3(
+    val alderAar: Int,
     val beloep: Int,
     val inntektspensjon: Int?,
     val garantipensjon: Int?,
@@ -26,36 +28,42 @@ data class SimulertAlderspensjonV3(
     val pensjonBeholdningFoerUttak: Int?
 )
 
-data class SimulertPrivatAfpV3(
-    val alder: Int,
+@JsonInclude(NON_NULL)
+data class NavMaanedsbeloepV3(
+    val gradertUttakBeloep: Int?,
+    val heltUttakBeloep: Int
+)
+
+data class NavPrivatAfpV3(
+    val alderAar: Int,
     val beloep: Int
 )
 
-data class SimulertLivsvarigOffentligAfpV3(
-    val alder: Int,
+data class NavLivsvarigOffentligAfpV3(
+    val alderAar: Int,
     val beloep: Int
-)
-
-// no.nav.pensjon.pen.domain.api.simulering.SimulatorOpptjeningGrunnlag
-data class SimulatorOpptjeningGrunnlagV3(
-    val aar: Int,
-    val pensjonsgivendeInntekt: Int
 )
 
 @JsonInclude(NON_NULL)
-data class VilkaarsproevingResultatV3(
+data class NavVilkaarsproevingResultatV3(
     val vilkaarErOppfylt: Boolean,
-    val alternativ: AlternativtResultatV3?
+    val alternativ: NavAlternativtResultatV3?
+)
+
+// PEN: no.nav.pensjon.pen.domain.api.simulering.SimulatorOpptjeningGrunnlag
+data class NavOpptjeningGrunnlagV3(
+    val aar: Int,
+    val pensjonsgivendeInntektBeloep: Int
 )
 
 @JsonInclude(NON_NULL)
-data class AlternativtResultatV3(
-    val gradertUttaksalder: AlderV3?,
+data class NavAlternativtResultatV3(
+    val gradertUttakAlder: NavAlderV3?,
     val uttaksgrad: Int,
-    val heltUttaksalder: AlderV3
+    val heltUttakAlder: NavAlderV3
 )
 
-data class AlderV3(
+data class NavAlderV3(
     val aar: Int,
     val maaneder: Int
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringSpecV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringSpecV3.kt
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
-
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.person.Pid.Companion.redact
 import java.util.*
 
-// SimuleringSpecDtoAlderspensjon1963Plus
+// PEN: SimuleringSpecDtoAlderspensjon1963Plus
 /**
  * Data transfer object som representerer inn-data (spesifikasjon) for
  * simulering av alderspensjon for brukere født 1963 eller senere.
@@ -28,7 +28,25 @@ data class NavSimuleringSpecV3(
     val epsHarInntektOver2G: Boolean? = null,
     val fremtidigInntektListe: List<NavSimuleringInntektSpecV3>? = null,
     val utenlandsperiodeListe: List<NavSimuleringUtlandSpecV3>? = null
-)
+) {
+    /**
+     * toString with redacted person ID
+     */
+    override fun toString() =
+        "pid: ${redact(pid)}, " +
+                "sivilstand: $sivilstand, " +
+                "harEps: $harEps, " +
+                "uttaksar: $uttaksar, " +
+                "sisteInntekt: $sisteInntekt, " +
+                "simuleringstype: $simuleringstype, " +
+                "gradertUttak: $gradertUttak, " +
+                "heltUttak: $heltUttak, " +
+                "aarUtenlandsEtter16Aar: $aarUtenlandsEtter16Aar, " +
+                "epsHarPensjon: $epsHarPensjon, " +
+                "epsHarInntektOver2G: $epsHarInntektOver2G, " +
+                "fremtidigInntektListe: $fremtidigInntektListe, " +
+                "utenlandsperiodeListe: $utenlandsperiodeListe"
+}
 
 @JsonInclude(NON_NULL)
 data class NavSimuleringGradertUttakSpecV3(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringTypeSpecV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringTypeSpecV3.kt
@@ -4,6 +4,9 @@ import mu.KotlinLogging
 import no.nav.pensjon.simulator.core.domain.SimuleringType
 import org.springframework.util.StringUtils.hasLength
 
+/**
+ * Corresponds to SimulatorSimuleringType in pensjonskalkulator-backend.
+ */
 // no.nav.domain.pensjon.kjerne.kodetabeller.SimuleringTypeCode
 enum class NavSimuleringTypeSpecV3(val externalValue: String, val internalValue: SimuleringType) {
     /**
@@ -35,6 +38,8 @@ enum class NavSimuleringTypeSpecV3(val externalValue: String, val internalValue:
      * Alderspensjon med AFP i privat sektor
      */
     ALDER_M_AFP_PRIVAT("ALDER_M_AFP_PRIVAT", SimuleringType.ALDER_M_AFP_PRIVAT),
+
+    ALDERSPENSJON_MED_LIVSVARIG_OFFENTLIG_AFP("ALDERSPENSJON_MED_LIVSVARIG_OFFENTLIG_AFP", SimuleringType.ALDER_MED_AFP_OFFENTLIG_LIVSVARIG),
 
     /**
      * Alderspensjon med gjenlevenderettigheter

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/anonym/acl/v1/spec/AnonymUttakGradSpecV1.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/anonym/acl/v1/spec/AnonymUttakGradSpecV1.kt
@@ -1,45 +1,22 @@
 package no.nav.pensjon.simulator.alderspensjon.api.nav.direct.anonym.acl.v1.spec
 
 import mu.KotlinLogging
+import no.nav.pensjon.simulator.alderspensjon.api.nav.direct.anonym.acl.v1.spec.AnonymUttakGradSpecV1.entries
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
-import org.springframework.util.StringUtils
+import org.springframework.util.StringUtils.hasLength
 
-// no.nav.domain.pensjon.kjerne.kodetabeller.UttaksgradCode
+/**
+ * Corresponds to SimulatorUttaksgrad in pensjonskalkulator-backend.
+ */
 enum class AnonymUttakGradSpecV1(val externalValue: String, val internalValue: UttakGradKode) {
-    /**
-     * 0 %
-     */
-    P_0("0", UttakGradKode.P_0),
 
-    /**
-     * 100 %
-     */
-    P_100("100", UttakGradKode.P_100),
-
-    /**
-     * 20 %
-     */
-    P_20("20", UttakGradKode.P_20),
-
-    /**
-     * 40 %
-     */
-    P_40("40", UttakGradKode.P_40),
-
-    /**
-     * 50 %
-     */
-    P_50("50", UttakGradKode.P_50),
-
-    /**
-     * 60 %
-     */
-    P_60("60", UttakGradKode.P_60),
-
-    /**
-     * 80 %
-     */
-    P_80("80", UttakGradKode.P_80);
+    NULL(externalValue = "P_0", internalValue = UttakGradKode.P_0),
+    TJUE_PROSENT(externalValue = "P_20", internalValue = UttakGradKode.P_20),
+    FOERTI_PROSENT(externalValue = "P_40", internalValue = UttakGradKode.P_40),
+    FEMTI_PROSENT(externalValue = "P_50", internalValue = UttakGradKode.P_50),
+    SEKSTI_PROSENT(externalValue = "P_60", internalValue = UttakGradKode.P_60),
+    AATTI_PROSENT(externalValue = "P_80", internalValue = UttakGradKode.P_80),
+    HUNDRE_PROSENT(externalValue = "P_100", internalValue = UttakGradKode.P_100);
 
     companion object {
         private val log = KotlinLogging.logger {}
@@ -49,9 +26,9 @@ enum class AnonymUttakGradSpecV1(val externalValue: String, val internalValue: U
             entries.singleOrNull { it.externalValue.equals(value, true) } ?: default(value)
 
         private fun default(externalValue: String?): AnonymUttakGradSpecV1 =
-            if (StringUtils.hasLength(externalValue))
-                P_100.also { log.warn { "Unknown AnonymUttakGradSpec: '$externalValue'" } }
+            if (hasLength(externalValue))
+                HUNDRE_PROSENT.also { log.warn { "Unknown AnonymUttakGradSpec: '$externalValue'" } }
             else
-                P_100
+                HUNDRE_PROSENT
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/acl/v4/AlderspensjonSpecV4.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/acl/v4/AlderspensjonSpecV4.kt
@@ -1,5 +1,7 @@
 package no.nav.pensjon.simulator.alderspensjon.api.tpo.direct.acl.v4
 
+import no.nav.pensjon.simulator.person.Pid.Companion.redact
+
 /**
  * Version 4 of specification for 'simuler alderspensjon'.
  * NB: Versions 1 to 3 are services offered by PEN.
@@ -15,15 +17,16 @@ data class AlderspensjonSpecV4(
     val rettTilAfpOffentligDato: String? = null
 ) {
     /**
-     * toString excluding personId
+     * toString with redacted person ID
      */
-    override fun toString(): String =
-        "gradertUttak: $gradertUttak\n" +
-                "heltUttakFraOgMedDato: $heltUttakFraOgMedDato\n" +
-                "aarIUtlandetEtter16: $aarIUtlandetEtter16\n" +
-                "epsPensjon: $epsPensjon\n" +
-                "eps2G: $eps2G\n" +
-                "fremtidigInntektListe: $fremtidigInntektListe,\n" +
+    override fun toString() =
+        "personId: ${redact(personId)}, " +
+                "gradertUttak: $gradertUttak, " +
+                "heltUttakFraOgMedDato: $heltUttakFraOgMedDato, " +
+                "aarIUtlandetEtter16: $aarIUtlandetEtter16, " +
+                "epsPensjon: $epsPensjon, " +
+                "eps2G: $eps2G, " +
+                "fremtidigInntektListe: $fremtidigInntektListe, " +
                 "rettTilAfpOffentligDato: $rettTilAfpOffentligDato"
 }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/viapen/acl/v3/TpoSimuleringSpecV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/viapen/acl/v3/TpoSimuleringSpecV3.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import no.nav.pensjon.simulator.core.domain.SimuleringType
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.person.Pid.Companion.redact
 import java.time.LocalDate
 
 /**
@@ -29,17 +30,18 @@ data class TpoSimuleringSpecV3(
     val heltUttakDato: LocalDate? = null
 ) {
     /**
-     * toString excluding personId
+     * toString with redacted person ID
      */
-    override fun toString(): String =
-        "sivilstatus: $sivilstatus\n" +
-                "epsPensjon: $epsPensjon\n" +
-                "eps2G: $eps2G\n" +
-                "utenlandsopphold: $utenlandsopphold\n" +
-                "simuleringType: $simuleringType\n" +
-                "fremtidigInntektList: $fremtidigInntektList,\n" +
-                "foersteUttakDato: $foersteUttakDato,\n" +
-                "uttakGrad: $uttakGrad,\n" +
+    override fun toString() =
+        "pid: ${redact(pid)}, " +
+                "sivilstatus: $sivilstatus, " +
+                "epsPensjon: $epsPensjon, " +
+                "eps2G: $eps2G, " +
+                "utenlandsopphold: $utenlandsopphold, " +
+                "simuleringType: $simuleringType, " +
+                "fremtidigInntektList: $fremtidigInntektList, " +
+                "foersteUttakDato: $foersteUttakDato, " +
+                "uttakGrad: $uttakGrad, " +
                 "heltUttakDato: $heltUttakDato"
 }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
@@ -84,7 +84,8 @@ object SimulatorOutputConverter {
         SimulertAlderspensjonFraFolketrygden(
             datoFom = source.datoFom ?: LocalDate.MIN,
             delytelseListe = delytelser(source),
-            uttakGrad = source.uttakGrad?.toInt() ?: 0
+            uttakGrad = source.uttakGrad?.toInt() ?: 0,
+            maanedligBeloep = source.maanedligBeloep ?: 0
         )
 
     // SimulerAlderspensjonResponseV3Converter.getDelytelserFromSimulertBeregningsinformasjon

--- a/src/main/kotlin/no/nav/pensjon/simulator/common/api/ControllerBase.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/common/api/ControllerBase.kt
@@ -109,18 +109,6 @@ abstract class ControllerBase(
         log.error { "$category ${errorMessage()} : ${extractMessageRecursively(e)}" }
     }
 
-    private fun extractMessageRecursively(ex: Throwable): String {
-        val builder = StringBuilder()
-        builder.append(ex.message)
-
-        if (ex.cause == null) {
-            return builder.toString()
-        }
-
-        builder.append(" | Cause: ").append(extractMessageRecursively(ex.cause!!))
-        return builder.toString()
-    }
-
     protected companion object {
         val NAV_ORG_NUMMER = Organisasjonsnummer("889640782")
 
@@ -132,5 +120,17 @@ abstract class ControllerBase(
     "message": "En feil inntraff",
     "path": "/api/ressurs"
 }"""
+
+        fun extractMessageRecursively(ex: Throwable): String {
+            val builder = StringBuilder()
+            builder.append(ex.message)
+
+            if (ex.cause == null) {
+                return builder.toString()
+            }
+
+            builder.append(" | Cause: ").append(extractMessageRecursively(ex.cause!!))
+            return builder.toString()
+        }
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/ForUngForSimuleringException.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/ForUngForSimuleringException.kt
@@ -1,6 +1,0 @@
-package no.nav.pensjon.simulator.core.afp.offentlig.pre2025
-
-// PEN019ForUngForSimuleringException
-class ForUngForSimuleringException : RuntimeException{
-    constructor(message: String): super(message)
-}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/Pre2025OffentligAfpBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/Pre2025OffentligAfpBeregner.kt
@@ -22,10 +22,12 @@ import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresulta
 import no.nav.pensjon.simulator.core.domain.regler.to.SimuleringRequest
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import no.nav.pensjon.simulator.core.exception.FeilISimuleringsgrunnlagetException
+import no.nav.pensjon.simulator.core.exception.PersonForUngException
 import no.nav.pensjon.simulator.core.exception.RegelmotorFeilException
 import no.nav.pensjon.simulator.core.exception.RegelmotorValideringException
 import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableException
 import no.nav.pensjon.simulator.core.exception.KanIkkeBeregnesException
+import no.nav.pensjon.simulator.core.exception.KonsistensenIGrunnlagetErFeilException
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getRelativeDateByMonth
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
@@ -100,8 +102,6 @@ class Pre2025OffentligAfpBeregner(
             // For this reason the Exception is packaged in a RuntimeException, which will be explicitly catch by the service
             // using this command. This service will unpack the original exception and throw it, accordingly to the intended
             // design.
-            //val cause = PEN240VilkarsprovingAvAFPOffentligErAvslattException(simuleringsresultat.merknadListe.map(SimulatorContext.Companion::mapMerknadToPen))
-            //throw InternalSimuleringVilkarsprovingAvAFPOffentligErAvslattException(cause)
             throw Pre2025OffentligAfpAvslaattException(simuleringResultat.merknadListe.joinToString(", "))
         }
 
@@ -116,7 +116,7 @@ class Pre2025OffentligAfpBeregner(
     ): Simuleringsresultat =
         try {
             simulerPensjonsberegning(simulering(spec, persongrunnlagListe), normAlder)
-        } catch (e: ForUngForSimuleringException) {
+        } catch (e: PersonForUngException) {
             throw RegelmotorFeilException(e.message)
         } catch (e: KonsistensenIGrunnlagetErFeilException) {
             throw RegelmotorFeilException(e.message)
@@ -589,13 +589,13 @@ class Pre2025OffentligAfpBeregner(
 
             if (SimuleringTypeEnum.ALDER.name == simuleringTypeKode) {
                 if (alder < normAlder.aar || alder == normAlder.aar && uttakMaaned <= foedselMaaned) {
-                    throw ForUngForSimuleringException("Alderspensjon;${normAlder.aar};0")
+                    throw PersonForUngException("Alderspensjon;${normAlder.aar};0")
                 }
             }
 
             if (SimuleringTypeEnum.AFP.name == simuleringTypeKode) {
                 if (alder < AFP_MIN_AGE || alder == AFP_MIN_AGE && uttakMaaned <= foedselMaaned) {
-                    throw ForUngForSimuleringException("AFP;$AFP_MIN_AGE;0")
+                    throw PersonForUngException("AFP;$AFP_MIN_AGE;0")
                 }
             }
         }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/privat/PrivatAfpBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/privat/PrivatAfpBeregner.kt
@@ -2,12 +2,12 @@ package no.nav.pensjon.simulator.core.afp.privat
 
 import no.nav.pensjon.simulator.core.SimulatorContext
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.SakType
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsResultatAfpPrivat
 import no.nav.pensjon.simulator.core.domain.regler.enum.AFPtypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.KravlinjeTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.VedtakResultatEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Opptjeningsgrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
@@ -235,7 +235,7 @@ class PrivatAfpBeregner(
                 kravlinjeTypeEnum = KravlinjeTypeEnum.AFP_PRIVAT
                 relatertPerson = person
                 kravlinjeStatus = KravlinjeStatus.VILKARSPROVD
-                land = Land.NOR
+                land = LandkodeEnum.NOR
             }
 
         /**

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beholdning/BeholdningUpdater.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beholdning/BeholdningUpdater.kt
@@ -48,6 +48,7 @@ import no.nav.pensjon.simulator.core.domain.regler.satstabeller.SatsResultat
 import no.nav.pensjon.simulator.core.domain.regler.to.HentGyldigSatsRequest
 import no.nav.pensjon.simulator.core.domain.regler.to.RegulerPensjonsbeholdningRequest
 import no.nav.pensjon.simulator.core.domain.regler.to.SatsResponse
+import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableException
 import no.nav.pensjon.simulator.core.exception.KanIkkeBeregnesException
 import no.nav.pensjon.simulator.core.exception.RegelmotorValideringException
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.createDate
@@ -118,17 +119,9 @@ class BeholdningUpdater(
         try {
             persongrunnlag?.let { context.beregnOpptjening(beholdningTom, it, forrigeBeholdning) } ?: mutableListOf()
         } catch (e: KanIkkeBeregnesException) {
-            //throw ImplementationUnrecoverableException("The rules engine cannot calculate input for personId:" + persongrunnlag?.penPerson?.penPersonId, e)
-            throw RuntimeException(
-                "The rules engine cannot calculate input for personId:" + persongrunnlag?.penPerson?.penPersonId,
-                e
-            )
+            throw ImplementationUnrecoverableException("The rules engine cannot calculate input for personId:" + persongrunnlag?.penPerson?.penPersonId, e)
         } catch (e: RegelmotorValideringException) {
-            //throw ImplementationUnrecoverableException(("The rules engine cannot calculate input for personId:" + persongrunnlag?.penPerson?.penPersonId), e)
-            throw RuntimeException(
-                ("The rules engine cannot calculate input for personId:" + persongrunnlag?.penPerson?.penPersonId),
-                e
-            )
+            throw ImplementationUnrecoverableException(("The rules engine cannot calculate input for personId:" + persongrunnlag?.penPerson?.penPersonId), e)
         }
 
     // OppdaterPensjonsbeholdningerHelper.hentGyldigSats
@@ -143,8 +136,7 @@ class BeholdningUpdater(
         sisteGyldigeOpptjeningAar: String
     ): Persongrunnlag {
         if (opptjeningModus != INITIERING_OPPTJENINGMODUS && beregningGrunnlag.ufoerFoer2009) {
-            //throw ImplementationUnrecoverableException(
-            throw RuntimeException(
+            throw ImplementationUnrecoverableException(
                 "Invalid combination with opptjeningModus: $opptjeningModus with UforFoer2009 is TRUE."
             )
         }
@@ -255,8 +247,7 @@ class BeholdningUpdater(
                 val beholdning = beregningsgrunnlag.beholdning
 
                 if (beholdning?.ar?.let { it < OPPTJENING_MINIMUM_AAR } == true) {
-                    //throw ImplementationUnrecoverableException("berGrForPensjonsbeholdning.beholdning.ar er FØR 2010")
-                    throw RuntimeException("berGrForPensjonsbeholdning.beholdning.ar er FØR 2010")
+                    throw ImplementationUnrecoverableException("berGrForPensjonsbeholdning.beholdning.ar er FØR 2010")
                 } else if (verifyEmptyBeholdningAndGrunnlag(beholdning, persongrunnlag)) {
                     personBeholdning = newPersonbeholdning(beregningsgrunnlag.pid, sisteGyldigeOpptjeningAar)
 
@@ -284,8 +275,7 @@ class BeholdningUpdater(
 
                 // Sjekk at beholdning er oppdatert for bruker
                 if (personBeholdning == null) {
-                    //throw ImplementationUnrecoverableException("The user exists but the pensjonsbeholdning has not been updated.")
-                    throw RuntimeException("The user exists but the pensjonsbeholdning has not been updated.")
+                    throw ImplementationUnrecoverableException("The user exists but the pensjonsbeholdning has not been updated.")
                 }
 
                 personBeholdningListe.add(personBeholdning)
@@ -500,17 +490,9 @@ class BeholdningUpdater(
             // DefaultBeregningConsumerService.regulerPensjonsbeholdning -> RegulerPensjonsbeholdningConsumerCommand.execute
             return context.regulerPensjonsbeholdning(request).regulertBeregningsgrunnlagForPensjonsbeholdning.toList()
         } catch (e: KanIkkeBeregnesException) {
-            //throw ImplementationUnrecoverableException("The rules engine cannot calculate input for beholdning: " + personPensjonsbeholdning?.pensjonsbeholdning, e)
-            throw RuntimeException(
-                "The rules engine cannot calculate input for beholdning: " + personPensjonsbeholdning?.pensjonsbeholdning,
-                e
-            )
+            throw ImplementationUnrecoverableException("The rules engine cannot calculate input for beholdning: " + personPensjonsbeholdning?.pensjonsbeholdning, e)
         } catch (e: RegelmotorValideringException) {
-            //throw ImplementationUnrecoverableException("The rules engine cannot calculate input for beholdning: " + personPensjonsbeholdning?.pensjonsbeholdning, e)
-            throw RuntimeException(
-                "The rules engine cannot calculate input for beholdning: " + personPensjonsbeholdning?.pensjonsbeholdning,
-                e
-            )
+            throw ImplementationUnrecoverableException("The rules engine cannot calculate input for beholdning: " + personPensjonsbeholdning?.pensjonsbeholdning, e)
         }
     }
 
@@ -577,11 +559,9 @@ class BeholdningUpdater(
                 context.regulerPensjonsbeholdning(regulerPensjonsbeholdningConsumerRequest).regulertBeregningsgrunnlagForPensjonsbeholdning
             if (regulertBeholdningListe.isEmpty()) null else regulertBeholdningListe[0].pensjonsbeholdning
         } catch (e: KanIkkeBeregnesException) {
-            //throw ImplementationUnrecoverableException(CALL_TO_PREG_FAILED, e)
-            throw RuntimeException(CALL_TO_PREG_FAILED, e)
+            throw ImplementationUnrecoverableException(CALL_TO_PREG_FAILED, e)
         } catch (e: RegelmotorValideringException) {
-            //throw ImplementationUnrecoverableException(CALL_TO_PREG_FAILED, e)
-            throw RuntimeException(CALL_TO_PREG_FAILED, e)
+            throw ImplementationUnrecoverableException(CALL_TO_PREG_FAILED, e)
         }
 
         regulertBeholdning?.fom = kravhode.onsketVirkningsdato

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregner.kt
@@ -5,7 +5,6 @@ import no.nav.pensjon.simulator.core.SimulatorContext
 import no.nav.pensjon.simulator.core.afp.offentlig.livsvarig.LivsvarigOffentligAfpYtelseMedDelingstall
 import no.nav.pensjon.simulator.core.beholdning.BeholdningType
 import no.nav.pensjon.simulator.core.beregn.PeriodiseringUtil.periodiserGrunnlagAndModifyKravhode
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.SimuleringType
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
@@ -543,7 +542,7 @@ class AlderspensjonVilkaarsproeverOgBeregner(
         ) {
             vedtakListe.forEach {
                 it.kravlinje!!.kravlinjeStatus = KravlinjeStatus.VILKARSPROVD
-                it.kravlinje!!.land = Land.NOR
+                it.kravlinje!!.land = LandkodeEnum.NOR
                 it.vilkarsvedtakResultatEnum = it.anbefaltResultatEnum
 
                 val localFoersteVirk: LocalDate =
@@ -561,7 +560,7 @@ class AlderspensjonVilkaarsproeverOgBeregner(
 
             kravhode.kravlinjeListe.forEach {
                 it.kravlinjeStatus = KravlinjeStatus.VILKARSPROVD
-                it.land = Land.NOR
+                it.land = LandkodeEnum.NOR
             }
         }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreator.kt
@@ -1,8 +1,8 @@
 package no.nav.pensjon.simulator.core.beregn
 
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.SisteBeregning
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.RegelverkTypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.VedtakResultatEnum
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
@@ -174,7 +174,7 @@ class SisteBeregningCreator(
 
         // FiltrerVilkarsvedtakCommand.isKravlinjeNor
         private fun isNorsk(kravlinje: Kravlinje?): Boolean =
-            Land.NOR == kravlinje?.land
+            LandkodeEnum.NOR == kravlinje?.land
 
         // FiltrerVilkarsvedtakCommand.isVirkFomBeforeFomDate
         private fun isVirkFomBeforeDate(virkFom: Date?, date: Date): Boolean =

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/Land.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/Land.kt
@@ -1,7 +1,0 @@
-package no.nav.pensjon.simulator.core.domain
-
-//TODO
-enum class Land {
-    AUS,
-    NOR
-}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/krav/Kravhode.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/krav/Kravhode.kt
@@ -1,7 +1,6 @@
 package no.nav.pensjon.simulator.core.domain.regler.krav
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.SakType
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
 import no.nav.pensjon.simulator.core.domain.regler.enum.*
@@ -187,7 +186,7 @@ open class Kravhode {
         var hovedKravlinje: Kravlinje? = null
 
         for (linje in kravlinjeListe) {
-            val erNorge = linje.land == Land.NOR
+            val erNorge = linje.land == LandkodeEnum.NOR
 
             if (linje.erHovedkravlinje() && (erNorge || kunUtland(kravGjelder))) {
                 if (hovedKravlinje == null || !linje.isKravlinjeAvbrutt()) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/krav/Kravlinje.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/krav/Kravlinje.kt
@@ -1,9 +1,9 @@
 package no.nav.pensjon.simulator.core.domain.regler.krav
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
 import no.nav.pensjon.simulator.core.domain.regler.enum.KravlinjeTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.kode.KravlinjeTypeCti
 import no.nav.pensjon.simulator.core.krav.KravlinjeStatus
 import java.io.Serializable
@@ -48,7 +48,7 @@ open class Kravlinje : Serializable {
     var kravlinjeStatus: KravlinjeStatus? = null
 
     @JsonIgnore
-    var land: Land? = null
+    var land: LandkodeEnum? = null
 
     constructor(kravlinje: Kravlinje) {
         kravlinje.kravlinjeTypeEnum?.let { kravlinjeTypeEnum = it }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/exception/FeilISimuleringsgrunnlagetException.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/exception/FeilISimuleringsgrunnlagetException.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.simulator.core.exception
 
 // PEN071FeilISimuleringsgrunnlagetException
+// Can be replaced by KanIkkeBeregnesException?
 class FeilISimuleringsgrunnlagetException : RuntimeException {
     constructor(cause: Throwable) : super(cause)
     constructor(message: String) : super(message)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/exception/ImplementationUnrecoverableException.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/exception/ImplementationUnrecoverableException.kt
@@ -4,4 +4,5 @@ package no.nav.pensjon.simulator.core.exception
 class ImplementationUnrecoverableException : RuntimeException {
     constructor(message: String) : super(message)
     constructor(cause: Throwable) : super(cause)
+    constructor(message: String, cause: Throwable) : super(message, cause)
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/exception/KonsistensenIGrunnlagetErFeilException.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/exception/KonsistensenIGrunnlagetErFeilException.kt
@@ -1,4 +1,5 @@
-package no.nav.pensjon.simulator.core.afp.offentlig.pre2025
+package no.nav.pensjon.simulator.core.exception
 
 // PEN070KonsistensenIGrunnlagetErFeilException
+// Can be replaced by RegelmotorValideringException?
 class KonsistensenIGrunnlagetErFeilException(e: Throwable) : RuntimeException(e)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/exception/PersonForUngException.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/exception/PersonForUngException.kt
@@ -1,0 +1,6 @@
+package no.nav.pensjon.simulator.core.exception
+
+// PEN019ForUngForSimuleringException
+class PersonForUngException : RuntimeException{
+    constructor(message: String): super(message)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravUtil.kt
@@ -1,8 +1,10 @@
 package no.nav.pensjon.simulator.core.krav
 
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.tech.time.DateUtil.MAANEDER_PER_AAR
 import no.nav.pensjon.simulator.tech.time.DateUtil.maanederInnenforAaret
 import no.nav.pensjon.simulator.tech.time.DateUtil.maanederInnenforRestenAvAaret
+import java.time.LocalDate
 
 object KravUtil {
 
@@ -21,5 +23,43 @@ object KravUtil {
         spec.utlandPeriodeListe.maxOfOrNull {
             maanederInnenforRestenAvAaret(it.fom, it.tom, spec.foersteUttakDato!!)
         } ?: 0
+
+    /**
+     * Finner antall hele måneder utenlands i perioden fra første dag i uttaksåret til første uttaksdato.
+     */
+    fun utlandMaanederFraAarStartTilFoersteUttakDato(spec: SimuleringSpec): Int =
+        spec.utlandPeriodeListe.maxOfOrNull {
+            maanederInnenforAarStartTilDato(it.fom, it.tom, spec.foersteUttakDato!!)
+        } ?: 0
+
+    /**
+     * Gitt en dato (dd.mm.yyyy), returneres antall hele måneder i perioden f.o.m.-t.o.m. som overlapper med perioden 01.01.yyyy-dd.mm.yyyy.
+     * T.o.m.-datoen kan være udefinert (dvs. periode uten slutt).
+     */
+    private fun maanederInnenforAarStartTilDato(fom: LocalDate, nullableTom: LocalDate?, dato: LocalDate): Int {
+        val aaretsFoersteDag = foersteDagAv(dato.year)
+        val tom = nullableTom ?: sisteDagAv(dato.year)
+        if (tom.year < dato.year || fom.isAfter(dato)) return 0
+
+        val periodisertFom: LocalDate = aaretsFoersteDag.let { if (fom.isBefore(it)) it else fom }
+        val periodisertTom: LocalDate = dato.let { if (it.isBefore(tom)) it else tom }
+
+        return maaneder(
+            fom = periodisertFom,
+            til = periodisertTom.plusDays(1) // til (men ikke med) = dagen etter til-og-med
+        )
+    }
+
+    /**
+     * Finner antall hele måneder i perioden fra og med (fom) en gitt dato til (men ikke med) en annen gitt dato.
+     */
+    private fun maaneder(fom: LocalDate, til: LocalDate): Int {
+        val maanedDiff: Int = MAANEDER_PER_AAR * (til.year - fom.year) + til.monthValue - fom.monthValue
+        return if (fom.dayOfMonth > til.dayOfMonth) maanedDiff - 1 else maanedDiff // delvis måned teller ikke med
+    }
+
+    private fun foersteDagAv(aar: Int) = LocalDate.of(aar, 1, 1)
+
+    private fun sisteDagAv(aar: Int) = LocalDate.of(aar, 12, 31)
 }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeCreator.kt
@@ -7,7 +7,6 @@ import no.nav.pensjon.simulator.core.beholdning.BeholdningUpdater
 import no.nav.pensjon.simulator.core.beholdning.BeholdningUtil.SISTE_GYLDIGE_OPPTJENING_AAR
 import no.nav.pensjon.simulator.core.beregn.InntektType
 import no.nav.pensjon.simulator.core.domain.GrunnlagKilde
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.SakType
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
@@ -26,8 +25,8 @@ import no.nav.pensjon.simulator.core.endring.EndringUttakGrad
 import no.nav.pensjon.simulator.core.exception.FeilISimuleringsgrunnlagetException
 import no.nav.pensjon.simulator.core.exception.PersonForGammelException
 import no.nav.pensjon.simulator.core.inntekt.InntektUtil.faktiskAarligInntekt
+import no.nav.pensjon.simulator.core.krav.KravUtil.utlandMaanederFraAarStartTilFoersteUttakDato
 import no.nav.pensjon.simulator.core.krav.KravUtil.utlandMaanederInnenforAaret
-import no.nav.pensjon.simulator.core.krav.KravUtil.utlandMaanederInnenforRestenAvAaret
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getRelativeDateByDays
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getRelativeDateByYear
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getYear
@@ -581,16 +580,12 @@ class KravhodeCreator(
         return 0
     }
 
-    //TODO change this according to change in PEN
     private fun forventetInntektAntallMaaneder(aar: Int, spec: SimuleringSpec): Int {
         val foersteUttakAar: Int = spec.foersteUttakDato?.year ?: 0
 
         return when {
             aar < foersteUttakAar -> MAANEDER_PER_AAR - utlandMaanederInnenforAaret(spec, aar)
-            aar == foersteUttakAar -> monthOfYearRange1To12(spec.foersteUttakDato!!) - 1 - utlandMaanederInnenforRestenAvAaret(
-                spec
-            )
-
+            aar == foersteUttakAar -> monthOfYearRange1To12(spec.foersteUttakDato!!) - 1 - utlandMaanederFraAarStartTilFoersteUttakDato(spec)
             else -> 0
         }
     }
@@ -840,7 +835,7 @@ class KravhodeCreator(
         private fun norskKravlinje(kravlinjeType: KravlinjeTypeEnum, person: PenPerson) =
             Kravlinje(kravlinjeTypeEnum = kravlinjeType, relatertPerson = person).apply {
                 kravlinjeStatus = KravlinjeStatus.VILKARSPROVD
-                land = Land.NOR
+                land = LandkodeEnum.NOR
             }
 
         private fun opptjeningsgrunnlag(inntekt: Inntekt) =
@@ -870,7 +865,7 @@ class KravhodeCreator(
                 antallAarUtenlands > 0
 
         private fun containsTrygdetidUtenlands(trygdetidPeriodeListe: List<TTPeriode>) =
-            trygdetidPeriodeListe.any { it.land!!.kode != Land.NOR.name }
+            trygdetidPeriodeListe.any { it.land!!.kode != LandkodeEnum.NOR.name }
 
         private fun erGradertUttak(spec: SimuleringSpec) = spec.uttakGrad != UttakGradKode.P_100
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/InngangOgEksportGrunnlagFactory.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/InngangOgEksportGrunnlagFactory.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.simulator.core.trygd
 
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.regler.TTPeriode
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.InngangOgEksportGrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
@@ -44,6 +44,6 @@ object InngangOgEksportGrunnlagFactory {
 
     private fun trygetidMillisekunder(periodeListe: List<TTPeriode>) =
         periodeListe
-            .filter { it.land!!.kode == Land.NOR.name }
+            .filter { it.land!!.kode == LandkodeEnum.NOR.name }
             .sumOf { it.tom!!.time - it.fom!!.time }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdeavtaleFactory.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdeavtaleFactory.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.trygd
 
-import no.nav.pensjon.simulator.core.domain.Land
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Trygdeavtale
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Trygdeavtaledetaljer
 import no.nav.pensjon.simulator.core.domain.regler.kode.AvtaleDatoCti
@@ -19,7 +19,7 @@ object TrygdeavtaleFactory {
             avtaledato = latestAvtaleDato()?.let { AvtaleDatoCti(it.name) }
             avtaleKriterie = AvtaleKritCti(AvtaleKrit.YRK_TRYGD.name)
             avtaleType = AvtaleTypeCti(AvtaleType.EOS_NOR.name)
-            bostedsland = LandCti(Land.NOR.name)
+            bostedsland = LandCti(LandkodeEnum.NOR.name)
             kravDatoIAvtaleland = Date()
             omfattesavAvtalensPersonkrets = true
             //TODO minst12MndMedlemskapFolketrygden = true

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdetidOpptjeningRettLand.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdetidOpptjeningRettLand.kt
@@ -1,59 +1,56 @@
 package no.nav.pensjon.simulator.core.trygd
 
-import no.nav.pensjon.simulator.core.domain.Land
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import java.util.*
 
-// no.nav.service.pensjon.simulering.support.command.LandMedRettTilOpptjeningAvTrygdetidCode
-enum class TrygdetidOpptjeningRettLand(val land: Land, val kravOmArbeid: Boolean) {
-    /* TODO
+// PEN: no.nav.service.pensjon.simulering.support.command.LandMedRettTilOpptjeningAvTrygdetidCode
+enum class TrygdetidOpptjeningRettLand(val land: LandkodeEnum, val kravOmArbeid: Boolean) {
     // Nederland + nordisk konvensjon
-    NLD(Land.NLD, false),
-    SWE(Land.SWE, false),
-    DNK(Land.DNK, false),
-    FIN(Land.FIN, false),
-    FRO(Land.FRO, false),
-    GRL(Land.GRL, false),
-    ISL(Land.ISL, false),
+    NLD(land = LandkodeEnum.NLD, kravOmArbeid = false),
+    SWE(land = LandkodeEnum.SWE, kravOmArbeid = false),
+    DNK(land = LandkodeEnum.DNK, kravOmArbeid = false),
+    FIN(land = LandkodeEnum.FIN, kravOmArbeid = false),
+    FRO(land = LandkodeEnum.FRO, kravOmArbeid = false),
+    GRL(land = LandkodeEnum.GRL, kravOmArbeid = false),
+    ISL(land = LandkodeEnum.ISL, kravOmArbeid = false),
 
     // EØS-land
-    BEL(Land.BEL, true),
-    BGR(Land.BGR, true),
-    EST(Land.EST, true),
-    FRA(Land.FRA, true),
-    GRC(Land.GRC, true),
-    IRL(Land.IRL, true),
-    ITA(Land.ITA, true),
-    CYP(Land.CYP, true),
-    HRV(Land.HRV, true),
-    LVA(Land.LVA, true),
-    LTU(Land.LTU, true),
-    LUX(Land.LUX, true),
-    MLT(Land.MLT, true),
-    POL(Land.POL, true),
-    PRT(Land.PRT, true),
-    ROU(Land.ROU, true),
-    SVK(Land.SVK, true),
-    SVN(Land.SVN, true),
-    ESP(Land.ESP, true),
-    GBR(Land.GBR, true),
-    CZE(Land.CZE, true),
-    DEU(Land.DEU, true),
-    HUN(Land.HUN, true),
-    AUT(Land.AUT, true),
+    BEL(land = LandkodeEnum.BEL, kravOmArbeid = true),
+    BGR(land = LandkodeEnum.BGR, kravOmArbeid = true),
+    EST(land = LandkodeEnum.EST, kravOmArbeid = true),
+    FRA(land = LandkodeEnum.FRA, kravOmArbeid = true),
+    GRC(land = LandkodeEnum.GRC, kravOmArbeid = true),
+    IRL(land = LandkodeEnum.IRL, kravOmArbeid = true),
+    ITA(land = LandkodeEnum.ITA, kravOmArbeid = true),
+    CYP(land = LandkodeEnum.CYP, kravOmArbeid = true),
+    HRV(land = LandkodeEnum.HRV, kravOmArbeid = true),
+    LVA(land = LandkodeEnum.LVA, kravOmArbeid = true),
+    LTU(land = LandkodeEnum.LTU, kravOmArbeid = true),
+    LUX(land = LandkodeEnum.LUX, kravOmArbeid = true),
+    MLT(land = LandkodeEnum.MLT, kravOmArbeid = true),
+    POL(land = LandkodeEnum.POL, kravOmArbeid = true),
+    PRT(land = LandkodeEnum.PRT, kravOmArbeid = true),
+    ROU(land = LandkodeEnum.ROU, kravOmArbeid = true),
+    SVK(land = LandkodeEnum.SVK, kravOmArbeid = true),
+    SVN(land = LandkodeEnum.SVN, kravOmArbeid = true),
+    ESP(land = LandkodeEnum.ESP, kravOmArbeid = true),
+    GBR(land = LandkodeEnum.GBR, kravOmArbeid = true),
+    CZE(land = LandkodeEnum.CZE, kravOmArbeid = true),
+    DEU(land = LandkodeEnum.DEU, kravOmArbeid = true),
+    HUN(land = LandkodeEnum.HUN, kravOmArbeid = true),
+    AUT(land = LandkodeEnum.AUT, kravOmArbeid = true),
 
     // Øvrige
-    USA(Land.USA, true),
-    CHL(Land.CHL, true),
-    ISR(Land.ISR, true),
-    AUS(Land.AUS, true),
-    CAN(Land.CAN, true),
-    CHE(Land.CHE, true),
-    IND(Land.IND, true)
-    */
-    NOR(Land.NOR, true);
+    USA(land = LandkodeEnum.USA, kravOmArbeid = true),
+    CHL(land = LandkodeEnum.CHL, kravOmArbeid = true),
+    ISR(land = LandkodeEnum.ISR, kravOmArbeid = true),
+    AUS(land = LandkodeEnum.AUS, kravOmArbeid = true),
+    CAN(land = LandkodeEnum.CAN, kravOmArbeid = true),
+    CHE(land = LandkodeEnum.CHE, kravOmArbeid = true),
+    IND(land = LandkodeEnum.IND, kravOmArbeid = true);
 
     companion object {
-        fun rettTilOpptjeningAvTrygdetid(land: Land?, harArbeidet: Boolean): Boolean {
+        fun rettTilOpptjeningAvTrygdetid(land: LandkodeEnum?, harArbeidet: Boolean): Boolean {
             if (mapper == null) {
                 initMapper()
             }
@@ -61,13 +58,13 @@ enum class TrygdetidOpptjeningRettLand(val land: Land, val kravOmArbeid: Boolean
             return mapper!!.containsKey(land) && (harArbeidet || !mapper!![land]?.kravOmArbeid!!)
         }
 
-        private var mapper: MutableMap<Land, TrygdetidOpptjeningRettLand>? = null
+        private var mapper: MutableMap<LandkodeEnum, TrygdetidOpptjeningRettLand>? = null
 
         private fun initMapper() {
-            mapper = EnumMap(Land::class.java)
+            mapper = EnumMap(LandkodeEnum::class.java)
 
             @OptIn(ExperimentalStdlibApi::class)
-            for (entry in TrygdetidOpptjeningRettLand.entries) {
+            for (entry in entries) {
                 mapper!![entry.land] = entry
             }
         }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdetidTrimmer.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/trygd/TrygdetidTrimmer.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.simulator.core.trygd
 
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.regler.TTPeriode
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getLastDateInYear
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getRelativeDateByDays
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getRelativeDateByYear
@@ -46,11 +46,11 @@ object TrygdetidTrimmer {
             .map { it.periode }
 
     private fun isOppholdINorge(grunnlag: TrygdetidOpphold) =
-        Land.NOR.name == grunnlag.periode.land?.kode
+        LandkodeEnum.NOR.name == grunnlag.periode.land?.kode
 
     private fun isOpptjeningIUtland(grunnlag: TrygdetidOpphold) =
         TrygdetidOpptjeningRettLand.rettTilOpptjeningAvTrygdetid(
-            land = grunnlag.periode.land?.kode?.let(Land::valueOf),
+            land = grunnlag.periode.land?.kode?.let(LandkodeEnum::valueOf),
             harArbeidet = grunnlag.arbeidet
         )
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenKravhodeMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenKravhodeMapper.kt
@@ -1,6 +1,5 @@
 package no.nav.pensjon.simulator.krav.client.pen.acl
 
-import no.nav.pensjon.simulator.core.domain.Land
 import no.nav.pensjon.simulator.core.domain.SakType
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
 import no.nav.pensjon.simulator.core.domain.regler.enum.*
@@ -73,7 +72,7 @@ object PenKravhodeMapper {
         Kravlinje().apply {
             kravlinjeStatus = source.kravlinjeStatus
             kravlinjeType = source.kravlinjeType
-            land = source.land?.let { Land.valueOf(it.name) } //TODO use LandkodeEnum instead of Land?
+            land = source.land?.let { LandkodeEnum.valueOf(it.name) }
             relatertPerson = source.relatertPerson?.let(::penPerson)
         }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/person/Pid.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/person/Pid.kt
@@ -5,24 +5,27 @@ package no.nav.pensjon.simulator.person
  */
 class Pid(argument: String) {
 
-    val isValid = argument.length == FNR_LENGTH
+    val isValid = argument.length == FOEDSELSNUMMER_LENGTH
     val value = if (isValid) argument else "invalid"
-    val displayValue = if (isValid) value.substring(0, PERSONNUMMER_START_INDEX) + "*****" else value
+    val displayValue = redact(value)
 
-    override fun toString(): String {
-        return displayValue
-    }
+    override fun toString(): String = displayValue
 
-    override fun hashCode(): Int {
-        return value.hashCode()
-    }
+    override fun hashCode(): Int = value.hashCode()
 
-    override fun equals(other: Any?): Boolean {
-        return (other as? Pid)?.let { value == it.value } ?: false
-    }
+    override fun equals(other: Any?): Boolean =
+        (other as? Pid)?.let { value == it.value } == true
 
     companion object {
-        private const val FNR_LENGTH = 11
+        private const val FOEDSELSNUMMER_LENGTH = 11
         private const val PERSONNUMMER_START_INDEX = 6
+
+        fun redact(pid: String?): String =
+            pid?.let {
+                if (it.length == FOEDSELSNUMMER_LENGTH)
+                    it.substring(0, PERSONNUMMER_START_INDEX) + "*****"
+                else
+                    "?(${it.length})?"
+            } ?: "<null>"
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/regel/client/pensjonregler/PensjonReglerGenericRegelClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/regel/client/pensjonregler/PensjonReglerGenericRegelClient.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.simulator.regel.client.pensjonregler
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.pensjon.simulator.common.client.ExternalServiceClient
+import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableException
 import no.nav.pensjon.simulator.regel.client.GenericRegelClient
 import no.nav.pensjon.simulator.tech.security.egress.EgressAccess
 import no.nav.pensjon.simulator.tech.security.egress.config.EgressService
@@ -16,7 +17,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import java.util.Objects.requireNonNull
 
-// PensjonReglerRestConsumerService
+// PEN: PensjonReglerRestConsumerService
 @Component
 class PensjonReglerGenericRegelClient(
     @Value("\${ps.fss-gw.url}") baseUrl: String,
@@ -38,8 +39,7 @@ class PensjonReglerGenericRegelClient(
         return try {
             callPensjonRegler(serviceName, request, responseClass, map, sakId)
         } catch (e: Exception) {
-            //throw ImplementationUnrecoverableException("Request failed to pensjon-regler", e)
-            throw RuntimeException("$serviceName request failed to pensjon-regler", e)
+            throw ImplementationUnrecoverableException("Request failed to pensjon-regler", e)
         }
     }
 

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
@@ -1,0 +1,103 @@
+package no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.result
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.alderspensjon.alternativ.*
+import no.nav.pensjon.simulator.core.beholdning.OpptjeningGrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import java.time.LocalDate
+
+class NavSimuleringResultMapperV3Test : FunSpec({
+
+    test("toDto for gradert uttak med alternativ") {
+        NavSimuleringResultMapperV3.toDto(
+            SimulertPensjonEllerAlternativ(
+                pensjon = SimulertPensjon(
+                    alderspensjon = listOf(
+                        SimulertAarligAlderspensjon(
+                            alderAar = 65,
+                            beloep = 123,
+                            inntektspensjon = 234,
+                            garantipensjon = 345,
+                            delingstall = 1.2,
+                            pensjonBeholdningFoerUttak = 456
+                        )
+                    ),
+                    alderspensjonFraFolketrygden = listOf(
+                        SimulertAlderspensjonFraFolketrygden(
+                            datoFom = LocalDate.of(2021, 1, 1),
+                            delytelseListe = listOf(
+                                SimulertDelytelse(type = YtelseskomponentTypeEnum.GAP, beloep = 567)
+                            ),
+                            uttakGrad = 50,
+                            maanedligBeloep = 678
+                        )
+                    ),
+                    privatAfp = listOf(SimulertPrivatAfp(alderAar = 66, beloep = 789)),
+                    pre2025OffentligAfp = SimulertPre2025OffentligAfp(alderAar = 62, beloep = 890),
+                    livsvarigOffentligAfp = listOf(SimulertLivsvarigOffentligAfp(alderAar = 63, beloep = 901)),
+                    pensjonBeholdningPeriodeListe = listOf(
+                        SimulertPensjonBeholdningPeriode(
+                            pensjonBeholdning = 2.3,
+                            garantipensjonBeholdning = 3.4,
+                            garantitilleggBeholdning = 4.5,
+                            datoFom = LocalDate.of(2022, 2, 1),
+                            garantipensjonNivaa = SimulertGarantipensjonNivaa(
+                                beloep = 5.6,
+                                satsType = "sats1",
+                                sats = 6.7,
+                                anvendtTrygdetid = 40
+                            )
+                        )
+                    ),
+                    harUttak = true,
+                    harNokTrygdetidForGarantipensjon = true,
+                    trygdetid = 39,
+                    opptjeningGrunnlagListe = listOf(OpptjeningGrunnlag(aar = 1999, pensjonsgivendeInntekt = 1002))
+                ),
+                alternativ = SimulertAlternativ(
+                    gradertUttakAlder = SimulertUttakAlder(
+                        alder = Alder(aar = 66, maaneder = 2),
+                        uttakDato = LocalDate.of(2023, 3, 1),
+                    ),
+                    uttakGrad = UttakGradKode.P_20,
+                    heltUttakAlder = SimulertUttakAlder(
+                        alder = Alder(aar = 67, maaneder = 0),
+                        uttakDato = LocalDate.of(2024, 1, 1),
+                    ),
+                    resultStatus = SimulatorResultStatus.GOOD
+                )
+            )
+        ) shouldBe NavSimuleringResultV3(
+            alderspensjonListe = listOf(
+                NavAlderspensjonV3(
+                    alderAar = 65,
+                    beloep = 123,
+                    inntektspensjon = 234,
+                    garantipensjon = 345,
+                    delingstall = 1.2,
+                    pensjonBeholdningFoerUttak = 456
+                )
+            ),
+            alderspensjonMaanedsbeloep = NavMaanedsbeloepV3(
+                gradertUttakBeloep = 678,
+                heltUttakBeloep = 0 // since gradert uttak
+            ),
+            privatAfpListe = listOf(NavPrivatAfpV3(alderAar = 66, beloep = 789)),
+            livsvarigOffentligAfpListe = listOf(NavLivsvarigOffentligAfpV3(alderAar = 63, beloep = 901)),
+            vilkaarsproeving = NavVilkaarsproevingResultatV3(
+                vilkaarErOppfylt = false, // since alternativ exists
+                alternativ = NavAlternativtResultatV3(
+                    gradertUttakAlder = NavAlderV3(aar = 66, maaneder = 2),
+                    uttaksgrad = 20,
+                    heltUttakAlder = NavAlderV3(aar = 67, maaneder = 0),
+                )
+            ),
+            tilstrekkeligTrygdetidForGarantipensjon = true,
+            trygdetid = 39,
+            opptjeningGrunnlagListe = listOf(NavOpptjeningGrunnlagV3(aar = 1999, pensjonsgivendeInntektBeloep = 1002))
+        )
+    }
+})

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
@@ -39,7 +39,8 @@ class TpoAlderspensjonResultMapperTest : FunSpec({
                                 delytelseListe = listOf(
                                     SimulertDelytelse(type = YtelseskomponentTypeEnum.GAP, beloep = 1234)
                                 ),
-                                uttakGrad = 50
+                                uttakGrad = 50,
+                                maanedligBeloep = 321
                             )
                         ),
                         privatAfp = emptyList(),
@@ -60,7 +61,7 @@ class TpoAlderspensjonResultMapperTest : FunSpec({
 
         exception.message shouldBe "Ingen alderspensjon fra folketrygden funnet for f.o.m.-dato 2030-02-01 blant" +
                 " [SimulertAlderspensjonFraFolketrygden(datoFom=2030-01-02," +
-                " delytelseListe=[SimulertDelytelse(type=GAP, beloep=1234)], uttakGrad=50)]"
+                " delytelseListe=[SimulertDelytelse(type=GAP, beloep=1234)], uttakGrad=50, maanedligBeloep=321)]"
     }
 
     test("mapPensjonEllerAlternativ for innvilget should return alderspensjon result") {

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
@@ -50,7 +50,8 @@ class TpoAlderspensjonResultMapperTest : FunSpec({
                                     beloep = 1234
                                 )
                             ),
-                            uttakGrad = 50
+                            uttakGrad = 50,
+                            maanedligBeloep = 500
                         )
                     ),
                     privatAfp = listOf(

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/krav/KravUtilTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/krav/KravUtilTest.kt
@@ -2,10 +2,10 @@ package no.nav.pensjon.simulator.core.krav
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.domain.SimuleringType
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.trygd.UtlandPeriode
 import java.time.LocalDate
 
@@ -28,25 +28,42 @@ class KravUtilTest : FunSpec({
             simuleringSpecUtenUtlandPerioder()
         ) shouldBe 0
     }
+
+    test("utlandMaanederFraAarStartTilFoersteUttakDato bruker utenlandsperioden med mest overlapp") {
+        KravUtil.utlandMaanederFraAarStartTilFoersteUttakDato(
+            simuleringSpecMedOverlappendeUtlandPerioder()
+        ) shouldBe 6
+    }
+
+    test("utlandMaanederFraAarStartTilFoersteUttakDato returnerer 0 hvis ingen utenlandsperioder") {
+        KravUtil.utlandMaanederFraAarStartTilFoersteUttakDato(
+            simuleringSpecUtenUtlandPerioder()
+        ) shouldBe 0
+    }
 })
 
 private fun simuleringSpecUtenUtlandPerioder(): SimuleringSpec =
     simuleringSpec(mutableListOf())
 
+// 2 delvis overlappende utenlandsperioder, hver med delvis overlapp med uttaksperiode;
+// da skal det lengste overlappet (6 måneder) velges:
+// inntektsperiode før uttak =  1.jan.-31.juli
+// utland-periode 1          = 15.jan.-15.sept. => overlapp 15.jan.-31.juli = 6 måneder
+// utland-periode 2          = 15.mai -15.des.  => overlapp 15.mai.-31.juli = 2 måneder
 private fun simuleringSpecMedOverlappendeUtlandPerioder(): SimuleringSpec =
     simuleringSpec(
         // 2 delvis overlappende utenlandsperioder, hver med delvis overlapp med uttaksperiode;
         // da skal det lengste overlappet (4 måneder) velges:
         mutableListOf(
             UtlandPeriode(
-                fom = LocalDate.of(2001, 1, 15), // overlapper uttaksperiode 2001...
-                tom = LocalDate.of(2001, 9, 15), // ...1.aug.-15.sept. (1 hel måned)
+                fom = LocalDate.of(2001, 1, 15),
+                tom = LocalDate.of(2001, 9, 15),
                 land = LandkodeEnum.AUS,
                 arbeidet = false
             ),
             UtlandPeriode(
-                fom = LocalDate.of(2001, 5, 15), // overlapper uttaksperiode 2001...
-                tom = LocalDate.of(2001, 12, 15), // ...1.aug.-15.des. (4 hele måneder)
+                fom = LocalDate.of(2001, 5, 15),
+                tom = LocalDate.of(2001, 12, 15),
                 land = LandkodeEnum.AUS,
                 arbeidet = true
             )
@@ -58,7 +75,7 @@ private fun simuleringSpec(utlandPeriodeListe: MutableList<UtlandPeriode>) =
         type = SimuleringType.ALDER,
         sivilstatus = SivilstatusType.UGIF,
         epsHarPensjon = false,
-        foersteUttakDato = LocalDate.of(2001, 8, 1), // => uttaksperiode 2001 = 1.aug.-31.des.
+        foersteUttakDato = LocalDate.of(2001, 8, 1), // => uttaksperiode 2001 = 1.aug.-31.des., inntektsperiode før uttak = 1.jan.-31.juli
         heltUttakDato = null,
         pid = null,
         foedselDato = null,


### PR DESCRIPTION
Oppdaterer simulering-responsen med det som forventes av pensjonskalkulator-backend (som også må oppdateres).
Viktigste endring er at `alderspensjonMaanedsbeloep` er lagt til i responsen.

Hører sammen med [backend-PR](https://github.com/navikt/pensjonskalkulator-backend/pull/177).