### PR TITLE
PEK-911 Include all AlderspensjonFraFolketrygden in 'TPO V4'

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonService.kt
@@ -48,7 +48,8 @@ class AlderspensjonService(
         return TpoAlderspensjonResultMapper.mapPensjonEllerAlternativ(
             source = simuleringResultat,
             angittFoersteUttakFom = foersteUttakFom(simuleringSpec),
-            angittAndreUttakFom = andreUttakFom(simuleringSpec)
+            angittAndreUttakFom = andreUttakFom(simuleringSpec),
+            onlyIncludeEntriesForUttakDatoer = false
         )
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapper.kt
@@ -24,7 +24,8 @@ object TpoAlderspensjonResultMapper {
     fun mapPensjonEllerAlternativ(
         source: SimulertPensjonEllerAlternativ?,
         angittFoersteUttakFom: LocalDate,
-        angittAndreUttakFom: LocalDate? // null if not gradert uttak
+        angittAndreUttakFom: LocalDate?, // null if not gradert uttak
+        onlyIncludeEntriesForUttakDatoer: Boolean // PEN: hentFullAPListe.not()
     ): AlderspensjonResult {
         val pensjon: SimulertPensjon? = source?.pensjon
         val harUttak = pensjon?.harUttak == true
@@ -33,11 +34,14 @@ object TpoAlderspensjonResultMapper {
         if (source?.alternativ == null) {
             // Angitt uttak ble innvilget i vilkårsprøvingen
             val alderspensjonListe =
-                pickEntriesForFomDatoer(
-                    pensjonListe = alderspensjonFraFolketrygdenListe,
-                    foersteUttakFom = angittFoersteUttakFom,
-                    andreUttakFom = angittAndreUttakFom
-                )
+                if (onlyIncludeEntriesForUttakDatoer)
+                    pickEntriesForFomDatoer(
+                        pensjonListe = alderspensjonFraFolketrygdenListe,
+                        foersteUttakFom = angittFoersteUttakFom,
+                        andreUttakFom = angittAndreUttakFom
+                    )
+                else
+                    alderspensjonFraFolketrygdenListe
 
             return AlderspensjonResult(
                 simuleringSuksess = alderspensjonListe.isNotEmpty(),


### PR DESCRIPTION
Inkluder all alderspensjon fra folketrygden i responsen til 'simuler AP for TPO V4'.
(Inntil nå har bare alderspensjon for uttaksdatoene blitt inkludert.)

Dette tilsvarer oppførselen til gamle 'simuler AP for TPO V3', med `hentFullAPListe = true`.