### PR TITLE
Include 'innvilget livsvarig offentlig AFP' in persongrunnlag

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/livsvarig/LivsvarigOffentligAfpUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/livsvarig/LivsvarigOffentligAfpUtil.kt
@@ -1,0 +1,22 @@
+package no.nav.pensjon.simulator.core.afp.offentlig.livsvarig
+
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AfpOffentligLivsvarig
+import no.nav.pensjon.simulator.core.util.isBeforeOrOn
+import java.time.LocalDate
+
+object LivsvarigOffentligAfpUtil {
+
+    fun getLivsvarigOffentligAfp(
+        resultatListe: List<LivsvarigOffentligAfpYtelseMedDelingstall>,
+        knekkpunktDato: LocalDate
+    ): AfpOffentligLivsvarig? =
+        resultatListe
+            .filter { it.gjelderFom.isBeforeOrOn(knekkpunktDato) }
+            .maxByOrNull { it.gjelderFom }
+            ?.let {
+                AfpOffentligLivsvarig().apply {
+                    bruttoPerAr = it.afpYtelsePerAar
+                    uttaksdato = it.gjelderFom
+                }
+            }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beholdning/BeholdningUpdaterUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beholdning/BeholdningUpdaterUtil.kt
@@ -21,7 +21,6 @@ import no.nav.pensjon.simulator.core.util.PensjonTidUtil.OPPTJENING_ETTERSLEP_AN
 import no.nav.pensjon.simulator.core.util.PeriodeUtil.findLatest
 import no.nav.pensjon.simulator.core.util.PeriodeUtil.findValidForDate
 import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
-import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.person.Pid
 import java.time.LocalDate
 import java.util.*
@@ -359,7 +358,7 @@ object BeholdningUpdaterUtil {
 
     // BeholdningSwitchDecider.beholdningShouldBeSwitched
     fun isVirkFomEligibleForSwitching(kravhode: Kravhode): Boolean =
-        kravhode.onsketVirkningsdato?.let { isFirstDayOfYear(it) || isFirstDayOfMay(it) } == true
+        kravhode.onsketVirkningsdato?.let { it.dayOfYear == 1 || isFirstDayOfMay(it) } == true
 
     // BeholdningSwitchDecider.isSokersPersongrunnlag
     fun isSokersPersongrunnlag(kravhode: Kravhode, persongrunnlag: Persongrunnlag): Boolean =
@@ -375,16 +374,12 @@ object BeholdningUpdaterUtil {
     // RevurderingHelper.isRevurderingBackToFirstUttaksdatoOrForstegangsbehandling
     fun isRevurderingBackToFirstUttaksdatoOrForstegangsbehandling(kravhode: Kravhode): Boolean =
         with(kravhode.sakForsteVirkningsdato()) {
-            this == null || this == kravhode.onsketVirkningsdato?.toNorwegianLocalDate()
+            this == null || this == kravhode.onsketVirkningsdato
         }
 
-    // RevurderingHelper.isFirstDayOfYear
-    fun isFirstDayOfYear(date: Date): Boolean =
-        date.toNorwegianLocalDate().dayOfYear == 1
-
     // RevurderingHelper.isFirstDayOfMay
-    fun isFirstDayOfMay(date: Date): Boolean =
-        with(date.toNorwegianLocalDate()) {
+    fun isFirstDayOfMay(date: LocalDate): Boolean =
+        with(date) {
             dayOfMonth == 1 && monthValue == 5
             //TODO use const
         }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregner.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.beregn
 
 import mu.KotlinLogging
 import no.nav.pensjon.simulator.core.SimulatorContext
-import no.nav.pensjon.simulator.core.afp.offentlig.livsvarig.LivsvarigOffentligAfpYtelseMedDelingstall
+import no.nav.pensjon.simulator.core.afp.offentlig.livsvarig.LivsvarigOffentligAfpUtil.getLivsvarigOffentligAfp
 import no.nav.pensjon.simulator.core.beregn.PeriodiseringUtil.periodiserGrunnlagAndModifyKravhode
 import no.nav.pensjon.simulator.core.domain.SimuleringType
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
@@ -23,7 +23,6 @@ import no.nav.pensjon.simulator.core.person.eps.EpsUtil.epsMottarPensjon
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.util.PensjonTidUtil.OPPTJENING_ETTERSLEP_ANTALL_AAR
 import no.nav.pensjon.simulator.core.util.PensjonTidUtil.ubetingetPensjoneringDato
-import no.nav.pensjon.simulator.core.util.isBeforeOrOn
 import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.core.vilkaar.Vilkaarsproever
@@ -119,8 +118,9 @@ class AlderspensjonVilkaarsproeverOgBeregner(
                     sistRegulertG = it.sistRegulertG ?: CURRENT_GRUNNBELOEP,
                     bruttoPerAr = it.bruttoPerAr,
                     uttaksdato = it.uttaksdato
+                    // virkTom only relevant for innvilget AFP
                 )
-            }
+            } ?: kravhode.gjeldendeInnvilgetLivsvarigOffentligAfpGrunnlag()
 
             // Corresponds to part 5
             if (aarsaker.contains(KnekkpunktAarsak.UTG)) { // UTG = 'Endring av uttaksgrad'
@@ -364,20 +364,6 @@ class AlderspensjonVilkaarsproeverOgBeregner(
             knekkpunktDato: LocalDate
         ): AfpPrivatLivsvarig? =
             findValidForDate(resultatListe, knekkpunktDato)?.privatAfp()
-
-        private fun getLivsvarigOffentligAfp(
-            resultatListe: List<LivsvarigOffentligAfpYtelseMedDelingstall>,
-            knekkpunktDato: LocalDate
-        ): AfpOffentligLivsvarig? =
-            resultatListe
-                .filter { it.gjelderFom.isBeforeOrOn(knekkpunktDato) }
-                .maxByOrNull { it.gjelderFom }
-                ?.let {
-                    AfpOffentligLivsvarig().apply {
-                        bruttoPerAr = it.afpYtelsePerAar
-                        uttaksdato = it.gjelderFom
-                    }
-                }
 
         private fun vilkaarsproevingSpec(
             livsvarigOffentligAfp: AfpOffentligLivsvarigGrunnlag?,

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/AfpOffentligLivsvarigGrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/AfpOffentligLivsvarigGrunnlag.kt
@@ -2,11 +2,16 @@ package no.nav.pensjon.simulator.core.domain.regler.beregning2011
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING
+import com.fasterxml.jackson.annotation.JsonIgnore
 import java.time.LocalDate
 
-// 2025-03-19
+// 2025-04-06
 data class AfpOffentligLivsvarigGrunnlag(
     val sistRegulertG: Int,
     val bruttoPerAr: Double,
-    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd") val uttaksdato: LocalDate? = null
+    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd") val uttaksdato: LocalDate? = null,
+
+    //--- Extra:
+    @JsonIgnore
+    var virkTom: LocalDate? = null
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/grunnlag/Garantipensjonsbeholdning.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/grunnlag/Garantipensjonsbeholdning.kt
@@ -5,11 +5,13 @@ import no.nav.pensjon.simulator.core.domain.regler.beregning2011.JustertGarantip
 import no.nav.pensjon.simulator.core.domain.regler.enum.BeholdningtypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.GarantiPensjonsnivaSatsEnum
 
-// Checked 2025-02-28
+// 2025-04-06
 class Garantipensjonsbeholdning() : Beholdning() {
     var justertGarantipensjonsniva: JustertGarantipensjonsniva? = null
     var pensjonsbeholdning = 0.0
+    @Deprecated("Avvikles.", replaceWith = ReplaceWith("delingstallVedNormertPensjonsalder"))
     var delingstall67 = 0.0
+    var delingstallVedNormertPensjonsalder = 0.0
 
     /**
      * Satstype brukt i garantipensjonsnivå.
@@ -33,7 +35,7 @@ class Garantipensjonsbeholdning() : Beholdning() {
 
     override var beholdningsTypeEnum: BeholdningtypeEnum = BeholdningtypeEnum.GAR_PEN_B
 
-    // SIMDOM-ADD
+    //--- Extra:
     @JsonIgnore private var unclearedPensjonsbeholdning: Double? = null
 
     val internPensjonsbeholdning: Double
@@ -44,4 +46,5 @@ class Garantipensjonsbeholdning() : Beholdning() {
         unclearedPensjonsbeholdning = pensjonsbeholdning
         pensjonsbeholdning = 0.0
     }
+    // end extra ---
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/reglerextend/beregning2011/Beregning2011Extension.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/reglerextend/beregning2011/Beregning2011Extension.kt
@@ -42,6 +42,14 @@ fun AfpLivsvarig.asPrivatAfp() =
         copyYtelseskomponent(source = this, target = it)
     }
 
+fun AfpOffentligLivsvarigGrunnlag.copy() =
+    AfpOffentligLivsvarigGrunnlag(
+        sistRegulertG = this.sistRegulertG,
+        bruttoPerAr = this.bruttoPerAr,
+        uttaksdato = this.uttaksdato,
+        virkTom = this.virkTom
+    )
+
 fun AfpPrivatBeregning.copy() =
     AfpPrivatBeregning().also {
         it.afpLivsvarig = this.afpLivsvarig?.let(::AfpLivsvarig)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/reglerextend/grunnlag/GrunnlagExtension.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/reglerextend/grunnlag/GrunnlagExtension.kt
@@ -1,7 +1,6 @@
 package no.nav.pensjon.simulator.core.domain.reglerextend.grunnlag
 
 import no.nav.pensjon.simulator.core.domain.regler.Opptjening
-import no.nav.pensjon.simulator.core.domain.regler.beregning2011.LonnsvekstInformasjon
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.ReguleringsInformasjon
 import no.nav.pensjon.simulator.core.domain.regler.enum.BeholdningtypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.*
@@ -60,6 +59,7 @@ fun Garantipensjonsbeholdning.copy() =
         it.justertGarantipensjonsniva = this.justertGarantipensjonsniva?.copy()
         it.pensjonsbeholdning = this.pensjonsbeholdning
         it.delingstall67 = this.delingstall67
+        it.delingstallVedNormertPensjonsalder = this.delingstallVedNormertPensjonsalder
         it.satsTypeEnum = this.satsTypeEnum
         it.sats = this.sats
         it.garPN_tt_anv = this.garPN_tt_anv

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/krav/KravhodeCreator.kt
@@ -84,7 +84,7 @@ class KravhodeCreator(
 
         val kravhode = Kravhode().apply {
             kravFremsattDato = Date()
-            onsketVirkningsdato = oensketVirkningDato(spec)?.toNorwegianDateAtNoon()
+            onsketVirkningsdato = oensketVirkningDato(spec)
             gjelder = null
             sakId = null
             sakType = SakType.ALDER

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/virkning/FoersteVirkningDatoRepopulator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/virkning/FoersteVirkningDatoRepopulator.kt
@@ -8,6 +8,7 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravlinje
 import no.nav.pensjon.simulator.core.util.DateNoonExtension.noon
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import java.util.*
 
 /**
@@ -102,7 +103,7 @@ object FoersteVirkningDatoRepopulator {
         annenPerson: PenPerson?
     ) =
         ForsteVirkningsdatoGrunnlag().apply {
-            this.virkningsdato = kravhode.onsketVirkningsdato?.noon()
+            this.virkningsdato = kravhode.onsketVirkningsdato?.toNorwegianDateAtNoon()
             this.kravFremsattDato = kravhode.kravFremsattDato?.noon()
             this.bruker = soeker
             this.annenPerson = if (gjelderForsorgingstillegg(kravlinjeType)) annenPerson else null

--- a/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenKravhodeMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenKravhodeMapper.kt
@@ -20,7 +20,7 @@ object PenKravhodeMapper {
         Kravhode().apply {
             kravId = source.kravId
             kravFremsattDato = source.kravFremsattDato
-            onsketVirkningsdato = source.onsketVirkningsdato
+            onsketVirkningsdato = source.onsketVirkningsdato?.toNorwegianLocalDate()
             gjelder = source.gjelder
             sakId = source.sakId
             sakType = source.sakType
@@ -189,6 +189,7 @@ object PenKravhodeMapper {
             yrkesskadegrunnlagList = source.yrkesskadegrunnlagList
             barnetilleggVurderingsperioder = source.barnetilleggVurderingsperioder
             beholdninger = source.flatBeholdninger.map(::pensjonsbeholdning).toMutableList()
+            livsvarigOffentligAfpGrunnlagListe = source.livsvarigOffentligAfpGrunnlagListe
             trygdetider = source.trygdetider
             gjelderOmsorg = source.gjelderOmsorg
             gjelderUforetrygd = source.gjelderUforetrygd

--- a/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/acl/PenPersongrunnlag.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.simulator.krav.client.pen.acl
 
 import no.nav.pensjon.simulator.core.domain.regler.TTPeriode
 import no.nav.pensjon.simulator.core.domain.regler.Trygdetid
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AfpOffentligLivsvarigGrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.OvergangsinfoUPtilUT
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.UtbetalingsgradUT
 import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
@@ -80,6 +81,7 @@ class PenPersongrunnlag(
     var barnetilleggVurderingsperioder: MutableList<BarnetilleggVurderingsperiode> = mutableListOf(),
     var beholdninger: MutableList<PenPensjonsbeholdning> = mutableListOf(), // not used; flatBeholdninger used instead
     var flatBeholdninger: MutableList<PenPensjonsbeholdning> = mutableListOf(),
+    var livsvarigOffentligAfpGrunnlagListe: List<AfpOffentligLivsvarigGrunnlag> = emptyList(),
     var trygdetider: MutableList<Trygdetid> = mutableListOf(),
     var uforegrunnlagList: MutableList<Uforegrunnlag> = mutableListOf(),
     var yrkesskadegrunnlagList: MutableList<Yrkesskadegrunnlag> = mutableListOf()

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/time/Periode.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/time/Periode.kt
@@ -1,0 +1,23 @@
+package no.nav.pensjon.simulator.tech.time
+
+import java.time.LocalDate
+
+// PEN: no.nav.domain.pensjon.common.util.Periode
+data class Periode(
+    val fom: LocalDate,
+    val tom: LocalDate
+) {
+    fun fitsIn(other: Periode): Boolean =
+        !fom.isBefore(other.fom) && !tom.isAfter(other.tom)
+
+    fun sameStart(other: Periode): Boolean =
+        fom == other.fom
+
+    fun sameEnd(other: Periode): Boolean =
+        tom == other.tom
+
+    companion object {
+        fun of(fom: LocalDate?, tom: LocalDate?) =
+            Periode(fom ?: LocalDate.MIN, tom ?: LocalDate.MAX)
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/livsvarig/LivsvarigOffentligAfpUtilTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/livsvarig/LivsvarigOffentligAfpUtilTest.kt
@@ -1,0 +1,63 @@
+package no.nav.pensjon.simulator.core.afp.offentlig.livsvarig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AfpOffentligLivsvarig
+import java.time.LocalDate
+
+class LivsvarigOffentligAfpUtilTest : FunSpec({
+
+    test("getLivsvarigOffentligAfp should give null when 'gjelder fom' is after knekkpunktdato") {
+        LivsvarigOffentligAfpUtil.getLivsvarigOffentligAfp(
+            resultatListe = listOf(
+                ytelse(afpYtelsePerAar = 12.3, gjelderFom = LocalDate.of(2025, 3, 1))
+            ),
+            knekkpunktDato = LocalDate.of(2025, 2, 1)
+        ) shouldBe null
+    }
+
+    test("getLivsvarigOffentligAfp should give result when 'gjelder fom' is before knekkpunktdato") {
+        val result = LivsvarigOffentligAfpUtil.getLivsvarigOffentligAfp(
+            resultatListe = listOf(
+                ytelse(afpYtelsePerAar = 12.3, gjelderFom = LocalDate.of(2025, 1, 1))
+            ),
+            knekkpunktDato = LocalDate.of(2025, 2, 1)
+        )
+
+        result?.let {
+            it shouldBeEqualToComparingFields AfpOffentligLivsvarig().apply {
+                bruttoPerAr = 12.3
+                uttaksdato = LocalDate.of(2025, 1, 1)
+            }
+        }
+    }
+
+    test("getLivsvarigOffentligAfp should pick max. 'gjelder fom' before or on knekkpunktdato") {
+        val result = LivsvarigOffentligAfpUtil.getLivsvarigOffentligAfp(
+            resultatListe = listOf(
+                ytelse(afpYtelsePerAar = 12.3, gjelderFom = LocalDate.of(2025, 1, 1)), // before
+                ytelse(afpYtelsePerAar = 23.4, gjelderFom = LocalDate.of(2025, 2, 1)), // on => max gjelderFom
+                ytelse(afpYtelsePerAar = 34.5, gjelderFom = LocalDate.of(2025, 3, 1))  // after
+            ),
+            knekkpunktDato = LocalDate.of(2025, 2, 1)
+        )
+
+        result?.let {
+            it shouldBeEqualToComparingFields AfpOffentligLivsvarig().apply {
+                bruttoPerAr = 23.4
+                uttaksdato = LocalDate.of(2025, 2, 1)
+            }
+        }
+    }
+})
+
+private fun ytelse(afpYtelsePerAar: Double, gjelderFom: LocalDate) =
+    LivsvarigOffentligAfpYtelseMedDelingstall(
+        pensjonBeholdning = 1234,
+        afpYtelsePerAar,
+        delingstall = 1.2,
+        gjelderFom,
+        gjelderFomAlder = Alder(63, 0)
+    )

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beholdning/BeholdningUpdaterUtilTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beholdning/BeholdningUpdaterUtilTest.kt
@@ -5,9 +5,7 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDato
-import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtMidnight
 import java.time.LocalDate
-import java.util.*
 
 class BeholdningUpdaterUtilTest : FunSpec({
 
@@ -20,21 +18,21 @@ class BeholdningUpdaterUtilTest : FunSpec({
     test("isRevurderingBackToFirstUttaksdatoOrForstegangsbehandling => true if matching earliest 'første virkningsdato'") {
         BeholdningUpdaterUtil.isRevurderingBackToFirstUttaksdatoOrForstegangsbehandling(Kravhode().apply {
             sakForsteVirkningsdatoListe = foersteVirkningDatoListe
-            onsketVirkningsdato = dateAtMidnight(2025, Calendar.FEBRUARY, 15)
+            onsketVirkningsdato = LocalDate.of(2025, 2, 15)
         }).shouldBeTrue()
     }
 
     test("isRevurderingBackToFirstUttaksdatoOrForstegangsbehandling => true if no 'første virkningsdato'") {
         BeholdningUpdaterUtil.isRevurderingBackToFirstUttaksdatoOrForstegangsbehandling(Kravhode().apply {
             sakForsteVirkningsdatoListe = emptyList()
-            onsketVirkningsdato = dateAtMidnight(2025, Calendar.FEBRUARY, 15)
+            onsketVirkningsdato = LocalDate.of(2025, 2, 15)
         }).shouldBeTrue()
     }
 
     test("isRevurderingBackToFirstUttaksdatoOrForstegangsbehandling => false if not matching earliest 'første virkningsdato'") {
         BeholdningUpdaterUtil.isRevurderingBackToFirstUttaksdatoOrForstegangsbehandling(Kravhode().apply {
             sakForsteVirkningsdatoListe = foersteVirkningDatoListe
-            onsketVirkningsdato = dateAtMidnight(2027, Calendar.JANUARY, 1)
+            onsketVirkningsdato = LocalDate.of(2027, 1, 1)
         }).shouldBeFalse()
     }
 })

--- a/src/test/kotlin/no/nav/pensjon/simulator/tech/time/PeriodeTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/tech/time/PeriodeTest.kt
@@ -1,0 +1,40 @@
+package no.nav.pensjon.simulator.tech.time
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class PeriodeTest: FunSpec( {
+
+    test("fitsIn true") {
+        Periode.of(LocalDate.of(2021, 1, 2), LocalDate.of(2021, 1, 30))
+            .fitsIn(Periode.of(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 31))) shouldBe true
+    }
+
+    test("fitsIn false") {
+        Periode.of(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 2, 1))
+            .fitsIn(Periode.of(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 31))) shouldBe false
+    }
+
+    test("sameStart true") {
+        Periode.of(LocalDate.of(2022, 2, 2), LocalDate.of(2023, 1, 1))
+            .sameStart(Periode.of(LocalDate.of(2022, 2, 2), LocalDate.of(2024, 2, 2))) shouldBe true
+    }
+
+    test("sameStart false") {
+        Periode.of(LocalDate.of(2022, 2, 3), LocalDate.of(2023, 1, 1))
+            .sameStart(Periode.of(LocalDate.of(2022, 2, 2), LocalDate.of(2023, 1, 1))) shouldBe false
+    }
+
+    test("sameEnd true") {
+        Periode.of(LocalDate.of(2021, 1, 1), LocalDate.of(2023, 1, 1))
+            .sameEnd(Periode.of(LocalDate.of(2022, 2, 2), LocalDate.of(2023, 1, 1))) shouldBe true
+    }
+
+    test("sameEnd false") {
+        Periode.of(LocalDate.of(2022, 2, 2), LocalDate.of(2023, 1, 1))
+            .sameEnd(Periode.of(LocalDate.of(2022, 2, 2), LocalDate.of(2023, 2, 1))) shouldBe false
+    }
+})


### PR DESCRIPTION
Inkluderer innvilget livsvarig offentlig AFP i persongrunnlaget for løpende ytelser som hentes fra PEN.

Endrer også `onsketVirkningsdato` til å være `LocalDate` i `Kravhode`.

Tilhørende endring i PEN: [PR 15710](https://github.com/navikt/pensjon-pen/pull/15710)