### PR TITLE
PEK-1311 Remove adding EPS-grunnlag to krav

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringSpecMapperV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringSpecMapperV3.kt
@@ -9,9 +9,9 @@ import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.trygd.UtlandPeriode
 import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
+import no.nav.pensjon.simulator.inntekt.InntektService
 import no.nav.pensjon.simulator.person.GeneralPersonService
 import no.nav.pensjon.simulator.person.Pid
-import no.nav.pensjon.simulator.inntekt.InntektService
 import no.nav.pensjon.simulator.uttak.UttakUtil.uttakDato
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -42,7 +42,7 @@ class NavSimuleringSpecMapperV3(
             uttakGrad = gradertUttak?.let { NavUttakGradSpecV3.fromExternalValue(it.grad.value).internalValue }
                 ?: UttakGradKode.P_100,
             inntektUnderGradertUttakBeloep = gradertUttak?.aarligInntekt ?: 0,
-            heltUttakDato = heltUttak.uttakFom.toNorwegianLocalDate(),
+            heltUttakDato = gradertUttak?.let { heltUttak.uttakFom.toNorwegianLocalDate() },
             inntektEtterHeltUttakBeloep = heltUttak.aarligInntekt,
             inntektEtterHeltUttakAntallAar = heltUttak.antallArInntektEtterHeltUttak,
             utlandAntallAar = 0, // only for anonym

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/spec/NavSimuleringSpecV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/spec/NavSimuleringSpecV2.kt
@@ -66,20 +66,34 @@ data class NavSimuleringSpecV2(
     override fun toString() =
         "{ \"fnr\": ${textAsString(redact(fnr))}, " +
                 "\"fnrAvdod\": ${textAsString(redact(fnrAvdod))}, " +
+                "\"fodselsar\": $fodselsar, " +
                 "\"simuleringType\": ${textAsString(simuleringType)}, " +
-                "\"sivilstatus\": ${textAsString(sivilstatus)}, " +
                 "\"forventetInntekt\": $forventetInntekt, " +
+                "\"antArInntektOverG\": $antArInntektOverG, " +
                 "\"inntektUnderGradertUttak\": $inntektUnderGradertUttak, " +
                 "\"inntektEtterHeltUttak\": $inntektEtterHeltUttak, " +
                 "\"antallArInntektEtterHeltUttak\": $antallArInntektEtterHeltUttak, " +
+                "\"sivilstatus\": ${textAsString(sivilstatus)}, " +
+                "\"utenlandsopphold\": $utenlandsopphold, " +
+                "\"flyktning\": $flyktning, " +
                 "\"epsPensjon\": $epsPensjon, " +
                 "\"eps2G\": $eps2G, " +
-                "\"utenlandsopphold\": $utenlandsopphold, " +
+                "\"afpOrdning\": ${textAsString(afpOrdning)}, " +
+                "\"afpInntektMndForUttak\": $afpInntektMndForUttak, " +
                 "\"fremtidigInntektList\": ${listAsString(fremtidigInntektList)}, " +
+                "\"dodsdato\": ${textAsString(dodsdato)}, " +
+                "\"avdodAntallArIUtlandet\": $avdodAntallArIUtlandet, " +
+                "\"avdodInntektForDod\": $avdodInntektForDod, " +
+                "\"inntektAvdodOver1G\": $inntektAvdodOver1G, " +
+                "\"avdodMedlemAvFolketrygden\": $avdodMedlemAvFolketrygden, " +
+                "\"avdodFlyktning\": $avdodFlyktning, " +
+                "\"simulerForTp\": $simulerForTp, " +
+                "\"tpOrigSimulering\": $tpOrigSimulering, " +
                 "\"utenlandsperiodeForSimuleringList\": ${listAsString(utenlandsperiodeForSimuleringList)}, " +
                 "\"forsteUttakDato\": ${textAsString(forsteUttakDato)}, " +
                 "\"utg\": ${textAsString(utg)}, " +
-                "\"heltUttakDato\": ${textAsString(heltUttakDato)} }"
+                "\"heltUttakDato\": ${textAsString(heltUttakDato)}, " +
+                "\"ansettelsessektor\": ${textAsString(ansettelsessektor)} }"
 }
 
 // Maps 1-to-1 with no.nav.pensjon.pen.domain.api.kalkulator.UtenlandsperiodeForSimulering in PEN

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/endring/EndringPersongrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/endring/EndringPersongrunnlag.kt
@@ -59,16 +59,16 @@ class EndringPersongrunnlag(
             }
     }
 
-    // SimulerEndringAvAPCommand.opprettPersongrunnlagForEPS
-    // + AbstraktSimulerAPFra2011Command.opprettPersongrunnlagForEPS
-    // -> OpprettKravHodeHelper.opprettPersongrunnlagForEPS
+    // PEN: SimulerEndringAvAPCommand.opprettPersongrunnlagForEPS
+    //    + AbstraktSimulerAPFra2011Command.opprettPersongrunnlagForEPS
+    //   -> OpprettKravHodeHelper.opprettPersongrunnlagForEPS
     fun addPersongrunnlagForEpsToKravhode(
         spec: SimuleringSpec,
         endringKravhode: Kravhode,
         forrigeAlderspensjonBeregningResultat: AbstraktBeregningsResultat?,
         grunnbeloep: Int
     ): Kravhode {
-        if (spec.isTpOrigSimulering || spec.epsKanOverskrives) {
+        if (spec.isTpOrigSimulering) {
             epsService.addPersongrunnlagForEpsToKravhode(spec, endringKravhode, grunnbeloep)
             return endringKravhode
         }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpec.kt
@@ -12,17 +12,16 @@ import no.nav.pensjon.simulator.person.Pid
 import java.time.LocalDate
 import java.util.*
 
-// no.nav.domain.pensjon.kjerne.simulering.SimuleringEtter2011 &
-// SimuleringSpecAlderspensjon1963Plus
+// PEN: no.nav.domain.pensjon.kjerne.simulering.SimuleringEtter2011
 data class SimuleringSpec(
     val type: SimuleringTypeEnum,
     val sivilstatus: SivilstatusType,
     var epsHarPensjon: Boolean,
     val foersteUttakDato: LocalDate?,
-    val heltUttakDato: LocalDate?,
-    val pid: Pid?, // null for forenklet simulering
-    val foedselDato: LocalDate?, // null for forenklet simulering
-    val avdoed: Avdoed?,
+    val heltUttakDato: LocalDate?, // null for ugradert uttak
+    val pid: Pid?, // null for anonym simulering
+    val foedselDato: LocalDate?, // null for anonym simulering
+    val avdoed: Avdoed?, // for ENDR_ALDER_M_GJEN
     val isTpOrigSimulering: Boolean,
     var simulerForTp: Boolean,
     val uttakGrad: UttakGradKode,
@@ -39,9 +38,9 @@ data class SimuleringSpec(
     val flyktning: Boolean?,
     val epsHarInntektOver2G: Boolean,
     val rettTilOffentligAfpFom: LocalDate?,
-    val pre2025OffentligAfp: Pre2025OffentligAfpSpec?,
-    val erAnonym: Boolean,
-    val ignoreAvslag: Boolean,
+    val pre2025OffentligAfp: Pre2025OffentligAfpSpec?, // for "gammel" AFP i offentlig sektor
+    val erAnonym: Boolean, // støtter uinnlogget kalkulator
+    val ignoreAvslag: Boolean, // simulering fullføres selv med for lav opptjening/trygdetid
     val isHentPensjonsbeholdninger: Boolean,
     val isOutputSimulertBeregningsinformasjonForAllKnekkpunkter: Boolean,
     val onlyVilkaarsproeving: Boolean,

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringSpecMapperV3Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/spec/NavSimuleringSpecMapperV3Test.kt
@@ -40,7 +40,7 @@ class NavSimuleringSpecMapperV3Test : FunSpec({
                     aarligInntekt = 5000,
                     inntektTomAlder = NavSimuleringAlderSpecV3(aar = 74, maaneder = 5)
                 ),
-                aarUtenlandsEtter16Aar = 8,
+                aarUtenlandsEtter16Aar = 8, // ignoreres; i denne kontekst brukes utenlandsperiodeListe
                 epsHarPensjon = true,
                 epsHarInntektOver2G = false,
                 fremtidigInntektListe = listOf(
@@ -74,8 +74,8 @@ class NavSimuleringSpecMapperV3Test : FunSpec({
             inntektUnderGradertUttakBeloep = 4000,
             inntektEtterHeltUttakBeloep = 5000,
             inntektEtterHeltUttakAntallAar = 9,
-            foedselAar = 0,
-            utlandAntallAar = 0,
+            foedselAar = 0, // brukes ikke i denne kontekst
+            utlandAntallAar = 0, // siden utlandPeriodeListe brukes isteden
             utlandPeriodeListe = mutableListOf(
                 UtlandPeriode(
                     fom = LocalDate.of(2021, 1, 1),
@@ -95,6 +95,64 @@ class NavSimuleringSpecMapperV3Test : FunSpec({
             ignoreAvslag = false,
             isHentPensjonsbeholdninger = false,
             isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = true, // to produce månedsbeløp
+            onlyVilkaarsproeving = false,
+            epsKanOverskrives = true
+        )
+    }
+
+    test("fromNavSimuleringSpecV3 should use heltUttakDato = null if ugradert uttak") {
+        NavSimuleringSpecMapperV3(
+            personService = Arrange.foedselsdato(1963, 4, 5),
+            inntektService = arrangeGrunnbeloep()
+        ).fromNavSimuleringSpecV3(
+            source = NavSimuleringSpecV3(
+                pid.value,
+                sivilstand = NavSivilstandSpecV3.ENKE,
+                uttaksar = 0,
+                sisteInntekt = 2000,
+                simuleringstype = NavSimuleringTypeSpecV3.ENDR_AP_M_AFP_OFFENTLIG_LIVSVARIG,
+                gradertUttak = null, // => ugradert uttak
+                heltUttak = NavSimuleringHeltUttakSpecV3(
+                    uttakFomAlder = NavSimuleringAlderSpecV3(aar = 66, maaneder = 7),
+                    aarligInntekt = 5000,
+                    inntektTomAlder = NavSimuleringAlderSpecV3(aar = 73, maaneder = 0)
+                ),
+                aarUtenlandsEtter16Aar = 0,
+                epsHarPensjon = false,
+                epsHarInntektOver2G = true,
+                fremtidigInntektListe = emptyList(),
+                utenlandsperiodeListe = emptyList()
+            ),
+        ) shouldBe SimuleringSpec(
+            type = SimuleringTypeEnum.ENDR_AP_M_AFP_OFFENTLIG_LIVSVARIG,
+            sivilstatus = SivilstatusType.ENKE,
+            epsHarPensjon = false,
+            foersteUttakDato = LocalDate.of(2029, 12, 1), // dato for helt uttak
+            heltUttakDato = null, // siden ugradert uttak
+            pid = pid,
+            foedselDato = LocalDate.of(1963, 4, 5),
+            avdoed = null,
+            isTpOrigSimulering = false,
+            simulerForTp = false,
+            uttakGrad = UttakGradKode.P_100,
+            forventetInntektBeloep = 2000,
+            inntektUnderGradertUttakBeloep = 0,
+            inntektEtterHeltUttakBeloep = 5000,
+            inntektEtterHeltUttakAntallAar = 8,
+            foedselAar = 0,
+            utlandAntallAar = 0,
+            utlandPeriodeListe = mutableListOf(),
+            fremtidigInntektListe = mutableListOf(),
+            brukFremtidigInntekt = false,
+            inntektOver1GAntallAar = 0,
+            flyktning = false,
+            epsHarInntektOver2G = true,
+            rettTilOffentligAfpFom = null,
+            pre2025OffentligAfp = null,
+            erAnonym = false,
+            ignoreAvslag = false,
+            isHentPensjonsbeholdninger = false,
+            isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = true,
             onlyVilkaarsproeving = false,
             epsKanOverskrives = true
         )


### PR DESCRIPTION
Fjernet "`|| spec.epsKanOverskrives`" i `EndringPersongrunnlag`, da det gir pensjon-regler-feil ved endring av alderspensjon med gjenlevenderett.

Forøvrig blir `epsKanOverskrives` satt tilbake til `false` for alle simuleringsvarianter i [PR 145](https://github.com/navikt/pensjonssimulator/pull/145), så `epsKanOverskrives`-feltet kan sikkert etterhvert fjernes helt.

Øvrige endringer:

- "fromNavSimuleringSpecV3 should use heltUttakDato = null if ugradert uttak" som gjør at `heltUttakDato` håndteres likt i ny og gammel kalkulator.
- Legge til felter i `toString` for `NavSimuleringSpecV2`