### PR TITLE
PEK-1029 Deploy to Q1

### DIFF
--- a/.github/workflows/deploy-alerts.yml
+++ b/.github/workflows/deploy-alerts.yml
@@ -21,6 +21,19 @@ jobs:
         env:
           CLUSTER: dev-gcp
           RESOURCE: .nais/alerts.yml
+  deploy-alerts-q1:
+    name: Deploy q1 alerts
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy alerts
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/alerts-q1.yml
   deploy-alerts-prod:
     name: Deploy prod alerts
     permissions:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,6 +11,10 @@ on:
       - 'README.md'
   workflow_dispatch:
     inputs:
+      q1:
+        description: Deploy to Q1
+        type: boolean
+        required: false
       prod:
         description: Deploy to production
         type: boolean
@@ -52,7 +56,7 @@ jobs:
     needs: [ build ]
     if: |
       github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.prod != 'true')
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.q1 != 'true' && github.event.inputs.prod != 'true')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -69,7 +73,7 @@ jobs:
     name: Deploy KrakenD config to dev
     if: |
       github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.prod != 'true')
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.q1 != 'true' && github.event.inputs.prod != 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -86,6 +90,25 @@ jobs:
         env:
           CLUSTER: dev-gcp
           RESOURCE: .nais/api/apiendpoints.yaml
+  deploy-q1:
+    name: Deploy to dev-gcp q1
+    needs: [ build ]
+    if: |
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.q1 == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Deploy
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          IMAGE: ${{ needs.build.outputs.image }}
+          RESOURCE: .nais/deploy-q1.yml
   deploy-prod:
     name: Deploy to prod-gcp
     needs: [ build ]

--- a/.nais/alerts-q1.yml
+++ b/.nais/alerts-q1.yml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pensjonssimulator-alert-q1
+  namespace: pensjonskalkulator
+  labels:
+    team: pensjonskalkulator
+spec:
+  groups:
+    - name: pensjonssimulator-alert-q1
+      rules:
+        - alert: pensjonssimulator-q1 - Applikasjonen er nede
+          expr: kube_deployment_status_replicas_available{deployment="pensjonssimulator-q1"} == 0
+          for: 2m
+          annotations:
+            consequence: "pensjonssimulator-q1 er utilgjengelig"
+            action: "`kubectl describe pod -l app=pensjonssimulator-q1 -n pensjonskalkulator` for events, `kubectl logs -l app=pensjonssimulator-q1 -n pensjonskalkulator` for logger"
+          labels:
+            namespace: pensjonskalkulator
+            severity: critical
+        - alert: pensjonssimulator-q1 - Høy feilrate i logger
+          expr: (100 * sum by (app, namespace) (rate(log_messages_errors{app="pensjonssimulator-q1",level="Error"}[3m])) / sum by (app, namespace) (rate(log_messages_total{app="pensjonssimulator-q1"}[3m]))) > 5
+          for: 3m
+          annotations:
+            consequence: "høy feilrate for pensjonssimulator-q1"
+            action: "Sjekk loggene til pensjonssimulator-q1 for å se hvorfor det er så mange feil"
+          labels:
+            namespace: pensjonskalkulator
+            severity: warning

--- a/.nais/deploy-q1.yml
+++ b/.nais/deploy-q1.yml
@@ -1,0 +1,103 @@
+apiVersion: nais.io/v1alpha1
+kind: Application
+metadata:
+  name: pensjonssimulator-q1
+  namespace: pensjonskalkulator
+  labels:
+    team: pensjonskalkulator
+spec:
+  image: {{ image }}
+  replicas:
+    min: 2
+    max: 2
+  resources:
+    limits:
+      memory: 1024Mi
+    requests:
+      cpu: 20m
+      memory: 512Mi
+  ingresses:
+    - https://pensjonssimulator-q1.intern.dev.nav.no
+  port: 8080
+  liveness:
+    path: /internal/health/liveness
+    initialDelay: 30
+    timeout: 1
+    periodSeconds: 30
+    failureThreshold: 5
+  readiness:
+    path: /internal/health/readiness
+    periodSeconds: 30
+  prometheus:
+    enabled: true
+    path: /internal/prometheus
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
+  azure:
+    application:
+      enabled: true
+  tokenx:
+    enabled: true
+  maskinporten:
+    enabled: true
+    scopes:
+      exposes:
+        - name: "simulering"
+          enabled: true
+          product: "pensjonssimulator"
+          consumers:
+            - orgno: "889640782" # Nav (NB: dev only)
+            - orgno: "938708606" # KLP
+            - orgno: "982759412" # Oslo Pensjonsforsikring
+            - orgno: "982583462" # SPK
+            - orgno: "931936492" # Storebrand Pensjonstjenester
+        - name: simulering.read
+          enabled: true
+          product: pensjon
+          separator: "/"
+          delegationSource: altinn
+          consumers:
+            - orgno: "889640782" # Nav (NB: dev only)
+            - orgno: "927613298" # Aksio
+            - orgno: "940380014" # Arendal kommunale pensjonskasse
+            - orgno: "980650383" # Drammen kommunale pensjonskasse
+  accessPolicy:
+    inbound:
+      rules:
+        - application: pensjon-pen-q1
+          namespace: pensjon-q1
+          cluster: dev-fss
+    outbound:
+      rules:
+        - application: pensjon-pen-q1
+          namespace: pensjon-q1
+          cluster: dev-fss
+        - application: pensjon-selvbetjening-fss-gateway-q1
+          namespace: pensjonselvbetjening
+          cluster: dev-fss
+        - application: tp-q1
+          namespace: pensjonsamhandling
+          cluster: dev-fss
+      external:
+        - host: pensjon-pen-q1.dev-fss-pub.nais.io
+        - host: pensjon-selvbetjening-fss-gateway-q1.dev-fss-pub.nais.io
+        - host: tp-api-q1.dev-fss-pub.nais.io
+  env:
+    - name: FSS_GATEWAY_SERVICE_ID
+      value: dev-fss:pensjonselvbetjening:pensjon-selvbetjening-fss-gateway-q1
+    - name: FSS_GATEWAY_URL
+      value: https://pensjon-selvbetjening-fss-gateway-q1.dev-fss-pub.nais.io
+    - name: PEN_SERVICE_ID
+      value: dev-fss:pensjon-q1:pensjon-pen-q1
+    - name: PEN_URL
+      value: https://pensjon-pen-q1.dev-fss-pub.nais.io
+    - name: TJENESTEPENSJON_SERVICE_ID
+      value: dev-fss:pensjonsamhandling:tp-q1
+    - name: TJENESTEPENSJON_URL
+      value: https://tp-api-q1.dev-fss-pub.nais.io
+    - name: STDOUT_LOG_OUTPUT
+      value: JSON
+    - name: PS_LOGGING_LEVEL
+      value: DEBUG


### PR DESCRIPTION
SPK tester tjenesten 'simuler alderspensjon V3' i Q1.
Dersom V3 skal simuleres av pensjonssimulator ("flyttet kode") istedenfor PEN, må det opprettes et Q1-miljø for pensjonssimulator.
Denne PR oppretter et slikt Q1-miljø.

Relaterte PR:
- PEN: [PR 15160](https://github.com/navikt/pensjon-pen/pull/15160)
- TP: [PR 731](https://github.com/navikt/tp/pull/731)

Relatert [commit i pensjon-selvbetjening-fss-gateway](https://github.com/navikt/pensjon-selvbetjening-fss-gateway/commit/ee3ba57f52c9e14243891761afccaaef95b20019)

NB 1: Når "flyttet kode" er påskrudd for V3, så vil SPK fortsatt kalle V3 via PEN (som sender kallet videre til pensjonssimulator). Dermed behøves ingress-tilgang i Q1 kun for PEN (`pensjon-pen-q1`). 

NB 2: De nye tjenestene (simuler AP V4, folketrygdbeholdning, TMU) gjør kall til pensjonssimulator "direkte" (dvs. ikke via PEN). Men disse tjenestene skal (foreløpig?) ikke være tilgjengelige i Q1. Dermed er det ikke nødvendig med noe KrakenD-oppsett for pensjonssimulator i Q1.

NB 3: Siden `pensjonskalkulator-backend` ikke skal være tilgjengelig i Q1, så behøves ikke ingress-tilgang for denne i Q1. Det er heller ikke nødvendig med egress-tilgang til `tjenestepensjon-simulering` i Q1, siden dette ikke brukes av V3.