### PR TITLE
PEK-556 For AFP_ETTERF_ALDER use inntektUnderGradertUttak as AFP-inntekt

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/NavViaPenAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/NavViaPenAlderspensjonController.kt
@@ -15,6 +15,7 @@ import no.nav.pensjon.simulator.common.api.ControllerBase
 import no.nav.pensjon.simulator.core.SimulatorCore
 import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.core.util.toNorwegianDate
 import no.nav.pensjon.simulator.tech.trace.TraceAid
 import no.nav.pensjon.simulator.tech.validation.InvalidEnumValueException
 import no.nav.pensjon.simulator.tech.web.BadRequestException
@@ -72,7 +73,9 @@ class NavViaPenAlderspensjonController(
             val output: SimulatorOutput = simulator.simuler(spec)
 
             NavSimuleringSpecAndResultV2(
-                simulering = specV2,
+                simulering = specV2.apply {
+                    heltUttakDato = output.heltUttakDato?.toNorwegianDate()
+                },
                 simuleringsresultat = toSimuleringResultV2(output)
             )
         } catch (e: EgressException) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/result/NavBeregningResultV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/result/NavBeregningResultV2.kt
@@ -15,8 +15,8 @@ import java.time.LocalDate
 @JsonInclude(NON_NULL)
 data class NavBeregningResultV2 (
     val merknadliste: List<MerknadV2> = emptyList(),
-    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd", timezone = "CET") val virkDatoFom: LocalDate? = null,
-    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd", timezone = "CET") val virkDatoTom: LocalDate? = null,
+    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd") val virkDatoFom: LocalDate? = null,
+    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd") val virkDatoTom: LocalDate? = null,
     val brutto: Int? = 0,
     val netto: Int? = 0,
     val g: Int? = 0,
@@ -28,7 +28,9 @@ data class NavBeregningResultV2 (
     val minstepensjonType: MinstepensjonstypeEnum? = null,
     val ttAnv: Int? = 0,
     val yug: Int? = 0,
-    val ufg: Int? = 0
+    val ufg: Int? = 0,
+    val ctype: String = "BEREGNING" // needed for PEN to resolve type during deserialization
+
     // Not used in PSELV:
     // beregningId
     // versjon

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/result/NavSimuleringResultV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/result/NavSimuleringResultV2.kt
@@ -74,7 +74,7 @@ data class SimuleringResultatV2(
 // (which is the same as no.nav.pensjon.pen.domain.api.Merknad in PSELV)
 @JsonInclude(NON_NULL)
 data class MerknadV2(
-    val ar: Int? = null, // will not be set
+    val ar: Int? = null,
     val argumentListeString: String? = null,
     val kode: String? = null
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/result/NavYtelseKomponentV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/result/NavYtelseKomponentV2.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.simulator.alderspensjon.api.nav.viapen.acl.v2.result
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
-import no.nav.pensjon.simulator.core.domain.regler.Merknad
 import no.nav.pensjon.simulator.core.domain.regler.enum.FormelKodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.PoengtalltypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
@@ -10,7 +9,6 @@ import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
 // PSELV: no.nav.pensjon.pen.domain.api.beregning.Ytelseskomponent
 @JsonInclude(NON_NULL)
 data class NavYtelseKomponentV2 (
-
     val ytelseskomponentType: YtelseskomponentTypeEnum? = null,
     val merknader: List<MerknadV2> = emptyList(),
     val bruttoPerAr: Double? = 0.0,
@@ -174,7 +172,7 @@ data class PoengtallV2 (
     val gv: Int? = 0,
     val poengtallType: PoengtalltypeEnum? = null,
     val maksUforegrad: Int? = 0,
-    val merknadListe: List<Merknad> = emptyList()
+    val merknadListe: List<MerknadV2> = emptyList()
     // Not used in PSELV:
     // uforear
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/spec/NavSimuleringSpecMapperV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/spec/NavSimuleringSpecMapperV2.kt
@@ -24,7 +24,7 @@ object NavSimuleringSpecMapperV2 {
             epsHarPensjon = source.epsPensjon == true,
             foersteUttakDato = source.forsteUttakDato?.toNorwegianLocalDate(),
             heltUttakDato = source.heltUttakDato?.toNorwegianLocalDate(),
-            pid = source.fnr?.pid?.let(::Pid),
+            pid = source.fnr?.let(::Pid),
             foedselDato = null, // used for anonym only
             avdoed = avdoed(source),
             isTpOrigSimulering = false,
@@ -64,7 +64,7 @@ object NavSimuleringSpecMapperV2 {
     private fun avdoed(source: NavSimuleringSpecV2): Avdoed? =
         source.fnrAvdod?.let {
             Avdoed(
-                pid = Pid(it.pid),
+                pid = Pid(it),
                 antallAarUtenlands = source.avdodAntallArIUtlandet ?: 0,
                 inntektFoerDoed = source.avdodInntektForDod ?: 0,
                 doedDato = source.dodsdato!!.toNorwegianLocalDate(),

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/spec/NavSimuleringSpecV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/spec/NavSimuleringSpecV2.kt
@@ -17,9 +17,9 @@ data class NavSimuleringSpecV2(
     val simuleringId: Long? = null,
     val simuleringType: NavSimuleringTypeSpecV2? = null,
     val simuleringNavn: String? = null,
-    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd", timezone = "CET") val lagringstidspunkt: LocalDate? = null,
-    val fnr: NavSimuleringPersonIdComboSpecV2? = null,
-    val fnrAvdod: NavSimuleringPersonIdComboSpecV2? = null,
+    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd") val lagringstidspunkt: LocalDate? = null,
+    val fnr: String? = null,
+    val fnrAvdod: String? = null,
     val fodselsar: Int? = null,
     val offentligAfpRett: Boolean? = null,
     val privatAfpRett: Boolean? = null,
@@ -30,7 +30,7 @@ data class NavSimuleringSpecV2(
     val forsteUttakDato: Date? = null, // epoch value in JSON
     val utg: UttakGradKode? = null,
     val inntektUnderGradertUttak: Int? = null,
-    val heltUttakDato: Date? = null, // epoch value in JSON
+    var heltUttakDato: Date? = null, // epoch value in JSON
     val inntektEtterHeltUttak: Int? = null,
     val antallArInntektEtterHeltUttak: Int? = null,
     val utenlandsopphold: Int? = null,
@@ -56,13 +56,6 @@ data class NavSimuleringSpecV2(
     val stillingsprosentOffGradertUttak: String? = null,
     val fremtidigInntektList: List<NavSimuleringFremtidigInntektSpecDummyV2> = emptyList(),
     val changeStamp: NavSimuleringChangeStampSpecDummyV2? = null
-)
-
-data class NavSimuleringPersonIdComboSpecV2(
-    val pid: String,
-    val dnummer: Boolean? = false,
-    val npid: Boolean? = false,
-    val pidInvalidWithBostnummer: Boolean? = false
 )
 
 // Maps 1-to-1 with no.nav.pensjon.pen.domain.api.kalkulator.UtenlandsperiodeForSimulering in PEN

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorCore.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorCore.kt
@@ -254,6 +254,7 @@ class SimulatorCore(
             output.apply {
                 this.foedselDato = foedselsdato
                 this.persongrunnlag = kravhode.hentPersongrunnlagForSoker()
+                this.heltUttakDato = spec.heltUttakDato
             }
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/Pre2025OffentligAfpPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/pre2025/Pre2025OffentligAfpPersongrunnlag.kt
@@ -215,7 +215,7 @@ class Pre2025OffentligAfpPersongrunnlag(
         private fun retainPersondetaljerHavingVirksomRolle(persongrunnlag: Persongrunnlag) {
             persongrunnlag.personDetaljListe =
                 persongrunnlag.personDetaljListe.filter {
-                    it.bruk == true && it.rolleTomDato == null
+                    it.bruk == true && it.penRolleTom == null
                 }.toMutableList()
         }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beholdning/BeholdningUpdaterUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beholdning/BeholdningUpdaterUtil.kt
@@ -449,11 +449,11 @@ object BeholdningUpdaterUtil {
     private fun createPersonDetalj(person: PenPerson) =
         PersonDetalj().apply {
             bruk = true
-            rolleFomDato = person.foedselsdato?.toNorwegianDateAtNoon()
+            penRolleFom = person.foedselsdato?.toNorwegianDateAtNoon()
             grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
             grunnlagKildeEnum = GrunnlagkildeEnum.PEN
         }.also {
-            it.finishInit() // NB: Assuming finishInit is appropriate here
+            it.finishInit()
         }
 
     // BeholdningHelper.deleteBeholdningerFromPenPersongrunnlagObject

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/endring/EndringPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/endring/EndringPersongrunnlag.kt
@@ -268,9 +268,11 @@ class EndringPersongrunnlag(
         private fun persondetalj(avdoed: Avdoed) =
             PersonDetalj().apply {
                 bruk = true
-                rolleFomDato = avdoed.doedDato.toNorwegianDateAtNoon()
+                penRolleFom = avdoed.doedDato.toNorwegianDateAtNoon()
                 grunnlagsrolleEnum = GrunnlagsrolleEnum.AVDOD
                 grunnlagKildeEnum = GrunnlagkildeEnum.BRUKER
+            }.also {
+                it.finishInit()
             }
 
         // SimulerEndringAvAPCommandHelper.isPersonDetaljValid
@@ -319,7 +321,7 @@ class EndringPersongrunnlag(
                 }.toMutableList()
 
                 personDetaljListe = personDetaljListe.filter {
-                    it.bruk == true && it.rolleTomDato == null
+                    it.bruk == true && it.penRolleTom == null
                 }.toMutableList()
                 // NB: In the original code (SimulerEndringAvAPCommandHelper.createPersongrunnlagWithValidPersonDetaljer)
                 // the PersonDetalj objects are copied twice: new Persongrunnlag(...) and then new PersonDetalj(...)
@@ -362,8 +364,10 @@ class EndringPersongrunnlag(
                 grunnlagKildeEnum = GrunnlagkildeEnum.BRUKER
                 grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
                 sivilstandTypeEnum = SivilstandEnum.ENKE
-                rolleFomDato = fom?.toNorwegianDateAtNoon()
+                penRolleFom = fom?.toNorwegianDateAtNoon()
                 bruk = true
+            }.also {
+                it.finishInit()
             }
 
         // Extracted from SimulerEndringAvAPCommandHelper.updatePersongrunnlagForBruker
@@ -372,7 +376,7 @@ class EndringPersongrunnlag(
 
         // Extracted from SimulerEndringAvAPCommandHelper.updatePersongrunnlagForBruker
         private fun isValidInPast(detalj: PersonDetalj): Boolean =
-            detalj.rolleTomDato?.let { isBeforeByDay(it, LocalDate.now(), false) } == true
+            detalj.penRolleTom?.let { isBeforeByDay(it, LocalDate.now(), false) } == true
 
         // Extracted from SimulerEndringAvAPCommandHelper.updatePersongrunnlagForBruker
         private fun isValidToday(detalj: PersonDetalj) =
@@ -387,6 +391,6 @@ class EndringPersongrunnlag(
 
         // Extracted from SimulerEndringAvAPCommandHelper.isPersonDetaljValid
         private fun isValidInFuture(detalj: PersonDetalj?) =
-            detalj?.let { it.rolleTomDato == null } == true
+            detalj?.let { it.penRolleTom == null } == true
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagMapper.kt
@@ -73,18 +73,20 @@ class PersongrunnlagMapper(
         PersonDetalj().apply {
             grunnlagsrolleEnum = GrunnlagsrolleEnum.AVDOD
             grunnlagKildeEnum = GrunnlagkildeEnum.BRUKER
-            rolleFomDato = soekerPid?.let {
+            penRolleFom = soekerPid?.let {
                 generelleDataHolder.getPerson(it).foedselDato.toNorwegianDateAtNoon()
             }
             borMedEnum = null
             bruk = true
+        }.also {
+            it.finishInit()
         }
 
     // PersongrunnlagMapper.createPersonDetalj
     private fun createPersonDetalj(spec: SimuleringSpec) =
         PersonDetalj().apply {
             grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
-            rolleFomDato = rolleFom(spec)?.toNorwegianDateAtNoon()
+            penRolleFom = rolleFom(spec)?.toNorwegianDateAtNoon()
             sivilstandTypeEnum = mapToSivilstand(spec)
             bruk = true
             grunnlagKildeEnum = GrunnlagkildeEnum.BRUKER
@@ -146,13 +148,11 @@ class PersongrunnlagMapper(
         private fun mapToEpsPersonDetalj(sivilstatus: SivilstatusType, foedselsdato: LocalDate?) =
             PersonDetalj().apply {
                 grunnlagsrolleEnum = mapToEpsGrunnlagRolle(sivilstatus)
-                rolleFomDato = foedselsdato?.toNorwegianDateAtNoon()
+                penRolleFom = foedselsdato?.toNorwegianDateAtNoon()
                 borMedEnum = mapToEpsBorMedType(sivilstatus)
                 bruk = true
                 grunnlagKildeEnum = GrunnlagkildeEnum.BRUKER
             }.also {
-                // finishInit sets virkFom and then rolleFomDato = virkFom.noon()
-                // (ref. PEN GrunnlagToReglerMapper.mapPersonDetaljToRegler):
                 it.finishInit()
             }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutput.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutput.kt
@@ -23,4 +23,6 @@ class SimulatorOutput {
 
     var foedselDato: LocalDate? = null
     var persongrunnlag: Persongrunnlag? = null
+
+    var heltUttakDato: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpec.kt
@@ -27,7 +27,7 @@ data class SimuleringSpec(
     var simulerForTp: Boolean,
     val uttakGrad: UttakGradKode,
     val forventetInntektBeloep: Int,
-    val inntektUnderGradertUttakBeloep: Int,
+    val inntektUnderGradertUttakBeloep: Int, // NB: For AFP_ETTERF_ALDER this is inntekt during AFP-uttak
     val inntektEtterHeltUttakBeloep: Int,
     val inntektEtterHeltUttakAntallAar: Int?,
     val foedselAar: Int,
@@ -170,6 +170,12 @@ data class SimuleringSpec(
         uttakGrad == other.uttakGrad &&
                 foersteUttakDato == other.foersteUttakDato &&
                 heltUttakDato == other.heltUttakDato
+
+    /**
+     * NB: inntektUnderGradertUttak should for AFP_ETTERF_ALDER be interpreted as inntekt during AFP-uttak.
+     */
+    fun isRegardedAsHeltUttak() =
+        uttakGrad == UttakGradKode.P_100 && type != SimuleringType.AFP_ETTERF_ALDER
 
     private companion object {
         //TODO move to UttakGradKode?

--- a/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenKravhodeMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenKravhodeMapper.kt
@@ -104,15 +104,15 @@ object PenKravhodeMapper {
             // beholdningsTypeEnum set in constructor
         }
 
+    /**
+     * Corresponds to GrunnlagToReglerMapper.mapPersonDetaljToRegler in PEN.
+     * Note in particular that virkFom/virkTom are mapped to rolleFomDato/rolleTomDato.
+     */
     private fun personDetalj(source: PenPersonDetalj) =
         PersonDetalj().apply {
             grunnlagsrolleEnum = source.grunnlagsrolleEnum
-            /* TODO: PEN to regler mapping:
-            rolleFomDato = source.virkFom
-            rolleTomDato = source.virkTom
-            */
-            rolleFomDato = source.rolleFomDato
-            rolleTomDato = source.rolleTomDato
+            rolleFomDato = source.virkFom // yes, virkFom is actually mapped to rolleFomDato
+            rolleTomDato = source.virkTom // ... and virkTom is mapped to rolleTomDato
             sivilstandTypeEnum = source.sivilstandTypeEnum
             sivilstandRelatertPerson = source.sivilstandRelatertPerson?.let(::penPerson)
             borMedEnum = source.borMedEnum
@@ -123,14 +123,11 @@ object PenKravhodeMapper {
             serskiltSatsUtenET = source.serskiltSatsUtenET
             epsAvkallEgenPensjon = source.epsAvkallEgenPensjon
             //--- Extra:
+            penRolleFom = source.rolleFomDato // the original 'rolle f.o.m.-dato' in PEN
+            penRolleTom = source.rolleTomDato // the original 'rolle t.o.m.-dato' in PEN
             virkFom = source.virkFom
             virkTom = source.virkTom
-        }.also {
-            it.finishInit()
-            //TODO
-            // due to rolleFomDato manipulation in finishInit, have to use legacyRolleFomDato in logic
-            // (rolleFomDato shall only be used by regler)
-        }
+        } // do not call finishInit() here; the values received from PEN are already 'finished'
 
     private fun persongrunnlag(source: PenPersongrunnlag) =
         Persongrunnlag().apply {

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/spec/NavSimuleringSpecMapperV2Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/spec/NavSimuleringSpecMapperV2Test.kt
@@ -23,8 +23,8 @@ class NavSimuleringSpecMapperV2Test : FunSpec({
                 simuleringType = NavSimuleringTypeSpecV2.ALDER,
                 simuleringNavn = "x",
                 lagringstidspunkt = LocalDate.of(2012, 3, 4),
-                fnr = NavSimuleringPersonIdComboSpecV2(pid.value),
-                fnrAvdod = NavSimuleringPersonIdComboSpecV2("04925398980"),
+                fnr = pid.value,
+                fnrAvdod = "04925398980",
                 fodselsar = 1963,
                 forventetInntekt = 250000,
                 antArInntektOverG = 0, // used for anonym only

--- a/src/test/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenKravhodeMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenKravhodeMapperTest.kt
@@ -43,10 +43,12 @@ class PenKravhodeMapperTest : FunSpec({
             with(persongrunnlagListe.first()) {
                 with(personDetaljListe.first()) {
                     grunnlagsrolleEnum shouldBe GrunnlagsrolleEnum.SOKER
-                    legacyRolleFomDato shouldBe dateAtNoon(2021, Calendar.JANUARY, 1)
-                    legacyRolleTomDato shouldBe dateAtNoon(2022, Calendar.FEBRUARY, 2)
-                    rolleFomDato shouldBe dateAtNoon(2021, Calendar.FEBRUARY, 1) // NB (manipulated in finishInit)
-                    rolleTomDato shouldBe dateAtNoon(2022, Calendar.FEBRUARY, 28) // NB (manipulated in finishInit)
+                    penRolleFom shouldBe dateAtNoon(2021, Calendar.JANUARY, 1)
+                    penRolleTom shouldBe dateAtNoon(2022, Calendar.FEBRUARY, 2)
+                    rolleFomDato shouldBe dateAtNoon(2023, Calendar.MARCH, 3) // set to virkFom in mapper
+                    rolleTomDato shouldBe dateAtNoon(2024, Calendar.APRIL, 4) // set to virkTom in mapper
+                    virkFom shouldBe dateAtNoon(2023, Calendar.MARCH, 3)
+                    virkTom shouldBe dateAtNoon(2024, Calendar.APRIL, 4)
                     sivilstandTypeEnum shouldBe SivilstandEnum.GIFT
                     with(sivilstandRelatertPerson!!) { penPersonId shouldBe 1 }
                     borMedEnum shouldBe BorMedTypeEnum.SAMBOER3_2
@@ -56,8 +58,6 @@ class PenKravhodeMapperTest : FunSpec({
                     grunnlagKildeEnum shouldBe GrunnlagkildeEnum.PEN
                     serskiltSatsUtenET shouldBe true
                     epsAvkallEgenPensjon shouldBe false
-                    virkFom shouldBe dateAtNoon(2021, Calendar.FEBRUARY, 1) // NB (manipulated in finishInit)
-                    virkTom shouldBe dateAtNoon(2022, Calendar.FEBRUARY, 28) // NB (manipulated in finishInit)
                 }
             }
         }


### PR DESCRIPTION
Diverse rettelser for 'gammel' (pre-2025) offentlig AFP:

- "inntekt under gradert uttak" brukes for inntekt under AFP-perioden
- årsverdien (`ar`) i `Merknad` for `Poengtall` settes til poengtallets årsverdi
- verdien `heltUttakDato` i `SimuleringSpec` modifiseres i simuleringen; den modifiserte verdien returneres i responsen
- opprydding i håndtering av `virkFom`/`virkTom` vs `rolleFomDato`/`rolleTomDato` i `PersonDetalj`
