### PR TITLE
PEK-1132 ikke mappe fom dato til heltuttaksdato

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/spec/AfpEtterfulgtAvAlderspensjonSpecMapperV0.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/spec/AfpEtterfulgtAvAlderspensjonSpecMapperV0.kt
@@ -34,7 +34,7 @@ object AfpEtterfulgtAvAlderspensjonSpecMapperV0 {
             epsHarPensjon = epsHarPensjon,
             epsHarInntektOver2G = epsHarInntektOver2G,
             foersteUttakDato = uttakDato,
-            heltUttakDato = uttakDato,
+            heltUttakDato = null, //alltid 67 år ved AFP etterfulgt av AP
             fremtidigInntektListe = mutableListOf(),
             brukFremtidigInntekt = false,
             inntektEtterHeltUttakBeloep = 0,


### PR DESCRIPTION
Dette er riktig mapping som forhindrer feilmapping av inntektsgrunnlag for brukere som er over aldersgrense for å simulere AFP etterfulgt av AP