### PR TITLE
Handle 'no result' case for uføre

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimuleringFacade.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimuleringFacade.kt
@@ -53,9 +53,9 @@ class SimuleringFacade(
         if (gjelderUfoereMedAfp)
             if (spec.isGradert() && spec.heltUttakDato!!.isBefore(normAlderService.normAlderDato(spec.foedselDato!!)))
                 if (spec.uttakGrad == UttakGradKode.P_20) // ingen lavere uttaksgrad mulig
-                    ufoereAlternativSimulering.simulerAlternativHvisUtkanttilfelletInnvilges(spec, inkluderPensjonHvisUbetinget)
+                    ufoereAlternativSimulering.simulerAlternativHvisUtkanttilfelletInnvilges(spec)
                 else
-                    ufoereAlternativSimulering.simulerMedNesteLavereUttaksgrad(spec, inkluderPensjonHvisUbetinget)
+                    ufoereAlternativSimulering.simulerMedNesteLavereUttaksgrad(spec)
             else
                 ufoereAlternativSimulering.simulerMedFallendeUttaksgrad(spec, exception)
         else if (spec.onlyVilkaarsproeving.not() && isGradertAndReducible(spec))

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjonEllerAlternativ.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjonEllerAlternativ.kt
@@ -26,5 +26,6 @@ data class SimulertUttakAlder(
 enum class SimulatorResultStatus {
     GOOD,
     SUBOPTIMAL,
-    BAD
+    BAD,
+    NONE
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativSimuleringService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativSimuleringService.kt
@@ -9,12 +9,10 @@ import no.nav.pensjon.simulator.core.exception.UtilstrekkeligTrygdetidException
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
 import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
-import no.nav.pensjon.simulator.core.spec.SimuleringSpecUtil.ubetingetSimuleringSpec
 import no.nav.pensjon.simulator.core.spec.SimuleringSpecUtil.utkantSimuleringSpec
 import no.nav.pensjon.simulator.core.spec.SimuleringSpecUtil.withGradertInsteadOfHeltUttak
 import no.nav.pensjon.simulator.core.spec.SimuleringSpecUtil.withLavereUttakGrad
 import no.nav.pensjon.simulator.normalder.NormAlderService
-import no.nav.pensjon.simulator.uttak.UttakUtil.uttakDato
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -35,10 +33,7 @@ class UfoereAlternativSimuleringService(
     private val normAlderService: NormAlderService,
     private val alternativtUttakService: UfoereAlternativtUttakService
 ) {
-    fun simulerMedNesteLavereUttaksgrad(
-        spec: SimuleringSpec,
-        inkluderPensjonHvisUbetinget: Boolean
-    ): SimulertPensjonEllerAlternativ {
+    fun simulerMedNesteLavereUttaksgrad(spec: SimuleringSpec): SimulertPensjonEllerAlternativ {
         return try {
             val lavereGradSpec: SimuleringSpec = withLavereUttakGrad(spec)
             val result: SimulatorOutput = simulator.simuler(lavereGradSpec)
@@ -50,9 +45,9 @@ class UfoereAlternativSimuleringService(
             )
         } catch (e: UtilstrekkeligOpptjeningException) {
             // Lavere grad ga "avslått" resultat; prøv utkanttilfellet og ev. alternative parametre:
-            simulerAlternativHvisUtkanttilfelletInnvilges(spec, inkluderPensjonHvisUbetinget) ?: throw e
+            simulerAlternativHvisUtkanttilfelletInnvilges(spec) ?: throw e
         } catch (e: UtilstrekkeligTrygdetidException) {
-            simulerAlternativHvisUtkanttilfelletInnvilges(spec, inkluderPensjonHvisUbetinget) ?: throw e
+            simulerAlternativHvisUtkanttilfelletInnvilges(spec) ?: throw e
         }
     }
 
@@ -112,10 +107,7 @@ class UfoereAlternativSimuleringService(
      * Hvis utkantilfellet gir "avslått" i vilkårsprøvingen, kan vi konkludere med at brukeren kun kan ta ut helt uttak,
      * og uttaket kan tidligst starte ved normalderen.
      */
-    fun simulerAlternativHvisUtkanttilfelletInnvilges(
-        spec: SimuleringSpec,
-        inkluderPensjonHvisUbetinget: Boolean
-    ): SimulertPensjonEllerAlternativ? {
+    fun simulerAlternativHvisUtkanttilfelletInnvilges(spec: SimuleringSpec): SimulertPensjonEllerAlternativ? {
         val normAlder: Alder = normAlderService.normAlder(spec.foedselDato)
 
         return try {
@@ -133,37 +125,13 @@ class UfoereAlternativSimuleringService(
             // Ingen exception => utkanttilfellet innvilget => prøv alternative parametre:
             alternativtUttakService.findAlternativtUttak(spec)
         } catch (_: UtilstrekkeligOpptjeningException) {
-            // Utkanttilfellet avslått (intet gradert uttak mulig); returner alternativ for ubetinget uttak:
-            if (inkluderPensjonHvisUbetinget)
-                ubetingetUttakResponseMedSimulertPensjon(spec, normAlder)
-            else
-                ubetingetUttakResponseUtenSimulertPensjon(spec.foedselDato!!, normAlder)
+            // Utkanttilfellet avslått (intet gradert uttak mulig);
+            // for uføre er da intet alternativ mulig, siden alder for første uttak ikke skal foreslås økt
+            noResult()
         } catch (_: UtilstrekkeligTrygdetidException) {
-            if (inkluderPensjonHvisUbetinget)
-                ubetingetUttakResponseMedSimulertPensjon(spec, normAlder)
-            else
-                ubetingetUttakResponseUtenSimulertPensjon(spec.foedselDato!!, normAlder)
+            noResult()
         }
     }
-
-    private fun ubetingetUttakResponseMedSimulertPensjon(
-        spec: SimuleringSpec,
-        normAlder: Alder
-    ): SimulertPensjonEllerAlternativ =
-        try {
-            val ubetingetSpec: SimuleringSpec = ubetingetSimuleringSpec(spec, normAlder)
-            val result: SimulatorOutput = simulator.simuler(ubetingetSpec)
-            alternativResponse(ubetingetSpec, if (spec.onlyVilkaarsproeving) null else pensjon(result))
-        } catch (e: UtilstrekkeligOpptjeningException) {
-            // Skal ikke kunne skje
-            throw RuntimeException("Simulering for ubetinget alder feilet", e)
-        } catch (e: UtilstrekkeligTrygdetidException) {
-            // Skal ikke kunne skje
-            throw RuntimeException("Simulering for ubetinget alder feilet", e)
-        }
-
-    private fun ubetingetUttakResponseUtenSimulertPensjon(foedselsdato: LocalDate, normAlder: Alder) =
-        alternativResponse(ubetingetUttakAlternativ(foedselsdato, normAlder), alternativPensjon = null)
 
     private companion object {
 
@@ -179,20 +147,6 @@ class UfoereAlternativSimuleringService(
                 )
             }
 
-        private fun ubetingetUttakAlternativ(foedselsdato: LocalDate, normAlder: Alder) =
-            SimulertAlternativ(
-                gradertUttakAlder = null,
-                uttakGrad = UttakGradKode.P_100,
-                heltUttakAlder = ubetingetUttakAlder(foedselsdato, normAlder),
-                resultStatus = SimulatorResultStatus.GOOD
-            )
-
-        private fun ubetingetUttakAlder(foedselsdato: LocalDate, normAlder: Alder) =
-            SimulertUttakAlder(
-                alder = normAlder,
-                uttakDato = uttakDato(foedselsdato, normAlder)
-            )
-
         private fun alternativResponse(spec: SimuleringSpec, alternativPensjon: SimulertPensjon?) =
             alternativResponse(alternativ(spec), alternativPensjon)
 
@@ -200,6 +154,17 @@ class UfoereAlternativSimuleringService(
             SimulertPensjonEllerAlternativ(
                 pensjon = alternativPensjon,
                 alternativ
+            )
+
+        private fun noResult() =
+            SimulertPensjonEllerAlternativ(
+                pensjon = null,
+                alternativ = SimulertAlternativ(
+                    gradertUttakAlder = null,
+                    uttakGrad = UttakGradKode.P_0,
+                    heltUttakAlder = SimulertUttakAlder(alder = Alder(0, 0), uttakDato = LocalDate.MIN),
+                    resultStatus = SimulatorResultStatus.NONE
+                )
             )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
@@ -95,11 +95,14 @@ object NavSimuleringResultMapperV3 {
         )
 
     private fun alternativ(source: SimulertAlternativ) =
-        NavAlternativtResultatV3(
-            gradertUttakAlder = source.gradertUttakAlder?.let(::alder),
-            uttaksgrad = source.uttakGrad.value.toInt(),
-            heltUttakAlder = alder(source.heltUttakAlder)
-        )
+        if (source.resultStatus == SimulatorResultStatus.NONE)
+            null
+        else
+            NavAlternativtResultatV3(
+                gradertUttakAlder = source.gradertUttakAlder?.let(::alder),
+                uttaksgrad = source.uttakGrad.value.toInt(),
+                heltUttakAlder = alder(source.heltUttakAlder)
+            )
 
     private fun alder(source: SimulertUttakAlder) =
         NavAlderV3(


### PR DESCRIPTION
Håndtering av tilfellet der ingen alternative uttak finnes for uføre. Siden første uttaksalder ikke kan økes, kan ikke helt uttak ved normalder være et alternativ, slik det er normalt (for ikke-uføre).