### PR TITLE
PEK-1019 Support 'endring' in 'TPO AP V4' service

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonService.kt
@@ -4,31 +4,49 @@ import no.nav.pensjon.simulator.alderspensjon.alternativ.AlternativSimuleringSer
 import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertPensjonEllerAlternativ
 import no.nav.pensjon.simulator.alderspensjon.api.tpo.direct.TpoAlderspensjonResultMapper
 import no.nav.pensjon.simulator.alderspensjon.convert.SimulatorOutputConverter
-import no.nav.pensjon.simulator.alderspensjon.spec.SimuleringSpecSanitiser
+import no.nav.pensjon.simulator.alderspensjon.spec.AlderspensjonSpec
+import no.nav.pensjon.simulator.alderspensjon.spec.SimuleringSpecSanitiser.sanitise
 import no.nav.pensjon.simulator.alderspensjon.spec.SimuleringSpecValidator.validate
 import no.nav.pensjon.simulator.core.SimulatorCore
+import no.nav.pensjon.simulator.core.exception.FeilISimuleringsgrunnlagetException
 import no.nav.pensjon.simulator.core.exception.UtilstrekkeligOpptjeningException
 import no.nav.pensjon.simulator.core.exception.UtilstrekkeligTrygdetidException
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
 import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.generelt.GenerelleDataHolder
+import no.nav.pensjon.simulator.vedtak.VedtakService
+import no.nav.pensjon.simulator.vedtak.VedtakStatus
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
 @Component
 class AlderspensjonService(
     private val simulator: SimulatorCore,
-    private val alternativSimuleringService: AlternativSimuleringService
+    private val alternativSimuleringService: AlternativSimuleringService,
+    private val vedtakService: VedtakService,
+    private val generelleDataHolder: GenerelleDataHolder
 ) {
-    fun simulerAlderspensjon(simuleringSpec: SimuleringSpec): AlderspensjonResult {
-        val spec = SimuleringSpecSanitiser.sanitise(simuleringSpec)
-        validate(spec)
-        val simuleringResultat = simulerMedMuligAlternativ(spec)
+    fun simulerAlderspensjon(spec: AlderspensjonSpec): AlderspensjonResult {
+        val vedtakInfo = vedtakService.vedtakStatus(spec.pid, foersteUttakFom(spec))
+        checkForGjenlevenderettighet(vedtakInfo)
+        val foedselsdato = generelleDataHolder.getPerson(spec.pid).foedselDato
+
+        val simuleringSpec = sanitise(
+            AlderspensjonSpecMapper.simuleringSpec(
+                source = spec,
+                foedselsdato,
+                erFoerstegangsuttak = vedtakInfo.harGjeldendeVedtak.not()
+            )
+        )
+
+        validate(simuleringSpec)
+        val simuleringResultat = simulerMedMuligAlternativ(simuleringSpec)
 
         return TpoAlderspensjonResultMapper.mapPensjonEllerAlternativ(
             source = simuleringResultat,
-            angittFoersteUttakFom = foersteUttakFom(spec),
-            angittAndreUttakFom = andreUttakFom(spec)
+            angittFoersteUttakFom = foersteUttakFom(simuleringSpec),
+            angittAndreUttakFom = andreUttakFom(simuleringSpec)
         )
     }
 
@@ -69,6 +87,10 @@ class AlderspensjonService(
     }
 
     private companion object {
+
+        private fun foersteUttakFom(spec: AlderspensjonSpec): LocalDate =
+            spec.gradertUttak?.fom ?: spec.heltUttakFom
+
         private fun foersteUttakFom(spec: SimuleringSpec): LocalDate =
             spec.foersteUttakDato ?: spec.heltUttakDato!!
 
@@ -78,5 +100,12 @@ class AlderspensjonService(
         private fun isReducible(grad: UttakGradKode): Boolean =
             grad != UttakGradKode.P_20 // 20 % is lowest gradert uttak
                     && grad != UttakGradKode.P_100 // 100 % is not gradert uttak and hence not "adjustable" to a lower grad
+
+        // PEN: SimuleringServiceBase.checkForGjenlevenderettighet
+        private fun checkForGjenlevenderettighet(vedtakInfo: VedtakStatus) {
+            if (vedtakInfo.harGjenlevenderettighet) {
+                throw FeilISimuleringsgrunnlagetException("Kan ikke simulere bruker med gjenlevenderettigheter")
+            }
+        }
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonSpecMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonSpecMapper.kt
@@ -1,0 +1,79 @@
+package no.nav.pensjon.simulator.alderspensjon
+
+import no.nav.pensjon.simulator.alderspensjon.spec.AlderspensjonSpec
+import no.nav.pensjon.simulator.alderspensjon.spec.PensjonInntektSpec
+import no.nav.pensjon.simulator.core.domain.SimuleringType
+import no.nav.pensjon.simulator.core.domain.SivilstatusType
+import no.nav.pensjon.simulator.core.krav.FremtidigInntekt
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import java.time.LocalDate
+
+/**
+ * Maps from particular 'alderspensjon specification'
+ * to general 'simulering specification'.
+ */
+object AlderspensjonSpecMapper {
+
+    @OptIn(ExperimentalStdlibApi::class)
+    fun simuleringSpec(
+        source: AlderspensjonSpec,
+        foedselsdato: LocalDate,
+        erFoerstegangsuttak: Boolean
+    ) =
+        SimuleringSpec(
+            type = simuleringType(source.livsvarigOffentligAfpRettFom, erFoerstegangsuttak),
+            sivilstatus = if (source.epsHarPensjon || source.epsHarInntektOver2G) SivilstatusType.GIFT else SivilstatusType.UGIF,
+            epsHarPensjon = source.epsHarPensjon,
+            foersteUttakDato = foersteUttakFom(source),
+            heltUttakDato = if (source.gradertUttak == null) null else source.heltUttakFom,
+            pid = source.pid,
+            foedselDato = foedselsdato,
+            avdoed = null,
+            isTpOrigSimulering = true,
+            simulerForTp = false, // since not set in SimulerAlderspensjonRequestV3Converter in PEN
+            uttakGrad = source.gradertUttak?.uttaksgrad ?: UttakGradKode.P_100,
+            forventetInntektBeloep = 0, // fremtidigInntektListe is used instead
+            inntektUnderGradertUttakBeloep = 0, // fremtidigInntektListe is used instead
+            inntektEtterHeltUttakBeloep = 0, // fremtidigInntektListe is used instead
+            inntektEtterHeltUttakAntallAar = null, // fremtidigInntektListe is used instead
+            foedselAar = foedselsdato.year,
+            utlandAntallAar = source.antallAarUtenlandsEtter16,
+            utlandPeriodeListe = mutableListOf(), // utenlandsopphold is in V4 specified by utlandAntallAar
+            fremtidigInntektListe = source.fremtidigInntektListe.map(::fremtidigInntekt).toMutableList(),
+            inntektOver1GAntallAar = 0,
+            flyktning = false,
+            epsHarInntektOver2G = source.epsHarInntektOver2G,
+            rettTilOffentligAfpFom = source.livsvarigOffentligAfpRettFom,
+            afpOrdning = null,
+            afpInntektMaanedFoerUttak = null,
+            erAnonym = false,
+            ignoreAvslag = false,
+            isHentPensjonsbeholdninger = true, // also controls whether to include 'simulert beregningsinformasjon' in result
+            isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = true, // cf. SimulerAlderspensjonProviderV3.simulerAlderspensjon line 54
+            onlyVilkaarsproeving = false
+        )
+
+    private fun foersteUttakFom(source: AlderspensjonSpec): LocalDate =
+        source.gradertUttak?.fom ?: source.heltUttakFom
+
+    private fun simuleringType(
+        livsvarigOffentligAfpRettDato: LocalDate?,
+        erFoerstegangsuttak: Boolean
+    ): SimuleringType =
+        livsvarigOffentligAfpRettDato?.let {
+            if (erFoerstegangsuttak)
+                SimuleringType.ALDER_MED_AFP_OFFENTLIG_LIVSVARIG
+            else
+                SimuleringType.ENDR_AP_M_AFP_OFFENTLIG_LIVSVARIG
+        } ?: if (erFoerstegangsuttak)
+            SimuleringType.ALDER
+        else
+            SimuleringType.ENDR_ALDER
+
+    private fun fremtidigInntekt(source: PensjonInntektSpec) =
+        FremtidigInntekt(
+            aarligInntektBeloep = source.aarligBeloep,
+            fom = source.fom
+        )
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/acl/v4/AlderspensjonSpecMapperV4.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/acl/v4/AlderspensjonSpecMapperV4.kt
@@ -1,11 +1,9 @@
 package no.nav.pensjon.simulator.alderspensjon.api.tpo.direct.acl.v4
 
-
-import no.nav.pensjon.simulator.core.domain.SimuleringType
-import no.nav.pensjon.simulator.core.domain.SivilstatusType
-import no.nav.pensjon.simulator.core.krav.FremtidigInntekt
+import no.nav.pensjon.simulator.alderspensjon.spec.AlderspensjonSpec
+import no.nav.pensjon.simulator.alderspensjon.spec.GradertUttakSpec
+import no.nav.pensjon.simulator.alderspensjon.spec.PensjonInntektSpec
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
-import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.person.Pid
 import no.nav.pensjon.simulator.tech.web.BadRequestException
 import java.time.LocalDate
@@ -16,55 +14,30 @@ import java.time.LocalDate
  */
 object AlderspensjonSpecMapperV4 {
 
-    @OptIn(ExperimentalStdlibApi::class)
-    fun fromSpecV4(source: AlderspensjonSpecV4, foedselsdato: LocalDate) =
-        SimuleringSpec(
-            type = source.rettTilAfpOffentligDato?.let { SimuleringType.ALDER_MED_AFP_OFFENTLIG_LIVSVARIG }
-                ?: SimuleringType.ALDER,
-            sivilstatus = if (source.epsPensjon == true || source.eps2G == true) SivilstatusType.GIFT else SivilstatusType.UGIF,
+    fun fromDto(source: AlderspensjonSpecV4) =
+        AlderspensjonSpec(
+            pid = source.personId?.let(::Pid) ?: missing("personId"),
+            gradertUttak = source.gradertUttak?.let(::gradertUttak),
+            heltUttakFom = source.heltUttakFraOgMedDato?.let(LocalDate::parse) ?: missing("heltUttakFraOgMedDato"),
+            antallAarUtenlandsEtter16 = source.aarIUtlandetEtter16 ?: 0,
             epsHarPensjon = source.epsPensjon == true,
-            foersteUttakDato = (source.gradertUttak?.fraOgMedDato ?: source.heltUttakFraOgMedDato)
-                ?.let(LocalDate::parse) ?: missing("heltUttakFraOgMedDato"),
-            heltUttakDato = if (source.gradertUttak == null) null else
-                source.heltUttakFraOgMedDato?.let(LocalDate::parse).also { validate(source.gradertUttak) }
-                    ?: missing("heltUttakFraOgMedDato"),
-            pid = source.personId?.let(::Pid),
-            foedselDato = foedselsdato,
-            avdoed = null,
-            isTpOrigSimulering = true,
-            simulerForTp = false, // since not set in SimulerAlderspensjonRequestV3Converter in PEN
-            uttakGrad = UttakGradKode.entries.firstOrNull { it.value.toInt() == source.gradertUttak?.uttaksgrad }
-                ?: UttakGradKode.P_100,
-            forventetInntektBeloep = 0, // fremtidigInntektListe is used instead
-            inntektUnderGradertUttakBeloep = 0, // fremtidigInntektListe is used instead
-            inntektEtterHeltUttakBeloep = 0, // fremtidigInntektListe is used instead
-            inntektEtterHeltUttakAntallAar = null, // fremtidigInntektListe is used instead
-            foedselAar = foedselsdato.year,
-            utlandAntallAar = source.aarIUtlandetEtter16 ?: 0,
-            utlandPeriodeListe = mutableListOf(), // utenlandsopphold is in V4 specified by utlandAntallAar
-            fremtidigInntektListe = source.fremtidigInntektListe.orEmpty().map(::fremtidigInntekt).toMutableList(),
-            inntektOver1GAntallAar = 0,
-            flyktning = false,
             epsHarInntektOver2G = source.eps2G == true,
-            rettTilOffentligAfpFom = source.rettTilAfpOffentligDato?.let(LocalDate::parse),
-            afpOrdning = null,
-            afpInntektMaanedFoerUttak = null,
-            erAnonym = false,
-            ignoreAvslag = false,
-            isHentPensjonsbeholdninger = true, // also controls whether to include 'simulert beregningsinformasjon' in result
-            isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = true, // cf. SimulerAlderspensjonProviderV3.simulerAlderspensjon line 54
-            onlyVilkaarsproeving = false
+            fremtidigInntektListe = source.fremtidigInntektListe.orEmpty().map(::inntekt),
+            livsvarigOffentligAfpRettFom = source.rettTilAfpOffentligDato?.let(LocalDate::parse)
         )
 
-    private fun validate(uttak: GradertUttakSpecV4) {
-        if (uttak.fraOgMedDato == null) missing("gradertUttak.fraOgMedDato")
-        if (uttak.uttaksgrad == null) missing("gradertUttak.uttaksgrad")
-    }
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun gradertUttak(source: GradertUttakSpecV4) =
+        GradertUttakSpec(
+            fom = source.fraOgMedDato?.let(LocalDate::parse) ?: missing("gradertUttak.fraOgMedDato"),
+            uttaksgrad = UttakGradKode.entries.firstOrNull { it.value.toInt() == source.uttaksgrad }
+                ?: UttakGradKode.P_100
+        )
 
-    private fun fremtidigInntekt(source: PensjonInntektSpecV4) =
-        FremtidigInntekt(
-            aarligInntektBeloep = source.aarligInntekt ?: 0,
-            fom = source.fraOgMedDato?.let(LocalDate::parse) ?: missing("fremtidigInntekt.fraOgMedDato")
+    private fun inntekt(source: PensjonInntektSpecV4) =
+        PensjonInntektSpec(
+            aarligBeloep = source.aarligInntekt ?: 0,
+            fom = source.fraOgMedDato?.let(LocalDate::parse) ?: missing("fremtidigInntektListe[x].fraOgMedDato")
         )
 
     private fun missing(valueName: String): Nothing {

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/spec/AlderspensjonSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/spec/AlderspensjonSpec.kt
@@ -1,0 +1,30 @@
+package no.nav.pensjon.simulator.alderspensjon.spec
+
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.person.Pid
+import java.time.LocalDate
+
+/**
+ * Specification for 'simuler alderspensjon'.
+ */
+data class AlderspensjonSpec(
+    val pid: Pid,
+    val gradertUttak: GradertUttakSpec?,
+    val heltUttakFom: LocalDate,
+    val antallAarUtenlandsEtter16: Int,
+    val epsHarPensjon: Boolean,
+    val epsHarInntektOver2G: Boolean,
+    val fremtidigInntektListe: List<PensjonInntektSpec>,
+    val livsvarigOffentligAfpRettFom: LocalDate?
+)
+
+// NB: Compare with GradertUttakSpec in TidligstMuligUttakSpec
+data class GradertUttakSpec(
+    val uttaksgrad: UttakGradKode,
+    val fom: LocalDate
+)
+
+data class PensjonInntektSpec(
+    val aarligBeloep: Int,
+    val fom: LocalDate
+)

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonSpecMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonSpecMapperTest.kt
@@ -1,10 +1,9 @@
-package no.nav.pensjon.simulator.alderspensjon.api.acl
+package no.nav.pensjon.simulator.alderspensjon
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import no.nav.pensjon.simulator.alderspensjon.api.tpo.direct.acl.v4.AlderspensjonSpecMapperV4
-import no.nav.pensjon.simulator.alderspensjon.api.tpo.direct.acl.v4.AlderspensjonSpecV4
-import no.nav.pensjon.simulator.alderspensjon.api.tpo.direct.acl.v4.PensjonInntektSpecV4
+import no.nav.pensjon.simulator.alderspensjon.spec.AlderspensjonSpec
+import no.nav.pensjon.simulator.alderspensjon.spec.PensjonInntektSpec
 import no.nav.pensjon.simulator.core.domain.SimuleringType
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.krav.FremtidigInntekt
@@ -13,26 +12,27 @@ import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.testutil.TestObjects.pid
 import java.time.LocalDate
 
-class AlderspensjonSpecMapperV4Test : FunSpec({
+class AlderspensjonSpecMapperTest : FunSpec({
 
-    test("fromSpecV4 maps from DTO version 4 to domain") {
-        AlderspensjonSpecMapperV4.fromSpecV4(
-            source = AlderspensjonSpecV4(
-                personId = pid.value,
+    test("simuleringSpec maps from particular specification to general specification") {
+        AlderspensjonSpecMapper.simuleringSpec(
+            source = AlderspensjonSpec(
+                pid,
                 gradertUttak = null,
-                heltUttakFraOgMedDato = "2031-02-03",
-                epsPensjon = true,
-                eps2G = false,
-                aarIUtlandetEtter16 = 5,
+                heltUttakFom = LocalDate.of(2031, 2, 3),
+                antallAarUtenlandsEtter16 = 5,
+                epsHarPensjon = true,
+                epsHarInntektOver2G = false,
                 fremtidigInntektListe = listOf(
-                    PensjonInntektSpecV4(
-                        aarligInntekt = 123000,
-                        fraOgMedDato = "2029-05-06"
+                    PensjonInntektSpec(
+                        aarligBeloep = 123000,
+                        fom = LocalDate.of(2029, 5, 6)
                     )
                 ),
-                rettTilAfpOffentligDato = "2032-03-04"
+                livsvarigOffentligAfpRettFom = LocalDate.of(2032, 3, 4)
             ),
-            foedselsdato = LocalDate.of(1964, 1, 1)
+            foedselsdato = LocalDate.of(1964, 1, 1),
+            erFoerstegangsuttak = false
         ) shouldBe
                 SimuleringSpec(
                     type = SimuleringType.ALDER_MED_AFP_OFFENTLIG_LIVSVARIG,

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/acl/v4/AlderspensjonResultMapperV4Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/acl/v4/AlderspensjonResultMapperV4Test.kt
@@ -1,17 +1,8 @@
-package no.nav.pensjon.simulator.alderspensjon.api.acl
+package no.nav.pensjon.simulator.alderspensjon.api.tpo.direct.acl.v4
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import no.nav.pensjon.simulator.alderspensjon.AlderspensjonFraFolketrygden
-import no.nav.pensjon.simulator.alderspensjon.AlderspensjonResult
-import no.nav.pensjon.simulator.alderspensjon.ForslagVedForLavOpptjening
-import no.nav.pensjon.simulator.alderspensjon.GradertUttak
-import no.nav.pensjon.simulator.alderspensjon.PensjonDelytelse
-import no.nav.pensjon.simulator.alderspensjon.PensjonSimuleringStatus
-import no.nav.pensjon.simulator.alderspensjon.PensjonSimuleringStatusKode
-import no.nav.pensjon.simulator.alderspensjon.PensjonType
-import no.nav.pensjon.simulator.alderspensjon.Uttaksgrad
-import no.nav.pensjon.simulator.alderspensjon.api.tpo.direct.acl.v4.*
+import no.nav.pensjon.simulator.alderspensjon.*
 import java.time.LocalDate
 
 class AlderspensjonResultMapperV4Test : FunSpec({


### PR DESCRIPTION
Gjelder tjenesten 'simuler alderspensjon V4'.

Sjekker om bruker har gjeldende vedtak. I så fall brukes simuleringstype `ENDR_ALDER` eller `ENDR_AP_M_AFP_OFFENTLIG_LIVSVARIG`.

Sjekker også om bruker har gjenlevenderettighet. I så fall kan ikke simulering gjennomføres. Dette er samme oppførsel som i V3-tjenesten i PEN ([SimulerAlderspensjonProviderV3](https://github.com/navikt/pensjon-pen/blob/6c4619c1ebe861d7d0bea68e6289e6f6e3b7ad63/pen-app/src/main/java/no/nav/pensjon/pen_app/provider/ws/simuleralderspensjon/v3/support/SimulerAlderspensjonProviderV3.kt#L65)).