### PR TITLE
PEK-1290 Bruk EPS' inntekt/pensjon fra vedtak

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringSpecMapperV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringSpecMapperV3.kt
@@ -75,7 +75,7 @@ class NavSimuleringSpecMapperV3(
             isHentPensjonsbeholdninger = false,
             isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = true,
             onlyVilkaarsproeving = false,
-            epsKanOverskrives = true
+            epsKanOverskrives = false // verdier fra vedtak vil dermed brukes istedenfor brukeroppgitte verdier
         )
     }
 

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringSpecMapperV3Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringSpecMapperV3Test.kt
@@ -19,7 +19,7 @@ import java.util.*
 
 class NavSimuleringSpecMapperV3Test : FunSpec({
 
-    test("fromNavSimuleringSpecV3 should fetch foedselsdato and map values") {
+    test("fromNavSimuleringSpecV3 should fetch fødselsdato and map values") {
         NavSimuleringSpecMapperV3(
             personService = Arrange.foedselsdato(1963, 4, 5),
             inntektService = arrangeGrunnbeloep()
@@ -96,7 +96,7 @@ class NavSimuleringSpecMapperV3Test : FunSpec({
             isHentPensjonsbeholdninger = false,
             isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = true, // to produce månedsbeløp
             onlyVilkaarsproeving = false,
-            epsKanOverskrives = true
+            epsKanOverskrives = false
         )
     }
 })


### PR DESCRIPTION
Endring i simuleringstjenesten for 'ny' kalkulator:
Bruk EPS' inntekt/pensjon fra vedtak (istedenfor å 'overskrive' vedtaksverdiene med brukeroppgitte verdier).