### PR TITLE
Use inline value class for PID and organisasjonsnummer

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/generelt/organisasjon/Organisasjonsnummer.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/generelt/organisasjon/Organisasjonsnummer.kt
@@ -1,7 +1,20 @@
 package no.nav.pensjon.simulator.generelt.organisasjon
 
-data class Organisasjonsnummer(
-    val value: String
-) {
+/**
+ * Representerer organisasjonsnummer (no.wikipedia.org/wiki/Organisasjonsnummer)
+ */
+@JvmInline
+value class Organisasjonsnummer(val value: String) {
+
+    init {
+        require(value.length == REQUIRED_LENGTH) {
+            "Feil lengde (${value.length}) på organisasjonsnummer; må være $REQUIRED_LENGTH"
+        }
+    }
+
     override fun toString(): String = value
+
+    companion object {
+        private const val REQUIRED_LENGTH = 9
+    }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/person/Pid.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/person/Pid.kt
@@ -3,18 +3,19 @@ package no.nav.pensjon.simulator.person
 /**
  * Person identifier, e.g. fødselsnummer (FNR).
  */
-class Pid(argument: String) {
+@JvmInline
+value class Pid(val argument: String) {
 
-    val isValid = argument.length == FOEDSELSNUMMER_LENGTH
-    val value = if (isValid) argument else "invalid"
-    val displayValue = redact(value)
+    val isValid: Boolean
+        get() = argument.length == FOEDSELSNUMMER_LENGTH
+
+    val value: String
+        get() = if (isValid) argument else "invalid"
+
+    val displayValue : String
+        get() = redact(value)
 
     override fun toString(): String = displayValue
-
-    override fun hashCode(): Int = value.hashCode()
-
-    override fun equals(other: Any?): Boolean =
-        (other as? Pid)?.let { value == it.value } == true
 
     companion object {
         private const val FOEDSELSNUMMER_LENGTH = 11

--- a/src/test/kotlin/no/nav/pensjon/simulator/generelt/organisasjon/OrganisasjonsnummerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/generelt/organisasjon/OrganisasjonsnummerTest.kt
@@ -1,11 +1,22 @@
 package no.nav.pensjon.simulator.generelt.organisasjon
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class OrganisasjonsnummerTest : FunSpec({
 
-    test("toString returns the original organisasjonsnummer") {
+    test("toString should return the original organisasjonsnummer") {
         "Org: ${Organisasjonsnummer("123456789")}" shouldBe "Org: 123456789"
+    }
+
+    test("organisasjonsnummer should require length 9") {
+        shouldThrow<IllegalArgumentException> {
+            Organisasjonsnummer("")
+        }.message shouldBe "Feil lengde (0) på organisasjonsnummer; må være 9"
+
+        shouldThrow<IllegalArgumentException> {
+            Organisasjonsnummer("1234567890")
+        }.message shouldBe "Feil lengde (10) på organisasjonsnummer; må være 9"
     }
 })


### PR DESCRIPTION
Bruker 'inline value class' for å redusere 'runtime overhead', ref. [Inline value classes](https://kotlinlang.org/docs/inline-classes.html).

Pluss validering av lengde på organisasjonsnummer.