### PR TITLE
Inject time into SimulatorOutputConverter

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonService.kt
@@ -61,32 +61,32 @@ class AlderspensjonService(
             val result: SimulatorOutput = simulator.simuler(spec)
 
             return SimulertPensjonEllerAlternativ(
-                pensjon = SimulatorOutputConverter.pensjon(result, spec), // SimulatorOutput -> SimulertPensjon
+                pensjon = SimulatorOutputConverter.pensjon( // SimulatorOutput -> SimulertPensjon
+                    source = result,
+                    today = time.today(),
+                    inntektVedFase1Uttak = spec.inntektUnderGradertUttakBeloep
+                ),
                 alternativ = null
             )
         } catch (e: UtilstrekkeligOpptjeningException) {
             // Brukers angitte parametre ga "avslått" resultat; prøv med alternative parametre:
             return if (isReducible(spec.uttakGrad))
                 alternativSimuleringService.simulerMedNesteLavereUttaksgrad(
-                    spec,
-                    inkluderPensjonHvisUbetinget = true
+                    spec, inkluderPensjonHvisUbetinget = true
                 )
             else
                 alternativSimuleringService.simulerAlternativHvisUtkanttilfelletInnvilges(
-                    spec,
-                    inkluderPensjonHvisUbetinget = true
+                    spec, inkluderPensjonHvisUbetinget = true
                 ) ?: throw e
         } catch (e: UtilstrekkeligTrygdetidException) {
             // Brukers angitte parametre ga "avslått" resultat; prøv med alternative parametre:
             return if (isReducible(spec.uttakGrad))
                 alternativSimuleringService.simulerMedNesteLavereUttaksgrad(
-                    spec,
-                    inkluderPensjonHvisUbetinget = true
+                    spec, inkluderPensjonHvisUbetinget = true
                 )
             else
                 alternativSimuleringService.simulerAlternativHvisUtkanttilfelletInnvilges(
-                    spec,
-                    inkluderPensjonHvisUbetinget = true
+                    spec, inkluderPensjonHvisUbetinget = true
                 ) ?: throw e
         }
     }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakFinder.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakFinder.kt
@@ -9,6 +9,7 @@ import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
 import no.nav.pensjon.simulator.search.SmallestValueSearch
+import no.nav.pensjon.simulator.tech.time.Time
 import no.nav.pensjon.simulator.uttak.UttakUtil.uttakDato
 import java.time.LocalDate
 import java.time.Period
@@ -22,7 +23,8 @@ class AlternativtUttakFinder(
     private val discriminator: UttakAlderDiscriminator,
     private val simuleringSpec: SimuleringSpec,
     private val normalderService: NormertPensjonsalderService,
-    private val heltUttakInntektTomAlderAar: Int? // behøves bare ved helt uttak når fom/tom angis i form av alder
+    private val heltUttakInntektTomAlderAar: Int?, // behøves bare ved helt uttak når fom/tom angis i form av alder
+    private val time: Time
 ) {
     private val foedselsdato: LocalDate by lazy {
         simuleringSpec.pid?.let(discriminator::fetchFoedselsdato) ?: throw InvalidArgumentException("Udefinert PID")
@@ -79,7 +81,7 @@ class AlternativtUttakFinder(
         val helAlder = alder(helPeriode)
 
         return SimulertPensjonEllerAlternativ(
-            pensjon = if (simuleringSpec.onlyVilkaarsproeving) null else pensjon?.let(::pensjon),
+            pensjon = if (simuleringSpec.onlyVilkaarsproeving) null else pensjon?.let { pensjon(it, time.today()) },
             // for 'onlyVilkaarsproeving' er beregnet pensjon uinteressant (kun vilkårsvurdering blir brukt)
             alternativ = SimulertAlternativ(
                 uttakGrad = usedParameters.uttakGrad,

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakService.kt
@@ -7,12 +7,14 @@ import no.nav.pensjon.simulator.core.spec.GradertUttakSimuleringSpec
 import no.nav.pensjon.simulator.core.spec.HeltUttakSimuleringSpec
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
+import no.nav.pensjon.simulator.tech.time.Time
 import org.springframework.stereotype.Service
 
 @Service
 class AlternativtUttakService(
     private val simulator: SimulatorCore,
-    private val normalderService: NormertPensjonsalderService
+    private val normalderService: NormertPensjonsalderService,
+    private val time: Time
 ) {
     fun findAlternativtUttak(
         spec: SimuleringSpec,
@@ -45,7 +47,7 @@ class AlternativtUttakService(
         maxUttaksgrad: UttakGradKode
     ): SimulertPensjonEllerAlternativ {
         val normalder: Alder = normalderService.normalder(spec.foedselDato!!)
-        val finder = AlternativtUttakFinder(simulator, spec, normalderService, heltUttakInntektTomAlderAar)
+        val finder = AlternativtUttakFinder(simulator, spec, normalderService, heltUttakInntektTomAlderAar, time)
         val foersteUttakMinAlder = foersteUttakAngittAlder.plusMaaneder(1)
 
         val andreUttakMinAlder: Alder? =

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimuleringFacade.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimuleringFacade.kt
@@ -9,6 +9,7 @@ import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.ufoere.UfoereService
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
+import no.nav.pensjon.simulator.tech.time.Time
 import org.springframework.stereotype.Service
 
 // PEN: SimpleSimuleringService
@@ -19,7 +20,8 @@ class SimuleringFacade(
     private val alternativSimulering: AlternativSimuleringService,
     private val ufoereAlternativSimulering: UfoereAlternativSimuleringService,
     private val normalderService: NormertPensjonsalderService,
-    private val ufoereService: UfoereService
+    private val ufoereService: UfoereService,
+    private val time: Time
 ) {
     fun simulerAlderspensjon(
         spec: SimuleringSpec,
@@ -32,8 +34,13 @@ class SimuleringFacade(
 
             return SimulertPensjonEllerAlternativ(
                 pensjon =
-                    if (spec.onlyVilkaarsproeving) null // irrelevant when finding uttak only
-                    else pensjon(result, spec),
+                    if (spec.onlyVilkaarsproeving)
+                        null // irrelevant when finding uttak only
+                    else pensjon(
+                        source = result,
+                        today = time.today(),
+                        inntektVedFase1Uttak = spec.inntektUnderGradertUttakBeloep
+                    ),
                 alternativ = null
             )
         } catch (e: UtilstrekkeligOpptjeningException) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativSimuleringService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativSimuleringService.kt
@@ -13,6 +13,7 @@ import no.nav.pensjon.simulator.core.spec.SimuleringSpecUtil.utkantSimuleringSpe
 import no.nav.pensjon.simulator.core.spec.SimuleringSpecUtil.withGradertInsteadOfHeltUttak
 import no.nav.pensjon.simulator.core.spec.SimuleringSpecUtil.withLavereUttakGrad
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
+import no.nav.pensjon.simulator.tech.time.Time
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -31,7 +32,8 @@ import java.time.LocalDate
 class UfoereAlternativSimuleringService(
     private val simulator: SimulatorCore,
     private val normalderService: NormertPensjonsalderService,
-    private val alternativtUttakService: UfoereAlternativtUttakService
+    private val alternativtUttakService: UfoereAlternativtUttakService,
+    private val time: Time
 ) {
     fun simulerMedNesteLavereUttaksgrad(spec: SimuleringSpec): SimulertPensjonEllerAlternativ {
         return try {
@@ -40,7 +42,7 @@ class UfoereAlternativSimuleringService(
             // Lavere grad innvilget; returner dette som alternativ og avslutt:
             alternativResponse(
                 spec = lavereGradSpec,
-                alternativPensjon = if (spec.onlyVilkaarsproeving) null else pensjon(result)
+                alternativPensjon = if (spec.onlyVilkaarsproeving) null else pensjon(result, time.today())
                 // for 'onlyVilkaarsproeving' er beregnet pensjon uinteressant (kun vilkårsvurdering blir brukt)
             )
         } catch (e: UtilstrekkeligOpptjeningException) {
@@ -86,7 +88,7 @@ class UfoereAlternativSimuleringService(
             // Lavere grad innvilget; returner dette som alternativ og avslutt:
             alternativResponse(
                 spec = lavereGradSpec,
-                alternativPensjon = if (spec.onlyVilkaarsproeving) null else pensjon(result)
+                alternativPensjon = if (spec.onlyVilkaarsproeving) null else pensjon(result, time.today())
                 // for 'onlyVilkaarsproeving' er beregnet pensjon uinteressant (kun vilkårsvurdering blir brukt)
             )
         } catch (e: UtilstrekkeligOpptjeningException) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativtUttakFinder.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativtUttakFinder.kt
@@ -9,6 +9,7 @@ import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
 import no.nav.pensjon.simulator.search.SmallestValueSearch
+import no.nav.pensjon.simulator.tech.time.Time
 import no.nav.pensjon.simulator.uttak.UttakUtil.indexedUttakGradSubmap
 import no.nav.pensjon.simulator.uttak.UttakUtil.uttakDato
 import java.time.LocalDate
@@ -26,7 +27,8 @@ import kotlin.math.max
 class UfoereAlternativtUttakFinder(
     private val discriminator: UttakAlderDiscriminator,
     private val simuleringSpec: SimuleringSpec,
-    private val normalderService: NormertPensjonsalderService
+    private val normalderService: NormertPensjonsalderService,
+    private val time: Time
 ) {
     private val foedselsdato: LocalDate by lazy {
         simuleringSpec.pid?.let(discriminator::fetchFoedselsdato) ?: throw InvalidArgumentException("Udefinert PID")
@@ -86,7 +88,7 @@ class UfoereAlternativtUttakFinder(
         val helAlder = alder(helPeriode)
 
         return SimulertPensjonEllerAlternativ(
-            pensjon = if (simuleringSpec.onlyVilkaarsproeving) null else pensjon?.let(::pensjon),
+            pensjon = if (simuleringSpec.onlyVilkaarsproeving) null else pensjon?.let { pensjon(it, time.today()) },
             // for 'onlyVilkaarsproeving' er beregnet pensjon uinteressant (kun vilkårsvurdering blir brukt)
             alternativ = SimulertAlternativ(
                 uttakGrad = usedParameters.uttakGrad,

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativtUttakService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativtUttakService.kt
@@ -5,12 +5,14 @@ import no.nav.pensjon.simulator.core.SimulatorCore
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
+import no.nav.pensjon.simulator.tech.time.Time
 import org.springframework.stereotype.Service
 
 @Service
 class UfoereAlternativtUttakService(
     private val simulator: SimulatorCore,
-    private val normalderService: NormertPensjonsalderService
+    private val normalderService: NormertPensjonsalderService,
+    private val time: Time
 ) {
     fun findAlternativtUttak(spec: SimuleringSpec): SimulertPensjonEllerAlternativ {
         val gradertUttak = spec.gradertUttak()
@@ -39,7 +41,7 @@ class UfoereAlternativtUttakService(
         maxUttaksgrad: UttakGradKode
     ): SimulertPensjonEllerAlternativ {
         val normalder: Alder = normalderService.normalder(spec.foedselDato!!)
-        val finder = UfoereAlternativtUttakFinder(simulator, spec, normalderService)
+        val finder = UfoereAlternativtUttakFinder(simulator, spec, normalderService, time)
 
         val andreUttakMinAlder: Alder? =
             andreUttakAngittAlder.let { if (foersteUttakAngittAlder == it) it.plusMaaneder(1) else it }

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/FolketrygdBeholdningService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/FolketrygdBeholdningService.kt
@@ -15,6 +15,7 @@ import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.generelt.GenerelleDataHolder
 import no.nav.pensjon.simulator.uttak.UttaksdatoValidator
+import no.nav.pensjon.simulator.tech.time.Time
 import no.nav.pensjon.simulator.vedtak.VedtakService
 import no.nav.pensjon.simulator.vedtak.VedtakStatus
 import org.springframework.stereotype.Component
@@ -23,6 +24,7 @@ import java.time.LocalDate
 @Component
 class FolketrygdBeholdningService(
     private val simulator: SimulatorCore,
+    private val time: Time,
     private val vedtakService: VedtakService,
     private val generelleDataHolder: GenerelleDataHolder,
     private val validator: UttaksdatoValidator
@@ -45,7 +47,7 @@ class FolketrygdBeholdningService(
 
         return FolketrygdBeholdning(
             pensjonBeholdningPeriodeListe =
-                SimulatorOutputConverter.pensjon(result).pensjonBeholdningPeriodeListe
+                SimulatorOutputConverter.pensjon(result, time.today()).pensjonBeholdningPeriodeListe
                     .map(::beholdningPeriode)
         )
     }

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakServiceTest.kt
@@ -22,10 +22,11 @@ import java.time.LocalDate
 class AlternativtUttakServiceTest : FunSpec({
 
     test("findAlternativtUttak should find alternativt uttak") {
-        val simulator = mock(SimulatorCore::class.java).also { arrangeSimulator(it) }
-        val normalderService = mock(NormertPensjonsalderService::class.java).also { arrangeNormalder(it) }
-
-        val service = AlternativtUttakService(simulator, normalderService)
+        val service = AlternativtUttakService(
+            simulator = arrangeSimulator(),
+            normalderService = arrangeNormalder(),
+            time = { LocalDate.of(2025, 1, 1) }
+        )
 
         service.findAlternativtUttak(
             spec = simuleringSpec(
@@ -66,64 +67,66 @@ class AlternativtUttakServiceTest : FunSpec({
     }
 })
 
-private fun arrangeNormalder(service: NormertPensjonsalderService) {
-    `when`(service.normalder(foedselsdato = LocalDate.of(1967, 1, 1))).thenReturn(Alder(67, 0))
-}
+private fun arrangeNormalder() =
+    mock(NormertPensjonsalderService::class.java).also {
+        `when`(it.normalder(foedselsdato = LocalDate.of(1967, 1, 1))).thenReturn(Alder(67, 0))
+    }
 
-private fun arrangeSimulator(simulator: SimulatorCore) {
-    `when`(simulator.fetchFoedselsdato(pid)).thenReturn(LocalDate.of(1967, 1, 1))
+private fun arrangeSimulator() =
+    mock(SimulatorCore::class.java).also {
+        `when`(it.fetchFoedselsdato(pid)).thenReturn(LocalDate.of(1967, 1, 1))
 
-    // Arrange a series of simulations that converge towards the best alternative:
-    `when`(
-        simulator.simuler(
-            simuleringSpec(
-                foersteUttakDato = LocalDate.of(2032, 2, 1),
-                uttaksgrad = UttakGradKode.P_40,
-                heltUttakDato = LocalDate.of(2033, 2, 1)
+        // Arrange a series of simulations that converge towards the best alternative:
+        `when`(
+            it.simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2032, 2, 1),
+                    uttaksgrad = UttakGradKode.P_40,
+                    heltUttakDato = LocalDate.of(2033, 2, 1)
+                )
             )
-        )
-    ).thenThrow(UtilstrekkeligOpptjeningException())
+        ).thenThrow(UtilstrekkeligOpptjeningException())
 
-    `when`(
-        simulator.simuler(
-            simuleringSpec(
-                foersteUttakDato = LocalDate.of(2033, 1, 1),
-                uttaksgrad = UttakGradKode.P_40,
-                heltUttakDato = LocalDate.of(2033, 8, 1)
+        `when`(
+            it.simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2033, 1, 1),
+                    uttaksgrad = UttakGradKode.P_40,
+                    heltUttakDato = LocalDate.of(2033, 8, 1)
+                )
             )
-        )
-    ).thenReturn(SimulatorOutput())
+        ).thenReturn(SimulatorOutput())
 
-    `when`(
-        simulator.simuler(
-            simuleringSpec(
-                foersteUttakDato = LocalDate.of(2032, 7, 1),
-                uttaksgrad = UttakGradKode.P_40,
-                heltUttakDato = LocalDate.of(2033, 5, 1)
+        `when`(
+            it.simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2032, 7, 1),
+                    uttaksgrad = UttakGradKode.P_40,
+                    heltUttakDato = LocalDate.of(2033, 5, 1)
+                )
             )
-        )
-    ).thenReturn(SimulatorOutput())
+        ).thenReturn(SimulatorOutput())
 
-    `when`(
-        simulator.simuler(
-            simuleringSpec(
-                foersteUttakDato = LocalDate.of(2032, 4, 1),
-                uttaksgrad = UttakGradKode.P_40,
-                heltUttakDato = LocalDate.of(2033, 3, 1)
+        `when`(
+            it.simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2032, 4, 1),
+                    uttaksgrad = UttakGradKode.P_40,
+                    heltUttakDato = LocalDate.of(2033, 3, 1)
+                )
             )
-        )
-    ).thenReturn(SimulatorOutput())
+        ).thenReturn(SimulatorOutput())
 
-    `when`(
-        simulator.simuler(
-            simuleringSpec(
-                foersteUttakDato = LocalDate.of(2032, 3, 1),
-                uttaksgrad = UttakGradKode.P_40,
-                heltUttakDato = LocalDate.of(2033, 3, 1)
+        `when`(
+            it.simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2032, 3, 1),
+                    uttaksgrad = UttakGradKode.P_40,
+                    heltUttakDato = LocalDate.of(2033, 3, 1)
+                )
             )
-        )
-    ).thenReturn(SimulatorOutput())
-}
+        ).thenReturn(SimulatorOutput())
+    }
 
 /**
  * IndexBasedSimulering.tryIndex: discriminator.simuler(indexSimulatorSpec)

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativSimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativSimuleringServiceTest.kt
@@ -24,7 +24,8 @@ class UfoereAlternativSimuleringServiceTest : FunSpec({
         val service = UfoereAlternativSimuleringService(
             simulator = arrangeAvslaattUtkanttilfelle(),
             normalderService = arrangeNormalder(),
-            alternativtUttakService = mock(UfoereAlternativtUttakService::class.java)
+            alternativtUttakService = mock(UfoereAlternativtUttakService::class.java),
+            time = { LocalDate.of(2025, 1, 1) }
         )
 
         service.simulerAlternativHvisUtkanttilfelletInnvilges(
@@ -45,7 +46,8 @@ class UfoereAlternativSimuleringServiceTest : FunSpec({
         val service = UfoereAlternativSimuleringService(
             simulator = arrangeGradertUttakEtterAvslaatt60ProsentUttak(),
             normalderService = arrangeNormalder(),
-            alternativtUttakService = mock(UfoereAlternativtUttakService::class.java)
+            alternativtUttakService = mock(UfoereAlternativtUttakService::class.java),
+            time = { LocalDate.of(2025, 1, 1) }
         )
 
         service.simulerMedFallendeUttaksgrad(
@@ -67,7 +69,8 @@ class UfoereAlternativSimuleringServiceTest : FunSpec({
         val service = UfoereAlternativSimuleringService(
             simulator = arrangeGradertUttakEtterAvslaattHeltUttak(),
             normalderService = arrangeNormalder(),
-            alternativtUttakService = mock(UfoereAlternativtUttakService::class.java)
+            alternativtUttakService = mock(UfoereAlternativtUttakService::class.java),
+            time = { LocalDate.of(2025, 1, 1) }
         )
 
         service.simulerMedFallendeUttaksgrad(
@@ -89,7 +92,8 @@ class UfoereAlternativSimuleringServiceTest : FunSpec({
         val service = UfoereAlternativSimuleringService(
             simulator = arrangeIngenInnvilgedeUttak(),
             normalderService = arrangeNormalder(),
-            alternativtUttakService = mock(UfoereAlternativtUttakService::class.java)
+            alternativtUttakService = mock(UfoereAlternativtUttakService::class.java),
+            time = { LocalDate.of(2025, 1, 1) }
         )
 
         shouldThrow<UtilstrekkeligOpptjeningException> {

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverterTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverterTest.kt
@@ -1,0 +1,166 @@
+package no.nav.pensjon.simulator.alderspensjon.convert
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertAarligAlderspensjon
+import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertAlderspensjonFraFolketrygden
+import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertPensjon
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
+import no.nav.pensjon.simulator.core.result.PensjonPeriode
+import no.nav.pensjon.simulator.core.result.SimulatorOutput
+import no.nav.pensjon.simulator.core.result.SimulertAlderspensjon
+import no.nav.pensjon.simulator.core.result.SimulertBeregningInformasjon
+import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
+import java.time.LocalDate
+import java.util.*
+
+class SimulatorOutputConverterTest : FunSpec({
+
+    /**
+     * Tests mapping of:
+     * - alderspensjon to alderspensjonFraFolketrygden
+     * - pensjonPeriodeListe to alderspensjon
+     * Also tests that:
+     * - harUttak = false if no uttaksgrad covers today's date
+     * - harNokTrygdetidForGarantipensjon = false if mindre enn 5 år 'kapittel 20'-trygdetid
+     */
+    test("'pensjon' should map SimulatorOutput to SimulertPensjon") {
+        SimulatorOutputConverter.pensjon(
+            source = SimulatorOutput().apply {
+                alderspensjon = SimulertAlderspensjon().apply {
+                    kapittel19Andel = 0.2
+                    kapittel20Andel = 0.8
+                    simulertBeregningInformasjonListe = listOf(
+                        SimulertBeregningInformasjon().apply { datoFom = LocalDate.of(2030, 1, 1) }
+                    )
+                    pensjonPeriodeListe.add(
+                        PensjonPeriode().apply {
+                            beloep = 1000
+                            alderAar = 64
+                            simulertBeregningInformasjonListe = mutableListOf(
+                                SimulertBeregningInformasjon().apply {
+                                    datoFom = LocalDate.of(2031, 2, 1) // not mapped
+                                    inntektspensjon = 200
+                                    garantipensjon = 300
+                                    delingstall = 1.2
+                                    pensjonBeholdningFoerUttak = 123000
+                                    spt = 2.3
+                                    tt_anv_kap19 = 19
+                                    tt_anv_kap20 = 4 // => mindre enn 5 år 'kapittel 20'-trygdetid
+                                    pa_f92 = 5
+                                    pa_e91 = 6
+                                    forholdstall = 3.4
+                                    grunnpensjon = 400
+                                    tilleggspensjon = 500
+                                    pensjonstillegg = 600
+                                    skjermingstillegg = 700
+                                })
+                            uttakGradListe = listOf(
+                                Uttaksgrad(
+                                    fomDato = dateAtNoon(2030, Calendar.JANUARY, 1),
+                                    tomDato = dateAtNoon(2040, Calendar.DECEMBER, 1),
+                                    uttaksgrad = 50
+                                )
+                            )
+                        })
+                }
+            },
+            today = LocalDate.of(2025, 2, 15), // no uttaksgrad covers this date
+            inntektVedFase1Uttak = 123
+        ) shouldBe SimulertPensjon(
+            alderspensjon = listOf(
+                SimulertAarligAlderspensjon(
+                    alderAar = 64,
+                    beloep = 1000,
+                    inntektspensjon = 200,
+                    garantipensjon = 300,
+                    delingstall = 1.2,
+                    pensjonBeholdningFoerUttak = 123000,
+                    andelsbroekKap19 = 0.2,
+                    andelsbroekKap20 = 0.8,
+                    sluttpoengtall = 2.3,
+                    trygdetidKap19 = 19,
+                    trygdetidKap20 = 4,
+                    poengaarFoer92 = 5,
+                    poengaarEtter91 = 6,
+                    forholdstall = 3.4,
+                    grunnpensjon = 400,
+                    tilleggspensjon = 500,
+                    pensjonstillegg = 600,
+                    skjermingstillegg = 700
+                )
+            ),
+            alderspensjonFraFolketrygden = listOf(
+                SimulertAlderspensjonFraFolketrygden(
+                    datoFom = LocalDate.of(2030, 1, 1),
+                    delytelseListe = emptyList(),
+                    uttakGrad = 0,
+                    maanedligBeloep = 0
+                )
+            ),
+            privatAfp = emptyList(),
+            pre2025OffentligAfp = null,
+            livsvarigOffentligAfp = emptyList(),
+            pensjonBeholdningPeriodeListe = emptyList(),
+            harUttak = false,
+            harNokTrygdetidForGarantipensjon = false,
+            trygdetid = 4, // NB: Mapped twice (also to trygdetidKap20)
+            opptjeningGrunnlagListe = emptyList()
+        )
+    }
+
+    test("'pensjon' should set harUttak to 'true' if uttak covers today's date") {
+        SimulatorOutputConverter.pensjon(
+            source = SimulatorOutput().apply {
+                alderspensjon = SimulertAlderspensjon().apply {
+                    pensjonPeriodeListe.add(
+                        PensjonPeriode().apply {
+                            uttakGradListe = listOf(
+                                Uttaksgrad(
+                                    fomDato = dateAtNoon(2020, Calendar.JANUARY, 1),
+                                    tomDato = dateAtNoon(2030, Calendar.DECEMBER, 1),
+                                    uttaksgrad = 50
+                                )
+                            )
+                        })
+                }
+            },
+            today = LocalDate.of(2025, 2, 15) // uttaksgrad covers this date
+        ).harUttak shouldBe true
+    }
+
+    test("'pensjon' should set harUttak to 'false' if uttaksgrad zero") {
+        SimulatorOutputConverter.pensjon(
+            source = SimulatorOutput().apply {
+                alderspensjon = SimulertAlderspensjon().apply {
+                    pensjonPeriodeListe.add(
+                        PensjonPeriode().apply {
+                            uttakGradListe = listOf(
+                                Uttaksgrad(
+                                    fomDato = dateAtNoon(2020, Calendar.JANUARY, 1),
+                                    tomDato = dateAtNoon(2030, Calendar.DECEMBER, 1),
+                                    uttaksgrad = 0
+                                )
+                            )
+                        })
+                }
+            },
+            today = LocalDate.of(2025, 2, 15) // uttaksgrad covers this date
+        ).harUttak shouldBe false
+    }
+
+    test("'pensjon' should set harNokTrygdetidForGarantipensjon to 'true' if minst 5 år 'kapittel 20'-trygdetid") {
+        SimulatorOutputConverter.pensjon(
+            source = SimulatorOutput().apply {
+                alderspensjon = SimulertAlderspensjon().apply {
+                    pensjonPeriodeListe.add(
+                        PensjonPeriode().apply {
+                            simulertBeregningInformasjonListe = mutableListOf(
+                                SimulertBeregningInformasjon().apply { tt_anv_kap20 = 6 }) // => minst 5 år trygdetid
+                        })
+                }
+            },
+            today = LocalDate.of(2025, 2, 15)
+        ).harNokTrygdetidForGarantipensjon shouldBe true
+    }
+})

--- a/src/test/kotlin/no/nav/pensjon/simulator/beholdning/FolketrygdBeholdningServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/beholdning/FolketrygdBeholdningServiceTest.kt
@@ -35,6 +35,7 @@ class FolketrygdBeholdningServiceTest : FunSpec({
         FolketrygdBeholdningService(
             simulator,
             vedtakService = arrangeVedtak(),
+            time = { LocalDate.of(2025, 1, 1) },
             generelleDataHolder = arrangePerson(foedselsdato),
             validator = mock(UttaksdatoValidator::class.java)
         ).simulerFolketrygdBeholdning(
@@ -94,7 +95,8 @@ class FolketrygdBeholdningServiceTest : FunSpec({
             FolketrygdBeholdningService(
                 simulator = arrangeSimulator(),
                 vedtakService = arrangeVedtak(),
-                generelleDataHolder = arrangePerson(LocalDate.of(1965, 6, 7)),
+                time = { LocalDate.of(2025, 1, 1) },
+                generelleDataHolder = arrangePerson(foedselsdato = LocalDate.of(1965, 6, 7)),
                 validator = arrangeBadSpec() // "feil" i spesifikasjonen
             ).simulerFolketrygdBeholdning(
                 beholdningSpec(uttakFom = LocalDate.of(2030, 1, 1))
@@ -195,6 +197,7 @@ private fun simuleringSpec() =
 private fun simulerFolketrygdBeholdning(inntektSpecListe: List<InntektSpec>): FolketrygdBeholdning =
     FolketrygdBeholdningService(
         simulator = mock(SimulatorCore::class.java),
+        time = { LocalDate.of(2025, 1, 1) },
         vedtakService = mock(VedtakService::class.java),
         generelleDataHolder = mock(GenerelleDataHolder::class.java),
         validator = mock(UttaksdatoValidator::class.java)


### PR DESCRIPTION
Ved å angi tid (dagens dato) som parameter gjør man enhetstestene tidsuavhengige (man kan angi en konstant verdi for "dagens dato").

Bruker også en mer spesifikk parameter enn `simuleringSpec`, siden kun én verdi i spec-en brukes: `inntektUnderGradertUttakBeloep`. Parameteren får navnet `inntektVedFase1Uttak`, som er mer korrekt, siden den angir inntekt ved uttak av AFP, ikke ved gradert uttak.