### PR TITLE
Feature/pek 964 maanedsbeløp

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
@@ -49,7 +49,7 @@ data class SimulertAlderspensjonFraFolketrygden(
 data class SimulertPrivatAfp(
     val alderAar: Int,
     val beloep: Int,
-    val maanedligBeloep: Int?
+    val maanedligBeloep: Int
 )
 
 data class SimulertPre2025OffentligAfp(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
@@ -69,7 +69,8 @@ data class SimulertPre2025OffentligAfp(
 
 data class SimulertLivsvarigOffentligAfp(
     val alderAar: Int,
-    val beloep: Int
+    val beloep: Int,
+    val maanedligBeloep: Int
 )
 
 data class SimulertPensjonBeholdningPeriode(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
@@ -48,7 +48,8 @@ data class SimulertAlderspensjonFraFolketrygden(
 
 data class SimulertPrivatAfp(
     val alderAar: Int,
-    val beloep: Int
+    val beloep: Int,
+    val maanedligBeloep: Int?
 )
 
 data class SimulertPre2025OffentligAfp(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
@@ -76,7 +76,8 @@ object NavSimuleringResultMapperV3 {
     private fun livsvarigOffentligAfp(source: SimulertLivsvarigOffentligAfp) =
         NavLivsvarigOffentligAfpV3(
             alderAar = source.alderAar,
-            beloep = source.beloep
+            beloep = source.beloep,
+            maanedligBeloep = source.maanedligBeloep
         )
 
     private fun vilkaarsproevingResultat(source: SimulertAlternativ?) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
@@ -69,7 +69,8 @@ object NavSimuleringResultMapperV3 {
     private fun privatAfp(source: SimulertPrivatAfp) =
         NavPrivatAfpV3(
             alderAar = source.alderAar,
-            beloep = source.beloep
+            beloep = source.beloep,
+            maanedligBeloep = source.maanedligBeloep
         )
 
     private fun livsvarigOffentligAfp(source: SimulertLivsvarigOffentligAfp) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
@@ -51,7 +51,7 @@ data class NavMaanedsbeloepV3(
 data class NavPrivatAfpV3(
     val alderAar: Int,
     val beloep: Int,
-    val maanedligBeloep: Int?
+    val maanedligBeloep: Int
 )
 
 data class NavLivsvarigOffentligAfpV3(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
@@ -56,7 +56,8 @@ data class NavPrivatAfpV3(
 
 data class NavLivsvarigOffentligAfpV3(
     val alderAar: Int,
-    val beloep: Int
+    val beloep: Int,
+    val maanedligBeloep: Int
 )
 
 data class NavPre2025OffentligAfp(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
@@ -50,7 +50,8 @@ data class NavMaanedsbeloepV3(
 
 data class NavPrivatAfpV3(
     val alderAar: Int,
-    val beloep: Int
+    val beloep: Int,
+    val maanedligBeloep: Int?
 )
 
 data class NavLivsvarigOffentligAfpV3(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
@@ -125,7 +125,7 @@ object SimulatorOutputConverter {
     }
 
     private fun privatAfp(source: SimulertPrivatAfpPeriode) =
-        SimulertPrivatAfp(source.alderAar ?: 0, source.aarligBeloep ?: 0)
+        SimulertPrivatAfp(source.alderAar ?: 0, source.aarligBeloep ?: 0, source.maanedligBeloep)
 
     /**
      * Ref. BeregningFormPopulator.createBeregningFormDataFromBeregning in pensjon-pselv

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
@@ -125,7 +125,7 @@ object SimulatorOutputConverter {
     }
 
     private fun privatAfp(source: SimulertPrivatAfpPeriode) =
-        SimulertPrivatAfp(source.alderAar ?: 0, source.aarligBeloep ?: 0, source.maanedligBeloep)
+        SimulertPrivatAfp(source.alderAar ?: 0, source.aarligBeloep ?: 0, source.maanedligBeloep ?: 0)
 
     /**
      * Ref. BeregningFormPopulator.createBeregningFormDataFromBeregning in pensjon-pselv

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
@@ -159,7 +159,7 @@ object SimulatorOutputConverter {
 
 
     private fun livsvarigOffentligAfp(source: OutputLivsvarigOffentligAfp) =
-        SimulertLivsvarigOffentligAfp(source.alderAar, source.beloep)
+        SimulertLivsvarigOffentligAfp(source.alderAar, source.beloep, source.maanedligBeloep)
 
     private fun beholdningPeriode(source: BeholdningPeriode) =
         SimulertPensjonBeholdningPeriode(

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/livsvarig/LivsvarigOffentligAfpPeriodeConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/offentlig/livsvarig/LivsvarigOffentligAfpPeriodeConverter.kt
@@ -35,7 +35,8 @@ object LivsvarigOffentligAfpPeriodeConverter {
             else -> listOf(
                 OutputLivsvarigOffentligAfp(
                     alderAar = ytelseVedUttak.gjelderFomAlder.aar,
-                    beloep = ytelseVedUttak.afpYtelsePerAar.toInt()
+                    beloep = ytelseVedUttak.afpYtelsePerAar.toInt(),
+                    maanedligBeloep = (ytelseVedUttak.afpYtelsePerAar / MAANEDER_PER_AAR).roundToInt()
                 )
             )
         }
@@ -66,10 +67,11 @@ object LivsvarigOffentligAfpPeriodeConverter {
             satsPerMaanedVedUttak * maanederMedUttakSats + satsPerMaanedEtterOppdatering * maanederMedOppdatertUttakSats
 
         return listOf(
-            OutputLivsvarigOffentligAfp(alderAar = alderAarVedUttak, beloep = belop.roundToInt()),
+            OutputLivsvarigOffentligAfp(alderAar = alderAarVedUttak, beloep = belop.roundToInt(), maanedligBeloep = satsPerMaanedVedUttak.roundToInt()),
             OutputLivsvarigOffentligAfp(
                 alderAar = alderAarVedUttak + 1,
-                beloep = ytelsePerAarEtterOppdatering.roundToInt()
+                beloep = ytelsePerAarEtterOppdatering.roundToInt(),
+                maanedligBeloep = satsPerMaanedEtterOppdatering.roundToInt()
             )
         )
     }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/out/OutputLivsvarigOffentligAfp.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/out/OutputLivsvarigOffentligAfp.kt
@@ -2,5 +2,6 @@ package no.nav.pensjon.simulator.core.out
 
 data class OutputLivsvarigOffentligAfp(
     val alderAar: Int,
-    val beloep: Int
+    val beloep: Int,
+    val maanedligBeloep: Int
 )

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
@@ -47,7 +47,7 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                             maanedligBeloep = 678
                         )
                     ),
-                    privatAfp = listOf(SimulertPrivatAfp(alderAar = 66, beloep = 789)),
+                    privatAfp = listOf(SimulertPrivatAfp(alderAar = 66, beloep = 789, maanedligBeloep = 100)),
                     pre2025OffentligAfp = SimulertPre2025OffentligAfp(alderAar = 62, totaltAfpBeloep = 890, tidligereArbeidsinntekt = 123, grunnbeloep = 456, sluttpoengtall = 7.8, trygdetid = 30, poengaarTom1991 = 10, poengaarFom1992 = 20, grunnpensjon = 567, tilleggspensjon = 678, afpTillegg = 789, saertillegg = 890),
                     livsvarigOffentligAfp = listOf(SimulertLivsvarigOffentligAfp(alderAar = 63, beloep = 901)),
                     pensjonBeholdningPeriodeListe = listOf(
@@ -123,7 +123,7 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                 afpTillegg = 789,
                 saertillegg = 890
             ),
-            privatAfpListe = listOf(NavPrivatAfpV3(alderAar = 66, beloep = 789)),
+            privatAfpListe = listOf(NavPrivatAfpV3(alderAar = 66, beloep = 789, maanedligBeloep = 300)),
             livsvarigOffentligAfpListe = listOf(NavLivsvarigOffentligAfpV3(alderAar = 63, beloep = 901)),
             vilkaarsproeving = NavVilkaarsproevingResultatV3(
                 vilkaarErOppfylt = false, // since alternativ exists

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
@@ -49,7 +49,7 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                     ),
                     privatAfp = listOf(SimulertPrivatAfp(alderAar = 66, beloep = 789, maanedligBeloep = 100)),
                     pre2025OffentligAfp = SimulertPre2025OffentligAfp(alderAar = 62, totaltAfpBeloep = 890, tidligereArbeidsinntekt = 123, grunnbeloep = 456, sluttpoengtall = 7.8, trygdetid = 30, poengaarTom1991 = 10, poengaarFom1992 = 20, grunnpensjon = 567, tilleggspensjon = 678, afpTillegg = 789, saertillegg = 890),
-                    livsvarigOffentligAfp = listOf(SimulertLivsvarigOffentligAfp(alderAar = 63, beloep = 901)),
+                    livsvarigOffentligAfp = listOf(SimulertLivsvarigOffentligAfp(alderAar = 63, beloep = 901, maanedligBeloep = 100)),
                     pensjonBeholdningPeriodeListe = listOf(
                         SimulertPensjonBeholdningPeriode(
                             pensjonBeholdning = 2.3,
@@ -124,7 +124,7 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                 saertillegg = 890
             ),
             privatAfpListe = listOf(NavPrivatAfpV3(alderAar = 66, beloep = 789, maanedligBeloep = 100)),
-            livsvarigOffentligAfpListe = listOf(NavLivsvarigOffentligAfpV3(alderAar = 63, beloep = 901)),
+            livsvarigOffentligAfpListe = listOf(NavLivsvarigOffentligAfpV3(alderAar = 63, beloep = 901, maanedligBeloep = 100)),
             vilkaarsproeving = NavVilkaarsproevingResultatV3(
                 vilkaarErOppfylt = false, // since alternativ exists
                 alternativ = NavAlternativtResultatV3(

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
@@ -123,7 +123,7 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                 afpTillegg = 789,
                 saertillegg = 890
             ),
-            privatAfpListe = listOf(NavPrivatAfpV3(alderAar = 66, beloep = 789, maanedligBeloep = 300)),
+            privatAfpListe = listOf(NavPrivatAfpV3(alderAar = 66, beloep = 789, maanedligBeloep = 100)),
             livsvarigOffentligAfpListe = listOf(NavLivsvarigOffentligAfpV3(alderAar = 63, beloep = 901)),
             vilkaarsproeving = NavVilkaarsproevingResultatV3(
                 vilkaarErOppfylt = false, // since alternativ exists

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
@@ -151,7 +151,8 @@ class NavSimuleringResultMapperV3Test2 {
                     privatAfp = listOf(
                         SimulertPrivatAfp(
                             alderAar = 9,
-                            beloep = 10
+                            beloep = 10,
+                            maanedligBeloep = 1
                         )
                     ),
                     pre2025OffentligAfp = SimulertPre2025OffentligAfp(

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
@@ -172,7 +172,8 @@ class NavSimuleringResultMapperV3Test2 {
                     livsvarigOffentligAfp = listOf(
                         SimulertLivsvarigOffentligAfp(
                             alderAar = 13,
-                            beloep = 14
+                            beloep = 14,
+                            maanedligBeloep = 1
                         )
                     ),
                     pensjonBeholdningPeriodeListe = listOf(

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
@@ -62,7 +62,7 @@ class TpoAlderspensjonResultMapperTest : FunSpec({
                     ),
                     privatAfp = listOf(SimulertPrivatAfp(alderAar = 63, beloep = 5000, maanedligBeloep = 900)),
                     pre2025OffentligAfp = null,
-                    livsvarigOffentligAfp = listOf(SimulertLivsvarigOffentligAfp(alderAar = 66, beloep = 6000)),
+                    livsvarigOffentligAfp = listOf(SimulertLivsvarigOffentligAfp(alderAar = 66, beloep = 6000, maanedligBeloep = 500)),
                     pensjonBeholdningPeriodeListe = listOf(
                         SimulertPensjonBeholdningPeriode(
                             pensjonBeholdning = 100.2,

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
@@ -60,7 +60,7 @@ class TpoAlderspensjonResultMapperTest : FunSpec({
                             maanedligBeloep = 500
                         )
                     ),
-                    privatAfp = listOf(SimulertPrivatAfp(alderAar = 63, beloep = 5000)),
+                    privatAfp = listOf(SimulertPrivatAfp(alderAar = 63, beloep = 5000, maanedligBeloep = 900)),
                     pre2025OffentligAfp = null,
                     livsvarigOffentligAfp = listOf(SimulertLivsvarigOffentligAfp(alderAar = 66, beloep = 6000)),
                     pensjonBeholdningPeriodeListe = listOf(


### PR DESCRIPTION
Lagt til månedsbeløp for livsvarig privat- og offentlig afp.

- `PrivatAFP` sitt månedsbeløp hentes rett fra regler
- `OffentligAFP` sitt månedsbeløp kalkuleres ved å dele de forskjellige ytelsene som kommer fra `tjenesetepensjon-simulering`
