### PR TITLE
PEK-1297 Version 0.95 of API 'AFP etterfulgt av AP'

### DIFF
--- a/end-to-end-test/src/main/resources/afp-etterfulgt-av-alder-response.json
+++ b/end-to-end-test/src/main/resources/afp-etterfulgt-av-alder-response.json
@@ -1,77 +1,74 @@
 {
-  "aarsakListeIkkeSuksess": [
-
-  ],
+  "simuleringSuksess": true,
+  "aarsakListeIkkeSuksess": [],
+  "folketrygdberegnetAfp": {
+    "fraOgMedDato": "2025-12-01",
+    "beregnetTidligereInntekt": 905000,
+    "sisteLignetInntektBrukt": false,
+    "sisteLignetInntektAar": null,
+    "afpGrad": 84,
+    "afpAvkortetTil70Prosent": false,
+    "grunnpensjon": {
+      "maanedligUtbetaling": 9111,
+      "grunnbeloep": 130160,
+      "grunnpensjonsats": 1.0,
+      "trygdetid": 40
+    },
+    "tilleggspensjon": {
+      "maanedligUtbetaling": 22593,
+      "grunnbeloep": 130160,
+      "sluttpoengTall": 5.76,
+      "antallPoengaarTilOgMed1991": 14,
+      "antallPoengaarFraOgMed1992": 26
+    },
+    "saertillegg": null,
+    "maanedligAfpTillegg": 1428,
+    "sumMaanedligUtbetaling": 33132
+  },
   "alderspensjonFraFolketrygden": [
     {
+      "fraOgMedDato": "2028-03-01",
+      "andelKapittel19": 0.2,
       "alderspensjonKapittel19": {
-        "forholdstall": 1.115,
         "grunnpensjon": {
+          "maanedligUtbetaling": 1946,
           "grunnbeloep": 130160,
           "grunnpensjonsats": 1.0,
-          "maanedligUtbetaling": 1946,
           "trygdetid": 40
+        },
+        "tilleggspensjon": {
+          "maanedligUtbetaling": 4824,
+          "grunnbeloep": 130160,
+          "sluttpoengTall": 5.76,
+          "antallPoengaarTilOgMed1991": 14,
+          "antallPoengaarFraOgMed1992": 26
         },
         "pensjonstillegg": {
           "maanedligUtbetaling": 0,
           "minstepensjonsnivaaSats": 279933.0
-        },
-        "tilleggspensjon": {
-          "antallPoengaarFraOgMed1992": 26,
-          "antallPoengaarTilOgMed1991": 14,
-          "grunnbeloep": 130160,
-          "maanedligUtbetaling": 4824,
-          "sluttpoengTall": 5.76
         }
       },
+      "andelKapittel20": 0.8,
       "alderspensjonKapittel20": {
-        "delingstall": 16.01,
-        "garantipensjon": {
-          "garantipensjonssats": 0.0,
-          "maanedligUtbetaling": 0,
-          "trygdetid": 40
-        },
         "inntektspensjon": {
           "maanedligUtbetaling": 32415,
-          "pensjonsbeholdningFoerUttak": 7784394
+          "pensjonsbeholdningForUttak": 7784394
+        },
+        "garantipensjon": {
+          "maanedligUtbetaling": 0,
+          "garantipensjonsbeholdningForUttak": -2346403,
+          "trygdetid": 40
         }
       },
-      "andelKapittel19": 0.2,
-      "andelKapittel20": 0.8,
-      "fraOgMedDato": "2028-03-01",
       "sumMaanedligUtbetaling": 39185
     },
     {
-      "alderspensjonKapittel19": null,
-      "alderspensjonKapittel20": null,
-      "andelKapittel19": 0.2,
-      "andelKapittel20": 0.8,
       "fraOgMedDato": "2029-01-01",
+      "andelKapittel19": 0.2,
+      "alderspensjonKapittel19": null,
+      "andelKapittel20": 0.8,
+      "alderspensjonKapittel20": null,
       "sumMaanedligUtbetaling": 39303
     }
-  ],
-  "folketrygdberegnetAfp": {
-    "afpAvkortetTil70Prosent": false,
-    "afpGrad": 84,
-    "beregnetTidligereInntekt": 905000,
-    "fraOgMedDato": "2025-12-01",
-    "fremtidigAarligInntektTilAfpUttak": 600000,
-    "grunnpensjon": {
-      "grunnbeloep": 130160,
-      "grunnpensjonsats": 1.0,
-      "maanedligUtbetaling": 9111,
-      "trygdetid": 40
-    },
-    "maanedligAfpTillegg": 1428,
-    "saertillegg": null,
-    "sumMaanedligUtbetaling": 33132,
-    "tilleggspensjon": {
-      "antallPoengaarFraOgMed1992": 26,
-      "antallPoengaarTilOgMed1991": 14,
-      "grunnbeloep": 130160,
-      "maanedligUtbetaling": 22593,
-      "sluttpoengTall": 5.76
-    }
-  },
-  "simuleringSuksess": true
+  ]
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultMapperV0.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultMapperV0.kt
@@ -1,199 +1,256 @@
 package no.nav.pensjon.simulator.afp_etterfulgt_ap.api.tpo.acl.v0.result
 
-import mu.KotlinLogging
 import no.nav.pensjon.simulator.afp.offentlig.pre2025.AfpGrad
 import no.nav.pensjon.simulator.core.domain.regler.beregning.Beregning
+import no.nav.pensjon.simulator.core.domain.regler.beregning.Grunnpensjon
+import no.nav.pensjon.simulator.core.domain.regler.beregning.Sertillegg
+import no.nav.pensjon.simulator.core.domain.regler.beregning.Tilleggspensjon
 import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableException
 import no.nav.pensjon.simulator.core.result.Maanedsutbetaling
 import no.nav.pensjon.simulator.core.result.PensjonPeriode
 import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.result.SimulertAlderspensjon
+import no.nav.pensjon.simulator.core.result.SimulertBeregningInformasjon
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import java.time.LocalDate
-import java.util.*
 
 object AfpEtterfulgtAvAlderspensjonResultMapperV0 {
-    private val log = KotlinLogging.logger {}
 
-    fun toDto(source: SimulatorOutput, spec: SimuleringSpec): AfpEtterfulgtAvAlderspensjonResultV0 {
-        val afp: Beregning = source.pre2025OffentligAfp?.beregning
-            ?: throw ImplementationUnrecoverableException("pre2025OffentligAfp mangler i beregningsresultatet")
-        val alderspensjon = source.alderspensjon
-            ?: throw ImplementationUnrecoverableException("alderspensjon mangler i beregningsresultatet")
-
-        return AfpEtterfulgtAvAlderspensjonResultV0(
+    fun toDto(source: SimulatorOutput, spec: SimuleringSpec) =
+        AfpEtterfulgtAvAlderspensjonResultV0(
             simuleringSuksess = true,
             aarsakListeIkkeSuksess = emptyList(),
-            folketrygdberegnetAfp = mapToFolketrygdberegnetAfp(
-                source.pre2025OffentligAfp?.virk!!,
-                afp,
+            folketrygdberegnetAfp = folketrygdberegnetAfp(
+                fom = source.pre2025OffentligAfp!!.virk!!.toNorwegianLocalDate(),
+                afp = validAfpBeregning(source),
                 spec
             ),
-            alderspensjonFraFolketrygden = mapToAlderspensjon(alderspensjon, source.grunnbeloep)
+            alderspensjonFraFolketrygden = alderspensjonFraFolketrygdenListe(
+                pensjon = validAlderspensjon(source),
+                grunnbeloep = source.grunnbeloep,
+                uttakDato = spec.foersteUttakDato!!
+            )
         )
-    }
 
-    fun tomResponsMedAarsak(arsakIkkeSuccess: AarsakIkkeSuccessV0): AfpEtterfulgtAvAlderspensjonResultV0 {
-        return AfpEtterfulgtAvAlderspensjonResultV0(
+    fun tomResponsMedAarsak(aarsak: AarsakIkkeSuccessV0) =
+        AfpEtterfulgtAvAlderspensjonResultV0(
             simuleringSuksess = false,
-            aarsakListeIkkeSuksess = listOf(arsakIkkeSuccess),
+            aarsakListeIkkeSuksess = listOf(aarsak),
             folketrygdberegnetAfp = null,
             alderspensjonFraFolketrygden = emptyList()
         )
-    }
 
-    private fun mapToFolketrygdberegnetAfp(
-        virk: Date,
+    private fun validAfpBeregning(source: SimulatorOutput): Beregning =
+        source.pre2025OffentligAfp?.beregning
+            ?: throw ImplementationUnrecoverableException("pre2025OffentligAfp-beregning mangler i beregningsresultatet")
+
+    private fun validAlderspensjon(source: SimulatorOutput): SimulertAlderspensjon =
+        source.alderspensjon
+            ?: throw ImplementationUnrecoverableException("alderspensjon mangler i beregningsresultatet")
+
+    private fun folketrygdberegnetAfp(
+        fom: LocalDate,
         afp: Beregning,
-        spec: SimuleringSpec,
+        spec: SimuleringSpec
     ): FolketrygdberegnetAfpV0 {
-        val tilleggspensjon = afp.tp
-        val grunnpensjon = afp.gp!!
-        val saertillegg = afp.st
-        val beregnetTidligereInntekt = tilleggspensjon?.spt?.poengrekke?.tpi!!
-        val res = FolketrygdberegnetAfpV0(
-            fraOgMedDato = virk.toNorwegianLocalDate(),
+        val beregnetTidligereInntekt = afp.tp!!.spt!!.poengrekke!!.tpi
+        val sisteLignetInntektAar = spec.registerData?.sisteLignetInntektAar
+
+        return FolketrygdberegnetAfpV0(
+            fraOgMedDato = fom,
             beregnetTidligereInntekt = beregnetTidligereInntekt,
+            sisteLignetInntektBrukt = sisteLignetInntektAar != null,
+            sisteLignetInntektAar = sisteLignetInntektAar,
             afpGrad = AfpGrad.beregnAfpGrad(spec.inntektUnderGradertUttakBeloep, beregnetTidligereInntekt),
-            fremtidigAarligInntektTilAfpUttak = spec.forventetInntektBeloep,
             afpAvkortetTil70Prosent = afp.gpAfpPensjonsregulert?.brukt == true,
-            grunnpensjon = GrunnpensjonV0(
-                maanedligUtbetaling = grunnpensjon.netto,
-                grunnbeloep = afp.g,
-                grunnpensjonsats = grunnpensjon.pSats_gp,
-                trygdetid = grunnpensjon.anvendtTrygdetid!!.tt_anv
-            ),
-            tilleggspensjon = tilleggspensjon.let {
-                TilleggspensjonV0(
-                    maanedligUtbetaling = tilleggspensjon.netto,
-                    grunnbeloep = afp.g,
-                    sluttpoengTall = it.spt!!.pt,
-                    antallPoengaarTilOgMed1991 = it.spt!!.poengrekke!!.pa_f92,
-                    antallPoengaarFraOgMed1992 = it.spt!!.poengrekke!!.pa_e91
-                )
-            },
-            saertillegg = saertillegg?.let {
-                SaertilleggV0(
-                    maanedligUtbetaling = saertillegg.netto,
-                    saertilleggsats = saertillegg.pSats_st
-                )
-            },
+            grunnpensjon = grunnpensjon(afp),
+            tilleggspensjon = tilleggspensjon(afp),
+            saertillegg = afp.st?.let(::saertillegg),
             maanedligAfpTillegg = afp.afpTillegg!!.netto,
             sumMaanedligUtbetaling = afp.netto
         )
-
-        return res
     }
 
-    private fun mapToAlderspensjon(
-        alderspensjon: SimulertAlderspensjon,
-        grunnbeloep: Int
-    ): List<AlderspensjonFraFolketrygdenV0> {
+    private fun grunnpensjon(source: Beregning) =
+        grunnpensjon(source = source.gp!!, grunnbeloep = source.g)
 
-        val liste: List<Simuleringsperiode> = alderspensjon
-            .pensjonPeriodeListe
+    private fun tilleggspensjon(source: Beregning) =
+        source.tp?.let { tilleggspensjon(source = it, grunnbeloep = source.g) }
+
+    private fun grunnpensjon(source: Grunnpensjon, grunnbeloep: Int) =
+        GrunnpensjonV0(
+            maanedligUtbetaling = source.netto,
+            grunnbeloep = grunnbeloep,
+            grunnpensjonsats = source.pSats_gp,
+            trygdetid = source.anvendtTrygdetid!!.tt_anv
+        )
+
+    private fun tilleggspensjon(source: Tilleggspensjon, grunnbeloep: Int): TilleggspensjonV0 {
+        val sluttpoengtall = source.spt!!
+        val poengrekke = sluttpoengtall.poengrekke!!
+
+        return TilleggspensjonV0(
+            maanedligUtbetaling = source.netto,
+            grunnbeloep = grunnbeloep,
+            sluttpoengTall = sluttpoengtall.pt,
+            antallPoengaarTilOgMed1991 = poengrekke.pa_f92,
+            antallPoengaarFraOgMed1992 = poengrekke.pa_e91
+        )
+    }
+
+    private fun saertillegg(source: Sertillegg) =
+        SaertilleggV0(maanedligUtbetaling = source.netto)
+
+    private fun alderspensjonFraFolketrygdenListe(
+        pensjon: SimulertAlderspensjon,
+        grunnbeloep: Int,
+        uttakDato: LocalDate
+    ): List<AlderspensjonFraFolketrygdenV0> =
+        pensjon.pensjonPeriodeListe
             .filter { it.simulertBeregningInformasjonListe.isNotEmpty() }
-            .map { alderspensjon(it, alderspensjon) }
+            .map { simuleringsperiodeListe(it, pensjon, uttakDato) }
             .flatten()
+            .map { alderspensjonFraFolketrygden(it, pensjon, grunnbeloep) }
 
-        log.info { "afp etterf ap output: $liste" }
-        val res = liste.map { simuleringsperiode ->
-            AlderspensjonFraFolketrygdenV0(
-                fraOgMedDato = simuleringsperiode.fom,
-                sumMaanedligUtbetaling = simuleringsperiode.maanedsbeloep,
-                andelKapittel19 = alderspensjon.kapittel19Andel,
-                alderspensjonKapittel19 = if (alderspensjon.kapittel19Andel == 0.0) null
-                else simuleringsperiode.simulertAlderspensjonInfo?.let {
-                    AlderspensjonKapittel19V0(
-                        grunnpensjon = GrunnpensjonV0(
-                            maanedligUtbetaling = it.grunnpensjon!!,
-                            grunnbeloep = grunnbeloep,
-                            grunnpensjonsats = it.grunnpensjonsats,
-                            trygdetid = it.trygdetidKap19!!
-                        ),
-                        tilleggspensjon = TilleggspensjonV0(
-                            maanedligUtbetaling = it.tilleggspensjon!!,
-                            grunnbeloep = grunnbeloep,
-                            sluttpoengTall = it.sluttpoengtall!!,
-                            antallPoengaarTilOgMed1991 = it.poengaarFoer92!!,
-                            antallPoengaarFraOgMed1992 = it.poengaarEtter91!!
-                        ),
-                        pensjonstillegg = PensjonstilleggV0(
-                            maanedligUtbetaling = it.pensjonstillegg!!,
-                            minstepensjonsnivaaSats = it.minstepensjonsnivaaSats,
-                        ),
-                        forholdstall = it.forholdstall!!
-                    )
-                },
-                andelKapittel20 = alderspensjon.kapittel20Andel,
-                alderspensjonKapittel20 = simuleringsperiode.simulertAlderspensjonInfo?.let {
-                    AlderspensjonKapittel20V0(
-                        inntektspensjon = InntektspensjonV0(
-                            maanedligUtbetaling = it.inntektspensjon!!,
-                            pensjonsbeholdningFoerUttak = it.pensjonBeholdningFoerUttak!!,
-                        ),
-                        garantipensjon = GarantipensjonV0(
-                            maanedligUtbetaling = it.garantipensjon!!,
-                            garantipensjonssats = it.garantipensjonssats,
-                            trygdetid = it.trygdetidKap20!!
-                        ),
-                        delingstall = it.delingstall!!
-                    )
-                }
+    private fun simuleringsperiodeListe(
+        periode: PensjonPeriode,
+        pensjon: SimulertAlderspensjon,
+        uttakDato: LocalDate
+    ): List<Simuleringsperiode> =
+        periode.maanedsutbetalinger.map {
+            simuleringsperiode(
+                maanedsutbetaling = it,
+                periode,
+                pensjon,
+                uttakDato
             )
         }
-        return res
-    }
 
+    private fun alderspensjonFraFolketrygden(
+        periode: Simuleringsperiode,
+        pensjon: SimulertAlderspensjon,
+        grunnbeloep: Int
+    ) =
+        AlderspensjonFraFolketrygdenV0(
+            fraOgMedDato = periode.fom,
+            sumMaanedligUtbetaling = periode.maanedsbeloep,
+            andelKapittel19 = pensjon.kapittel19Andel,
+            alderspensjonKapittel19 =
+                if (pensjon.kapittel19Andel == 0.0) null
+                else periode.simulertAlderspensjonInfo?.let { alderspensjonKapittel19(it, grunnbeloep) },
+            andelKapittel20 = pensjon.kapittel20Andel,
+            alderspensjonKapittel20 = periode.simulertAlderspensjonInfo?.let(::alderspensjonKapittel20)
+        )
 
-    fun alderspensjon(source: PensjonPeriode, simulertAlderspensjon: SimulertAlderspensjon?): List<Simuleringsperiode> {
-        return source.maanedsutbetalinger.map { maanedsutbetaling: Maanedsutbetaling ->
-            Simuleringsperiode(
-                fom = maanedsutbetaling.fom,
-                maanedsbeloep = maanedsutbetaling.beloep,
-                simulertAlderspensjonInfo = source.simulertBeregningInformasjonListe
-                    .filter { it.datoFom == maanedsutbetaling.fom }
-                    .map { info ->
-                        SimulertAlderspensjonInfo(
-                            fom = info.datoFom,
-                            beloep = source.beloep ?: 0,
-                            maanedsbeloep = maanedsutbetaling.beloep,
-                            inntektspensjon = info.inntektspensjonPerMaaned,
-                            garantipensjon = info.garantipensjonPerMaaned,
-                            delingstall = info.delingstall,
-                            pensjonBeholdningFoerUttak = source.simulertBeregningInformasjonListe
-                                .firstOrNull { it.pensjonBeholdningFoerUttak != null }
-                                ?.pensjonBeholdningFoerUttak,
-                            andelsbroekKap19 = simulertAlderspensjon?.kapittel19Andel ?: 0.0,
-                            andelsbroekKap20 = simulertAlderspensjon?.kapittel20Andel ?: 0.0,
-                            sluttpoengtall = info.spt,
-                            trygdetidKap19 = info.tt_anv_kap19,
-                            trygdetidKap20 = info.tt_anv_kap20,
-                            poengaarFoer92 = info.pa_f92,
-                            poengaarEtter91 = info.pa_e91,
-                            forholdstall = info.forholdstall,
-                            grunnpensjon = info.grunnpensjonPerMaaned,
-                            grunnpensjonsats = info.grunnpensjonsats,
-                            tilleggspensjon = info.tilleggspensjonPerMaaned,
-                            pensjonstillegg = info.pensjonstilleggPerMaaned,
-                            garantipensjonssats = info.garantipensjonssats,
-                            minstepensjonsnivaaSats = info.minstePensjonsnivaSats,
-                            skjermingstillegg = info.skjermingstillegg,
-                        )
-                    }
-                    .firstOrNull()
-            )
-        }
-    }
+    private fun alderspensjonKapittel19(source: SimulertAlderspensjonInfo, grunnbeloep: Int) =
+        AlderspensjonKapittel19V0(
+            grunnpensjon = grunnpensjon(source, grunnbeloep),
+            tilleggspensjon = tilleggspensjon(source, grunnbeloep),
+            pensjonstillegg = pensjonstillegg(source)
+        )
 
-    data class Simuleringsperiode(
+    private fun alderspensjonKapittel20(source: SimulertAlderspensjonInfo) =
+        AlderspensjonKapittel20V0(
+            inntektspensjon = inntektspensjon(source),
+            garantipensjon = garantipensjon(source)
+        )
+
+    private fun grunnpensjon(source: SimulertAlderspensjonInfo, grunnbeloep: Int) =
+        GrunnpensjonV0(
+            maanedligUtbetaling = source.grunnpensjon!!,
+            grunnbeloep = grunnbeloep,
+            grunnpensjonsats = source.grunnpensjonsats,
+            trygdetid = source.trygdetidKap19!!
+        )
+
+    private fun tilleggspensjon(source: SimulertAlderspensjonInfo, grunnbeloep: Int) =
+        TilleggspensjonV0(
+            maanedligUtbetaling = source.tilleggspensjon!!,
+            grunnbeloep = grunnbeloep,
+            sluttpoengTall = source.sluttpoengtall!!,
+            antallPoengaarTilOgMed1991 = source.poengaarFoer92!!,
+            antallPoengaarFraOgMed1992 = source.poengaarEtter91!!
+        )
+
+    private fun pensjonstillegg(source: SimulertAlderspensjonInfo) =
+        PensjonstilleggV0(
+            maanedligUtbetaling = source.pensjonstillegg!!,
+            minstepensjonsnivaaSats = source.minstepensjonsnivaaSats
+        )
+
+    private fun inntektspensjon(source: SimulertAlderspensjonInfo) =
+        InntektspensjonV0(
+            maanedligUtbetaling = source.inntektspensjon!!,
+            pensjonsbeholdningForUttak = source.pensjonBeholdningFoerUttak!!
+        )
+
+    private fun garantipensjon(source: SimulertAlderspensjonInfo) =
+        GarantipensjonV0(
+            maanedligUtbetaling = source.garantipensjon!!,
+            garantipensjonsbeholdningForUttak = source.garantipensjonBeholdningFoerUttak,
+            trygdetid = source.trygdetidKap20!!
+        )
+
+    private fun simuleringsperiode(
+        maanedsutbetaling: Maanedsutbetaling,
+        periode: PensjonPeriode,
+        pensjon: SimulertAlderspensjon,
+        uttakDato: LocalDate
+    ) =
+        Simuleringsperiode(
+            fom = maanedsutbetaling.fom,
+            maanedsbeloep = maanedsutbetaling.beloep,
+            simulertAlderspensjonInfo = periode.simulertBeregningInformasjonListe
+                .filter { it.datoFom == maanedsutbetaling.fom }
+                .map { simulertAlderspensjonInfo(it, periode, maanedsutbetaling, pensjon, uttakDato) }
+                .firstOrNull()
+        )
+
+    private fun simulertAlderspensjonInfo(
+        beregningsinfo: SimulertBeregningInformasjon,
+        periode: PensjonPeriode,
+        maanedsutbetaling: Maanedsutbetaling,
+        pensjon: SimulertAlderspensjon?,
+        uttakDato: LocalDate
+    ) =
+        SimulertAlderspensjonInfo(
+            fom = beregningsinfo.datoFom,
+            beloep = periode.beloep ?: 0,
+            maanedsbeloep = maanedsutbetaling.beloep,
+            inntektspensjon = beregningsinfo.inntektspensjonPerMaaned,
+            garantipensjon = beregningsinfo.garantipensjonPerMaaned,
+            delingstall = beregningsinfo.delingstall,
+            pensjonBeholdningFoerUttak =
+                periode.simulertBeregningInformasjonListe.firstOrNull { it.pensjonBeholdningFoerUttak != null }
+                    ?.pensjonBeholdningFoerUttak,
+            garantipensjonBeholdningFoerUttak =
+                pensjon?.pensjonBeholdningListe?.filter { it.datoFom.isBefore(uttakDato) }
+                    ?.maxByOrNull { it.datoFom }?.garantipensjonsbeholdning?.toInt(),
+            andelsbroekKap19 = pensjon?.kapittel19Andel ?: 0.0,
+            andelsbroekKap20 = pensjon?.kapittel20Andel ?: 0.0,
+            sluttpoengtall = beregningsinfo.spt,
+            trygdetidKap19 = beregningsinfo.tt_anv_kap19,
+            trygdetidKap20 = beregningsinfo.tt_anv_kap20,
+            poengaarFoer92 = beregningsinfo.pa_f92,
+            poengaarEtter91 = beregningsinfo.pa_e91,
+            forholdstall = beregningsinfo.forholdstall,
+            grunnpensjon = beregningsinfo.grunnpensjonPerMaaned,
+            grunnpensjonsats = beregningsinfo.grunnpensjonsats,
+            tilleggspensjon = beregningsinfo.tilleggspensjonPerMaaned,
+            pensjonstillegg = beregningsinfo.pensjonstilleggPerMaaned,
+            garantipensjonssats = beregningsinfo.garantipensjonssats,
+            minstepensjonsnivaaSats = beregningsinfo.minstePensjonsnivaSats,
+            skjermingstillegg = beregningsinfo.skjermingstillegg
+        )
+
+    private data class Simuleringsperiode(
         val fom: LocalDate,
         val maanedsbeloep: Int,
         val simulertAlderspensjonInfo: SimulertAlderspensjonInfo?,
     )
 
-    data class SimulertAlderspensjonInfo(
+    private data class SimulertAlderspensjonInfo(
         val fom: LocalDate?,
         val beloep: Int,
         val maanedsbeloep: Int,
@@ -201,6 +258,7 @@ object AfpEtterfulgtAvAlderspensjonResultMapperV0 {
         val garantipensjon: Int?,
         val delingstall: Double?,
         val pensjonBeholdningFoerUttak: Int?,
+        val garantipensjonBeholdningFoerUttak: Int?,
         val andelsbroekKap19: Double?,
         val andelsbroekKap20: Double?,
         val sluttpoengtall: Double?,

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultMapperV0.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultMapperV0.kt
@@ -6,11 +6,7 @@ import no.nav.pensjon.simulator.core.domain.regler.beregning.Grunnpensjon
 import no.nav.pensjon.simulator.core.domain.regler.beregning.Sertillegg
 import no.nav.pensjon.simulator.core.domain.regler.beregning.Tilleggspensjon
 import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableException
-import no.nav.pensjon.simulator.core.result.Maanedsutbetaling
-import no.nav.pensjon.simulator.core.result.PensjonPeriode
-import no.nav.pensjon.simulator.core.result.SimulatorOutput
-import no.nav.pensjon.simulator.core.result.SimulertAlderspensjon
-import no.nav.pensjon.simulator.core.result.SimulertBeregningInformasjon
+import no.nav.pensjon.simulator.core.result.*
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import java.time.LocalDate
@@ -211,7 +207,7 @@ object AfpEtterfulgtAvAlderspensjonResultMapperV0 {
         beregningsinfo: SimulertBeregningInformasjon,
         periode: PensjonPeriode,
         maanedsutbetaling: Maanedsutbetaling,
-        pensjon: SimulertAlderspensjon?,
+        pensjon: SimulertAlderspensjon,
         uttakDato: LocalDate
     ) =
         SimulertAlderspensjonInfo(
@@ -221,14 +217,10 @@ object AfpEtterfulgtAvAlderspensjonResultMapperV0 {
             inntektspensjon = beregningsinfo.inntektspensjonPerMaaned,
             garantipensjon = beregningsinfo.garantipensjonPerMaaned,
             delingstall = beregningsinfo.delingstall,
-            pensjonBeholdningFoerUttak =
-                periode.simulertBeregningInformasjonListe.firstOrNull { it.pensjonBeholdningFoerUttak != null }
-                    ?.pensjonBeholdningFoerUttak,
-            garantipensjonBeholdningFoerUttak =
-                pensjon?.pensjonBeholdningListe?.filter { it.datoFom.isBefore(uttakDato) }
-                    ?.maxByOrNull { it.datoFom }?.garantipensjonsbeholdning?.toInt(),
-            andelsbroekKap19 = pensjon?.kapittel19Andel ?: 0.0,
-            andelsbroekKap20 = pensjon?.kapittel20Andel ?: 0.0,
+            pensjonBeholdningFoerUttak = periode.foerstePensjonsbeholdningFoerUttak,
+            garantipensjonBeholdningFoerUttak = pensjon.garantipensjonsbeholdningVedDato(uttakDato),
+            andelsbroekKap19 = pensjon.kapittel19Andel,
+            andelsbroekKap20 = pensjon.kapittel20Andel,
             sluttpoengtall = beregningsinfo.spt,
             trygdetidKap19 = beregningsinfo.tt_anv_kap19,
             trygdetidKap20 = beregningsinfo.tt_anv_kap20,

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultV0.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultV0.kt
@@ -1,25 +1,28 @@
 package no.nav.pensjon.simulator.afp_etterfulgt_ap.api.tpo.acl.v0.result
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS
 import java.time.LocalDate
 
 /**
  * Ref. API specification: https://confluence.adeo.no/x/hJRHK
  */
-@JsonInclude(JsonInclude.Include.ALWAYS)
+@JsonInclude(ALWAYS)
 data class AfpEtterfulgtAvAlderspensjonResultV0(
     val simuleringSuksess: Boolean,
     val aarsakListeIkkeSuksess: List<AarsakIkkeSuccessV0>,
     val folketrygdberegnetAfp: FolketrygdberegnetAfpV0?,
     val alderspensjonFraFolketrygden: List<AlderspensjonFraFolketrygdenV0>,
 )
-@JsonInclude(JsonInclude.Include.ALWAYS)
+
+@JsonInclude(ALWAYS)
 data class FolketrygdberegnetAfpV0(
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    val fraOgMedDato: LocalDate,
+    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd") val fraOgMedDato: LocalDate,
     val beregnetTidligereInntekt: Int?,
-    val fremtidigAarligInntektTilAfpUttak: Int,
+    val sisteLignetInntektBrukt: Boolean,
+    val sisteLignetInntektAar: Int?,
     val afpGrad: Int,
     val afpAvkortetTil70Prosent: Boolean,
     val grunnpensjon: GrunnpensjonV0,
@@ -28,7 +31,8 @@ data class FolketrygdberegnetAfpV0(
     val maanedligAfpTillegg: Int,
     val sumMaanedligUtbetaling: Int,
 )
-@JsonInclude(JsonInclude.Include.ALWAYS)
+
+@JsonInclude(ALWAYS)
 data class GrunnpensjonV0(
     val maanedligUtbetaling: Int,
     val grunnbeloep: Int,
@@ -43,15 +47,15 @@ data class TilleggspensjonV0(
     val antallPoengaarTilOgMed1991: Int,
     val antallPoengaarFraOgMed1992: Int,
 )
-@JsonInclude(JsonInclude.Include.ALWAYS)
+
+@JsonInclude(ALWAYS)
 data class SaertilleggV0(
     val maanedligUtbetaling: Int,
-    val saertilleggsats: Double?,
 )
-@JsonInclude(JsonInclude.Include.ALWAYS)
+
+@JsonInclude(ALWAYS)
 data class AlderspensjonFraFolketrygdenV0(
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    val fraOgMedDato: LocalDate,
+    @JsonFormat(shape = STRING, pattern = "yyyy-MM-dd") val fraOgMedDato: LocalDate,
     val andelKapittel19: Double?,
     val alderspensjonKapittel19: AlderspensjonKapittel19V0?,
     val andelKapittel20: Double?,
@@ -63,9 +67,9 @@ data class AlderspensjonKapittel19V0(
     val grunnpensjon: GrunnpensjonV0,
     val tilleggspensjon: TilleggspensjonV0,
     val pensjonstillegg: PensjonstilleggV0,
-    val forholdstall: Double,
 )
-@JsonInclude(JsonInclude.Include.ALWAYS)
+
+@JsonInclude(ALWAYS)
 data class PensjonstilleggV0(
     val maanedligUtbetaling: Int,
     val minstepensjonsnivaaSats: Double?,
@@ -74,18 +78,18 @@ data class PensjonstilleggV0(
 data class AlderspensjonKapittel20V0(
     val inntektspensjon: InntektspensjonV0,
     val garantipensjon: GarantipensjonV0,
-    val delingstall: Double,
 )
-@JsonInclude(JsonInclude.Include.ALWAYS)
+
+@JsonInclude(ALWAYS)
 data class GarantipensjonV0(
     val maanedligUtbetaling: Int,
-    val garantipensjonssats: Double?,
+    val garantipensjonsbeholdningForUttak: Int?,
     val trygdetid: Int,
 )
 
 data class InntektspensjonV0(
     val maanedligUtbetaling: Int,
-    val pensjonsbeholdningFoerUttak: Int,
+    val pensjonsbeholdningForUttak: Int,
 )
 
 data class AarsakIkkeSuccessV0(

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/spec/AfpEtterfulgtAvAlderspensjonSpecMapperV0.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/spec/AfpEtterfulgtAvAlderspensjonSpecMapperV0.kt
@@ -47,7 +47,7 @@ class AfpEtterfulgtAvAlderspensjonSpecMapperV0(
             simulerForTp = false, // simulerer her ikke for tjenestepensjon
             erAnonym = false,
             ignoreAvslag = false,
-            isHentPensjonsbeholdninger = false,
+            isHentPensjonsbeholdninger = true, // behøves for garantipensjonsbeholdning
             isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = true,
             onlyVilkaarsproeving = false,
             utlandPeriodeListe = mutableListOf(),

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/spec/AfpEtterfulgtAvAlderspensjonSpecMapperV0.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/spec/AfpEtterfulgtAvAlderspensjonSpecMapperV0.kt
@@ -3,8 +3,10 @@ package no.nav.pensjon.simulator.afp_etterfulgt_ap.api.tpo.acl.v0.spec
 import no.nav.pensjon.simulator.core.afp.AfpOrdningType
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.result.RegisterData
 import no.nav.pensjon.simulator.core.spec.Pre2025OffentligAfpSpec
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.inntekt.Inntekt
 import no.nav.pensjon.simulator.person.GeneralPersonService
 import no.nav.pensjon.simulator.person.Pid
 import no.nav.pensjon.simulator.inntekt.InntektService
@@ -18,6 +20,10 @@ class AfpEtterfulgtAvAlderspensjonSpecMapperV0(
 ) {
     fun fromDto(source: AfpEtterfulgtAvAlderspensjonSpecV0.AfpEtterfulgtAvAlderspensjonValidatedSpecV0): SimuleringSpec {
         val pid = Pid(source.personId)
+
+        val sisteLignetInntekt: Inntekt? =
+            if (source.fremtidigAarligInntektTilAfpUttak == null) inntektService.hentSisteLignetInntekt(pid)
+            else null
 
         return SimuleringSpec(
             type = SimuleringTypeEnum.AFP_ETTERF_ALDER,
@@ -36,8 +42,7 @@ class AfpEtterfulgtAvAlderspensjonSpecMapperV0(
             inntektUnderGradertUttakBeloep = source.fremtidigAarligInntektUnderAfpUttak,
 
             inntektEtterHeltUttakAntallAar = null, //TODO mangler sluttdato
-            forventetInntektBeloep = source.fremtidigAarligInntektTilAfpUttak
-                ?: inntektService.hentSisteLignetInntekt(pid),
+            forventetInntektBeloep = source.fremtidigAarligInntektTilAfpUttak ?: sisteLignetInntekt!!.aarligBeloep,
             utlandAntallAar = source.aarIUtlandetEtter16,
             simulerForTp = false, // simulerer her ikke for tjenestepensjon
             erAnonym = false,
@@ -60,6 +65,7 @@ class AfpEtterfulgtAvAlderspensjonSpecMapperV0(
             avdoed = null,
             isTpOrigSimulering = true,
             uttakGrad = UttakGradKode.P_100,
+            registerData = RegisterData(sisteLignetInntektAar = sisteLignetInntekt?.fom?.year)
         )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorCore.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorCore.kt
@@ -228,6 +228,7 @@ class SimulatorCore(
                 this.foedselDato = foedselsdato
                 this.persongrunnlag = kravhode.hentPersongrunnlagForSoker()
                 this.heltUttakDato = spec.heltUttakDato
+                this.registerData = initialSpec.registerData
             }
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/PensjonPeriode.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/PensjonPeriode.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.result
 
-// no.nav.domain.pensjon.kjerne.simulering.Pensjonsperiode
+// PEN: no.nav.domain.pensjon.kjerne.simulering.Pensjonsperiode
 class PensjonPeriode {
     //TODO data class
     /**
@@ -20,4 +20,9 @@ class PensjonPeriode {
      * Vil finnes dersom der har skjedd en uttaksgradsendring og/eller bruker blir 67 år i løpet av perioden.
      */
     var simulertBeregningInformasjonListe: MutableList<SimulertBeregningInformasjon> = mutableListOf()
+
+    //--- Extra:
+    val foerstePensjonsbeholdningFoerUttak: Int?
+        get() = simulertBeregningInformasjonListe.firstOrNull { it.pensjonBeholdningFoerUttak != null }
+            ?.pensjonBeholdningFoerUttak
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/RegisterData.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/RegisterData.kt
@@ -1,0 +1,6 @@
+package no.nav.pensjon.simulator.core.result
+
+/**
+ * Data fra Nav-registre som skal inkluderes som informasjon i resultatet.
+ */
+data class RegisterData(val sisteLignetInntektAar: Int?)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutput.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutput.kt
@@ -7,7 +7,7 @@ import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresulta
 import no.nav.pensjon.simulator.afp.offentlig.livsvarig.LivsvarigOffentligAfpOutput
 import java.time.LocalDate
 
-// no.nav.domain.pensjon.kjerne.simulering.SimuleringEtter2011Resultat
+// PEN: no.nav.domain.pensjon.kjerne.simulering.SimuleringEtter2011Resultat
 class SimulatorOutput {
     //TODO data class
     var alderspensjon: SimulertAlderspensjon? = null
@@ -25,4 +25,5 @@ class SimulatorOutput {
     var persongrunnlag: Persongrunnlag? = null
 
     var heltUttakDato: LocalDate? = null
+    var registerData: RegisterData? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulertAlderspensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulertAlderspensjon.kt
@@ -2,8 +2,9 @@ package no.nav.pensjon.simulator.core.result
 
 import no.nav.pensjon.simulator.core.beregn.BeholdningPeriode
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
+import java.time.LocalDate
 
-// no.nav.domain.pensjon.kjerne.simulering.SimulertAlderspensjon
+// PEN: no.nav.domain.pensjon.kjerne.simulering.SimulertAlderspensjon
 class SimulertAlderspensjon {
     //TODO data class
     var simulertBeregningInformasjonListe: List<SimulertBeregningInformasjon> = emptyList()
@@ -15,5 +16,20 @@ class SimulertAlderspensjon {
 
     fun addPensjonsperiode(periode: PensjonPeriode?) {
         periode?.let(pensjonPeriodeListe::add)
+    }
+
+    //--- Extra:
+    /**
+     * Finner garantipensjonsbeholdningen med f.o.m.-dato nærmest, men før, angitt dato.
+     * Hvis ingen garantipensjonsbeholdning har f.o.m.-dato før angitt dato,
+     * returneres den som har f.o.m.-dato nærmest, men etter, angitt dato.
+     */
+    fun garantipensjonsbeholdningVedDato(dato: LocalDate): Int? =
+        beholdningVedDato(pensjonBeholdningListe, dato)?.garantipensjonsbeholdning?.toInt()
+
+    private companion object {
+        private fun beholdningVedDato(beholdningListe: List<BeholdningPeriode>, dato: LocalDate): BeholdningPeriode? =
+            beholdningListe.filter { it.datoFom.isBefore(dato) }.maxByOrNull { it.datoFom }
+                ?: beholdningListe.minByOrNull { it.datoFom }
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpec.kt
@@ -7,6 +7,7 @@ import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
 import no.nav.pensjon.simulator.core.krav.FremtidigInntekt
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.result.RegisterData
 import no.nav.pensjon.simulator.core.trygd.UtlandPeriode
 import no.nav.pensjon.simulator.person.Pid
 import java.time.LocalDate
@@ -45,7 +46,8 @@ data class SimuleringSpec(
     val isHentPensjonsbeholdninger: Boolean,
     val isOutputSimulertBeregningsinformasjonForAllKnekkpunkter: Boolean,
     val onlyVilkaarsproeving: Boolean,
-    val epsKanOverskrives: Boolean
+    val epsKanOverskrives: Boolean,
+    val registerData: RegisterData? = null
 ) {
     init {
         if (erAnonym) require(foedselAar > 0) { "For anonym simulering må fødselsår være angitt" }
@@ -149,7 +151,8 @@ data class SimuleringSpec(
             isHentPensjonsbeholdninger = isHentPensjonsbeholdninger,
             isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = isOutputSimulertBeregningsinformasjonForAllKnekkpunkter,
             onlyVilkaarsproeving = onlyVilkaarsproeving,
-            epsKanOverskrives = epsKanOverskrives
+            epsKanOverskrives = epsKanOverskrives,
+            registerData = registerData
         )
 
     fun withFoersteUttakDato(dato: LocalDate?) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpecUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/spec/SimuleringSpecUtil.kt
@@ -127,7 +127,8 @@ object SimuleringSpecUtil {
             isHentPensjonsbeholdninger = source.isHentPensjonsbeholdninger,
             isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = source.isOutputSimulertBeregningsinformasjonForAllKnekkpunkter,
             onlyVilkaarsproeving = source.onlyVilkaarsproeving,
-            epsKanOverskrives = source.epsKanOverskrives
+            epsKanOverskrives = source.epsKanOverskrives,
+            registerData = source.registerData
         )
     }
 
@@ -163,7 +164,8 @@ object SimuleringSpecUtil {
             isHentPensjonsbeholdninger = source.isHentPensjonsbeholdninger,
             isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = source.isOutputSimulertBeregningsinformasjonForAllKnekkpunkter,
             onlyVilkaarsproeving = source.onlyVilkaarsproeving,
-            epsKanOverskrives = source.epsKanOverskrives
+            epsKanOverskrives = source.epsKanOverskrives,
+            registerData = source.registerData
         )
 
     private fun naermesteLavereUttaksgrad(grad: UttakGradKode) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/inntekt/InntektService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/inntekt/InntektService.kt
@@ -11,8 +11,8 @@ class InntektService(
     private val lignetInntektService: SisteLignetInntekt,
     private val grunnbeloepService: GrunnbeloepService
 ) {
-    fun hentSisteLignetInntekt(pid: Pid): Int =
-        lignetInntektService.hentSisteLignetInntekt(pid).aarligBeloep
+    fun hentSisteLignetInntekt(pid: Pid): Inntekt =
+        lignetInntektService.hentSisteLignetInntekt(pid)
 
     fun hentSisteMaanedsInntektOver1G(harInntektSisteMaanedOver1G: Boolean): Int =
         if (harInntektSisteMaanedOver1G)

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultMapperV0Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultMapperV0Test.kt
@@ -22,150 +22,232 @@ import kotlin.reflect.full.companionObject
 import kotlin.reflect.full.memberProperties
 
 class AfpEtterfulgtAvAlderspensjonResultMapperV0Test : StringSpec({
+
     "toDto mapper alle felter til AfpEtterfulgtAvAlderspensjonResultV0" {
-
-        val foedseldato = LocalDate.of(1963, 2, 22)
+        val foedselsdato = LocalDate.of(1963, 2, 22)
         val nesteMaaned = LocalDate.now().plusMonths(1).withDayOfMonth(1)
-        val simuleringSpec = mockSimuleringSpec(nesteMaaned, foedseldato)
-        val simulatorOutput = mockSimulatorOutput(nesteMaaned, foedseldato)
+        val simuleringSpec = simuleringSpec(uttakDato = nesteMaaned, foedselsdato)
+        val simulatorOutput = mockSimulatorOutput(fom = nesteMaaned, foedselsdato)
 
         val dto: AfpEtterfulgtAvAlderspensjonResultV0 =
             AfpEtterfulgtAvAlderspensjonResultMapperV0.toDto(simulatorOutput, simuleringSpec)
 
-        dto.simuleringSuksess shouldBe true
-        dto.aarsakListeIkkeSuksess shouldBe emptyList()
-        dto.folketrygdberegnetAfp shouldBe afpResultat(simulatorOutput, simuleringSpec)
-        dto.alderspensjonFraFolketrygden shouldBe alderspensjonFraFolketrygdenResultatListe(
-            simulatorOutput,
-            nesteMaaned
-        )
-    }
-
-    "toDto haandterer alderspensjon med uten kapittel19" {
-        val foedseldato = LocalDate.of(1963, 2, 22)
-        val nesteMaaned = LocalDate.now().plusMonths(1).withDayOfMonth(1)
-        val simuleringSpec = mockSimuleringSpec(nesteMaaned, foedseldato)
-
-        val simulatorOutput = mockSimulatorOutput(nesteMaaned, foedseldato, kapittel19Andel = 0.0)
-
-        val dto: AfpEtterfulgtAvAlderspensjonResultV0 =
-            AfpEtterfulgtAvAlderspensjonResultMapperV0.toDto(simulatorOutput, simuleringSpec)
-
-        dto.simuleringSuksess shouldBe true
-        dto.aarsakListeIkkeSuksess shouldBe emptyList()
-
-        dto.alderspensjonFraFolketrygden.forEach { alderspensjon ->
-            alderspensjon.alderspensjonKapittel19 shouldBe null
+        with(dto) {
+            simuleringSuksess shouldBe true
+            aarsakListeIkkeSuksess shouldBe emptyList()
+            folketrygdberegnetAfp shouldBe folketrygdberegnetAfp(
+                pre2025OffentligAfp = simulatorOutput.pre2025OffentligAfp!!,
+                inntektUnderGradertUttakBeloep = simuleringSpec.inntektUnderGradertUttakBeloep
+            )
+            alderspensjonFraFolketrygden shouldBe alderspensjonFraFolketrygdenResultatListe(
+                output = simulatorOutput,
+                element2Fom = nesteMaaned.plusYears(1)
+            )
         }
     }
 
+    "toDto haandterer alderspensjon med uten kapittel19" {
+        val foedselsdato = LocalDate.of(1963, 2, 22)
+        val nesteMaaned = LocalDate.now().plusMonths(1).withDayOfMonth(1)
+        val simuleringSpec = simuleringSpec(uttakDato = nesteMaaned, foedselsdato)
+        val simulatorOutput = mockSimulatorOutput(fom = nesteMaaned, foedselsdato, kapittel19Andel = 0.0)
 
-    val alleAarsak = AarsakIkkeSuccessV0::class.companionObject!!
+        val dto: AfpEtterfulgtAvAlderspensjonResultV0 =
+            AfpEtterfulgtAvAlderspensjonResultMapperV0.toDto(simulatorOutput, simuleringSpec)
+
+        with(dto) {
+            simuleringSuksess shouldBe true
+            aarsakListeIkkeSuksess shouldBe emptyList()
+            alderspensjonFraFolketrygden.forEach { it.alderspensjonKapittel19 shouldBe null }
+        }
+    }
+
+    val alleAarsaker = AarsakIkkeSuccessV0::class.companionObject!!
         .memberProperties
         .mapNotNull { it.call(AarsakIkkeSuccessV0) as? AarsakIkkeSuccessV0 }
 
-    alleAarsak.forEach { aarsak ->
-        "${aarsak.statusKode} mappes til tom dto med fylt aarsak i listen" {
-            val dto = AfpEtterfulgtAvAlderspensjonResultMapperV0.tomResponsMedAarsak(aarsak)
-
-            dto.simuleringSuksess shouldBe false
-            dto.aarsakListeIkkeSuksess shouldBe listOf(aarsak)
-            dto.folketrygdberegnetAfp shouldBe null
-            dto.alderspensjonFraFolketrygden shouldBe emptyList()
+    alleAarsaker.forEach {
+        "${it.statusKode} mappes til tom dto med fylt aarsak i listen" {
+            val dto = AfpEtterfulgtAvAlderspensjonResultMapperV0.tomResponsMedAarsak(it)
+            with(dto) {
+                simuleringSuksess shouldBe false
+                aarsakListeIkkeSuksess shouldBe listOf(it)
+                folketrygdberegnetAfp shouldBe null
+                alderspensjonFraFolketrygden shouldBe emptyList()
+            }
         }
     }
 })
 
-private fun alderspensjonFraFolketrygdenResultatListe(
-    simulatorOutput: SimulatorOutput,
-    nesteMaaned: LocalDate
-) = listOf(
-    AlderspensjonFraFolketrygdenV0(
-        fraOgMedDato = simulatorOutput.heltUttakDato!!,
-        andelKapittel19 = simulatorOutput.alderspensjon!!.kapittel19Andel,
-        alderspensjonKapittel19 = AlderspensjonKapittel19V0(
-            grunnpensjon = GrunnpensjonV0(
-                maanedligUtbetaling = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].grunnpensjonPerMaaned!!,
-                grunnbeloep = simulatorOutput.grunnbeloep,
-                grunnpensjonsats = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].grunnpensjonsats,
-                trygdetid = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].tt_anv_kap19!!
-            ),
-            tilleggspensjon = TilleggspensjonV0(
-                maanedligUtbetaling = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].tilleggspensjonPerMaaned!!,
-                grunnbeloep = simulatorOutput.grunnbeloep,
-                sluttpoengTall = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].spt!!,
-                antallPoengaarTilOgMed1991 = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].pa_f92!!,
-                antallPoengaarFraOgMed1992 = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].pa_e91!!
-            ),
-            pensjonstillegg = PensjonstilleggV0(
-                maanedligUtbetaling = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].pensjonstilleggPerMaaned!!,
-                minstepensjonsnivaaSats = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].minstePensjonsnivaSats!!,
-            ),
-            forholdstall = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].forholdstall!!
+private fun simuleringSpec(uttakDato: LocalDate, foedselsdato: LocalDate) =
+    SimuleringSpec(
+        type = SimuleringTypeEnum.AFP_ETTERF_ALDER,
+        sivilstatus = SivilstatusType.GIFT,
+        epsHarPensjon = true,
+        foersteUttakDato = uttakDato,
+        heltUttakDato = uttakDato,
+        pid = Pid("22426305678"),
+        foedselDato = foedselsdato,
+        epsHarInntektOver2G = true,
+        fremtidigInntektListe = mutableListOf(),
+        brukFremtidigInntekt = false,
+        inntektEtterHeltUttakBeloep = 1,
+        inntektOver1GAntallAar = 0,
+        inntektUnderGradertUttakBeloep = 2,
+        inntektEtterHeltUttakAntallAar = null,
+        forventetInntektBeloep = 3,
+        utlandAntallAar = 4,
+        simulerForTp = false,
+        erAnonym = false,
+        ignoreAvslag = false,
+        isHentPensjonsbeholdninger = false,
+        isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = true,
+        onlyVilkaarsproeving = false,
+        utlandPeriodeListe = mutableListOf(),
+        epsKanOverskrives = false,
+        foedselAar = 0,
+        flyktning = false,
+        rettTilOffentligAfpFom = null,
+        pre2025OffentligAfp = Pre2025OffentligAfpSpec(
+            afpOrdning = AfpOrdningType.AFPSTAT,
+            inntektMaanedenFoerAfpUttakBeloep = 5,
+            inntektUnderAfpUttakBeloep = 6
         ),
-        andelKapittel20 = simulatorOutput.alderspensjon!!.kapittel20Andel,
-        alderspensjonKapittel20 = AlderspensjonKapittel20V0(
-            inntektspensjon = InntektspensjonV0(
-                maanedligUtbetaling = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].inntektspensjonPerMaaned!!,
-                pensjonsbeholdningFoerUttak = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].pensjonBeholdningFoerUttak!!,
-            ),
-            garantipensjon = GarantipensjonV0(
-                maanedligUtbetaling = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].garantipensjonPerMaaned!!,
-                garantipensjonssats = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].garantipensjonssats!!,
-                trygdetid = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].tt_anv_kap20!!
-            ),
-            delingstall = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].simulertBeregningInformasjonListe[0].delingstall!!,
-        ),
-        sumMaanedligUtbetaling = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].maanedsutbetalinger[0].beloep
-    ),
-    AlderspensjonFraFolketrygdenV0(
-        fraOgMedDato = nesteMaaned.plusYears(1),
-        andelKapittel19 = 3.0,
-        alderspensjonKapittel19 = null,
-        andelKapittel20 = 7.0,
-        alderspensjonKapittel20 = null,
-        sumMaanedligUtbetaling = simulatorOutput.alderspensjon!!.pensjonPeriodeListe[0].maanedsutbetalinger[1].beloep
+        avdoed = null,
+        isTpOrigSimulering = true,
+        uttakGrad = UttakGradKode.P_100,
     )
-)
-
-private fun afpResultat(
-    simulatorOutput: SimulatorOutput,
-    simuleringSpec: SimuleringSpec
-) = FolketrygdberegnetAfpV0(
-    fraOgMedDato = simulatorOutput.pre2025OffentligAfp!!.virk!!.toNorwegianLocalDate(),
-    beregnetTidligereInntekt = simulatorOutput.pre2025OffentligAfp!!.beregning!!.tp!!.spt!!.poengrekke!!.tpi,
-    fremtidigAarligInntektTilAfpUttak = simuleringSpec.forventetInntektBeloep,
-    afpGrad = 100 - (simuleringSpec.inntektUnderGradertUttakBeloep.toDouble() / (simulatorOutput.pre2025OffentligAfp!!.beregning!!.tp!!.spt!!.poengrekke!!.tpi + 1) * 100).toInt(),
-    afpAvkortetTil70Prosent = simulatorOutput.pre2025OffentligAfp!!.beregning!!.gpAfpPensjonsregulert!!.brukt,
-    grunnpensjon = GrunnpensjonV0(
-        maanedligUtbetaling = simulatorOutput.pre2025OffentligAfp!!.beregning!!.gp!!.netto,
-        grunnbeloep = simulatorOutput.pre2025OffentligAfp!!.beregning!!.g,
-        grunnpensjonsats = simulatorOutput.pre2025OffentligAfp!!.beregning!!.gp!!.pSats_gp,
-        trygdetid = simulatorOutput.pre2025OffentligAfp!!.beregning!!.gp!!.anvendtTrygdetid!!.tt_anv
-    ),
-    tilleggspensjon = TilleggspensjonV0(
-        maanedligUtbetaling = simulatorOutput.pre2025OffentligAfp!!.beregning!!.tp!!.netto,
-        grunnbeloep = simulatorOutput.pre2025OffentligAfp!!.beregning!!.g,
-        sluttpoengTall = simulatorOutput.pre2025OffentligAfp!!.beregning!!.tp!!.spt!!.pt,
-        antallPoengaarTilOgMed1991 = simulatorOutput.pre2025OffentligAfp!!.beregning!!.tp!!.spt!!.poengrekke!!.pa_f92,
-        antallPoengaarFraOgMed1992 = simulatorOutput.pre2025OffentligAfp!!.beregning!!.tp!!.spt!!.poengrekke!!.pa_e91
-    ),
-    saertillegg = SaertilleggV0(
-        maanedligUtbetaling = simulatorOutput.pre2025OffentligAfp!!.beregning!!.st!!.netto,
-        saertilleggsats = simulatorOutput.pre2025OffentligAfp!!.beregning!!.st!!.pSats_st
-    ),
-    maanedligAfpTillegg = simulatorOutput.pre2025OffentligAfp!!.beregning!!.afpTillegg!!.netto,
-    sumMaanedligUtbetaling = simulatorOutput.pre2025OffentligAfp!!.beregning!!.netto
-)
 
 private fun mockSimulatorOutput(
-    nesteMaaned: LocalDate,
-    foedseldato: LocalDate,
+    fom: LocalDate,
+    foedselsdato: LocalDate,
     kapittel19Andel: Double = 3.0
-): SimulatorOutput {
-    val result = SimulatorOutput()
-    result.pre2025OffentligAfp = Simuleringsresultat().apply {
-        virk = nesteMaaned.toNorwegianDate()
+) =
+    SimulatorOutput().apply {
+        pre2025OffentligAfp = pre2025OffentligAfp(fom)
+        alderspensjon = alderspensjon(kapittel19Andel, foersteUtbetalingFom = fom)
+        sisteGyldigeOpptjeningAar = 1
+        sivilstand = SivilstandEnum.GIFT
+        grunnbeloep = 2
+        epsHarPensjon = true
+        epsHarInntektOver2G = true
+        foedselDato = foedselsdato
+        heltUttakDato = fom
+    }
+
+private fun folketrygdberegnetAfp(
+    pre2025OffentligAfp: Simuleringsresultat,
+    inntektUnderGradertUttakBeloep: Int
+): FolketrygdberegnetAfpV0 {
+    val beregning = pre2025OffentligAfp.beregning!!
+    val grunnpensjon = beregning.gp!!
+    val tilleggspensjon = beregning.tp!!
+    val sluttpoengtall = tilleggspensjon.spt!!
+    val poengrekke = sluttpoengtall.poengrekke!!
+
+    return FolketrygdberegnetAfpV0(
+        fraOgMedDato = pre2025OffentligAfp.virk!!.toNorwegianLocalDate(),
+        beregnetTidligereInntekt = poengrekke.tpi,
+        sisteLignetInntektBrukt = false,
+        sisteLignetInntektAar = null,
+        afpGrad = 100 - (inntektUnderGradertUttakBeloep.toDouble() / poengrekke.tpi * 100).toInt(),
+        afpAvkortetTil70Prosent = beregning.gpAfpPensjonsregulert!!.brukt,
+        grunnpensjon = GrunnpensjonV0(
+            maanedligUtbetaling = grunnpensjon.netto,
+            grunnbeloep = beregning.g,
+            grunnpensjonsats = grunnpensjon.pSats_gp,
+            trygdetid = grunnpensjon.anvendtTrygdetid!!.tt_anv
+        ),
+        tilleggspensjon = TilleggspensjonV0(
+            maanedligUtbetaling = tilleggspensjon.netto,
+            grunnbeloep = beregning.g,
+            sluttpoengTall = sluttpoengtall.pt,
+            antallPoengaarTilOgMed1991 = poengrekke.pa_f92,
+            antallPoengaarFraOgMed1992 = poengrekke.pa_e91
+        ),
+        saertillegg = SaertilleggV0(maanedligUtbetaling = beregning.st!!.netto),
+        maanedligAfpTillegg = beregning.afpTillegg!!.netto,
+        sumMaanedligUtbetaling = beregning.netto
+    )
+}
+
+private fun alderspensjonFraFolketrygdenResultatListe(
+    output: SimulatorOutput,
+    element2Fom: LocalDate
+): List<AlderspensjonFraFolketrygdenV0> {
+    val alderspensjon = output.alderspensjon!!
+    val periode = alderspensjon.pensjonPeriodeListe[0]
+    val beregningsinfo = periode.simulertBeregningInformasjonListe[0]
+
+    return listOf(
+        AlderspensjonFraFolketrygdenV0(
+            fraOgMedDato = output.heltUttakDato!!,
+            andelKapittel19 = alderspensjon.kapittel19Andel,
+            alderspensjonKapittel19 = AlderspensjonKapittel19V0(
+                grunnpensjon = GrunnpensjonV0(
+                    maanedligUtbetaling = beregningsinfo.grunnpensjonPerMaaned!!,
+                    grunnbeloep = output.grunnbeloep,
+                    grunnpensjonsats = beregningsinfo.grunnpensjonsats,
+                    trygdetid = beregningsinfo.tt_anv_kap19!!
+                ),
+                tilleggspensjon = TilleggspensjonV0(
+                    maanedligUtbetaling = beregningsinfo.tilleggspensjonPerMaaned!!,
+                    grunnbeloep = output.grunnbeloep,
+                    sluttpoengTall = beregningsinfo.spt!!,
+                    antallPoengaarTilOgMed1991 = beregningsinfo.pa_f92!!,
+                    antallPoengaarFraOgMed1992 = beregningsinfo.pa_e91!!
+                ),
+                pensjonstillegg = PensjonstilleggV0(
+                    maanedligUtbetaling = beregningsinfo.pensjonstilleggPerMaaned!!,
+                    minstepensjonsnivaaSats = beregningsinfo.minstePensjonsnivaSats!!,
+                )
+            ),
+            andelKapittel20 = alderspensjon.kapittel20Andel,
+            alderspensjonKapittel20 = AlderspensjonKapittel20V0(
+                inntektspensjon = InntektspensjonV0(
+                    maanedligUtbetaling = beregningsinfo.inntektspensjonPerMaaned!!,
+                    pensjonsbeholdningForUttak = beregningsinfo.pensjonBeholdningFoerUttak!!,
+                ),
+                garantipensjon = GarantipensjonV0(
+                    maanedligUtbetaling = beregningsinfo.garantipensjonPerMaaned!!,
+                    garantipensjonsbeholdningForUttak = null,
+                    trygdetid = beregningsinfo.tt_anv_kap20!!
+                )
+            ),
+            sumMaanedligUtbetaling = periode.maanedsutbetalinger[0].beloep
+        ),
+        AlderspensjonFraFolketrygdenV0(
+            fraOgMedDato = element2Fom,
+            andelKapittel19 = 3.0,
+            alderspensjonKapittel19 = null,
+            andelKapittel20 = 7.0,
+            alderspensjonKapittel20 = null,
+            sumMaanedligUtbetaling = periode.maanedsutbetalinger[1].beloep
+        )
+    )
+}
+
+private fun alderspensjon(kapittel19Andel: Double, foersteUtbetalingFom: LocalDate) =
+    SimulertAlderspensjon().apply {
+        this.kapittel19Andel = kapittel19Andel
+        this.kapittel20Andel = 7.0
+        addPensjonsperiode(pensjonsperiode(foersteUtbetalingFom))
+    }
+
+private fun pensjonsperiode(foersteUtbetalingFom: LocalDate) =
+    PensjonPeriode().apply {
+        alderAar = 62
+        beloep = 5
+        maanedsutbetalinger = mutableListOf(
+            Maanedsutbetaling(beloep = 6, fom = foersteUtbetalingFom),
+            Maanedsutbetaling(beloep = 7, fom = foersteUtbetalingFom.plusYears(1))
+        )
+        simulertBeregningInformasjonListe = mutableListOf(simulertBeregningInformasjon(foersteUtbetalingFom))
+    }
+
+private fun pre2025OffentligAfp(fom: LocalDate) =
+    Simuleringsresultat().apply {
+        virk = fom.toNorwegianDate()
         beregning = Beregning().apply {
             g = 33
             gpAfpPensjonsregulert = Grunnpensjon().apply { brukt = true }
@@ -183,119 +265,53 @@ private fun mockSimulatorOutput(
             gp = Grunnpensjon().apply {
                 netto = 39
                 pSats_gp = 40.0
-                anvendtTrygdetid = AnvendtTrygdetid().apply {
-                    tt_anv = 41
-                }
+                anvendtTrygdetid = AnvendtTrygdetid().apply { tt_anv = 41 }
             }
             st = Sertillegg().apply {
                 netto = 42
                 pSats_st = 43.0
             }
-            afpTillegg = AfpTillegg().apply {
-                netto = 43
-            }
+            afpTillegg = AfpTillegg().apply { netto = 43 }
             netto = 44
         }
     }
 
-    result.alderspensjon = SimulertAlderspensjon()
-    result.alderspensjon!!.kapittel19Andel = kapittel19Andel
-    result.alderspensjon!!.kapittel20Andel = 7.0
-    result.alderspensjon!!.addPensjonsperiode(
-        PensjonPeriode().apply {
-            alderAar = 62
-            beloep = 5
-            maanedsutbetalinger =
-                mutableListOf(Maanedsutbetaling(6, nesteMaaned), Maanedsutbetaling(7, nesteMaaned.plusYears(1)))
-            simulertBeregningInformasjonListe = mutableListOf(
-                SimulertBeregningInformasjon()
-                    .apply {
-                        datoFom = nesteMaaned
-                        aarligBeloep = 8
-                        maanedligBeloep = 9
-                        inntektspensjon = 12
-                        garantipensjon = 14
-                        delingstall = 15.0
-                        pensjonBeholdningFoerUttak = 18
-                        spt = 19.0
-                        tt_anv_kap19 = 20
-                        tt_anv_kap20 = 21
-                        pa_f92 = 22
-                        pa_e91 = 23
-                        forholdstall = 24.0
-                        grunnpensjonPerMaaned = 25
-                        grunnpensjonsats = 26.0
-                        tilleggspensjonPerMaaned = 27
-                        pensjonstilleggPerMaaned = 28
-                        garantipensjonssats = 29.0
-                        minstePensjonsnivaSats = 30.0
-                        skjermingstillegg = 31
-                        startMaaned = 1
-                        vinnendeBeregning = GrunnlagsrolleEnum.SOKER
-                        uttakGrad = 100.0
-                        kapittel20Pensjon = 10
-                        vektetKapittel20Pensjon = 11
-                        inntektspensjonPerMaaned = 13
-                        garantipensjonPerMaaned = 15
-                        garantitillegg = 17
-                        pensjonBeholdningEtterUttak = 19
-                        kapittel19Pensjon = 20
-                        vektetKapittel19Pensjon = 21
-                        basispensjon = 22
-                        basisGrunnpensjon = 23.0
-                        basisTilleggspensjon = 24.0
-                        basisPensjonstillegg = 25.0
-                        restBasisPensjon = 26
-                    })
-        }
-    )
-    result.sisteGyldigeOpptjeningAar = 1
-    result.sivilstand = SivilstandEnum.GIFT
-    result.grunnbeloep = 2
-    result.epsHarPensjon = true
-    result.epsHarInntektOver2G = true
-    result.foedselDato = foedseldato
-    result.heltUttakDato = nesteMaaned
-    return result
-}
-
-private fun mockSimuleringSpec(
-    nesteMaaned: LocalDate,
-    foedseldato: LocalDate
-) = SimuleringSpec(
-    type = SimuleringTypeEnum.AFP_ETTERF_ALDER,
-    sivilstatus = SivilstatusType.GIFT,
-    epsHarPensjon = true,
-    foersteUttakDato = nesteMaaned,
-    heltUttakDato = nesteMaaned,
-    pid = Pid("22426305678"),
-    foedselDato = foedseldato,
-    epsHarInntektOver2G = true,
-    fremtidigInntektListe = mutableListOf(),
-    brukFremtidigInntekt = false,
-    inntektEtterHeltUttakBeloep = 1,
-    inntektOver1GAntallAar = 0,
-    inntektUnderGradertUttakBeloep = 2,
-    inntektEtterHeltUttakAntallAar = null,
-    forventetInntektBeloep = 3,
-    utlandAntallAar = 4,
-    simulerForTp = false,
-    erAnonym = false,
-    ignoreAvslag = false,
-    isHentPensjonsbeholdninger = false,
-    isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = true,
-    onlyVilkaarsproeving = false,
-    utlandPeriodeListe = mutableListOf(),
-    epsKanOverskrives = false,
-    foedselAar = 0,
-    flyktning = false,
-    rettTilOffentligAfpFom = null,
-    pre2025OffentligAfp = Pre2025OffentligAfpSpec(
-        afpOrdning = AfpOrdningType.AFPSTAT,
-        inntektMaanedenFoerAfpUttakBeloep = 5,
-        inntektUnderAfpUttakBeloep = 6
-    ),
-    avdoed = null,
-    isTpOrigSimulering = true,
-    uttakGrad = UttakGradKode.P_100,
-)
+private fun simulertBeregningInformasjon(fom: LocalDate) =
+    SimulertBeregningInformasjon().apply {
+        datoFom = fom
+        aarligBeloep = 8
+        maanedligBeloep = 9
+        inntektspensjon = 12
+        garantipensjon = 14
+        delingstall = 15.0
+        pensjonBeholdningFoerUttak = 18
+        spt = 19.0
+        tt_anv_kap19 = 20
+        tt_anv_kap20 = 21
+        pa_f92 = 22
+        pa_e91 = 23
+        forholdstall = 24.0
+        grunnpensjonPerMaaned = 25
+        grunnpensjonsats = 26.0
+        tilleggspensjonPerMaaned = 27
+        pensjonstilleggPerMaaned = 28
+        garantipensjonssats = 29.0
+        minstePensjonsnivaSats = 30.0
+        skjermingstillegg = 31
+        startMaaned = 1
+        vinnendeBeregning = GrunnlagsrolleEnum.SOKER
+        uttakGrad = 100.0
+        kapittel20Pensjon = 10
+        vektetKapittel20Pensjon = 11
+        inntektspensjonPerMaaned = 13
+        garantipensjonPerMaaned = 15
+        garantitillegg = 17
+        pensjonBeholdningEtterUttak = 19
+        kapittel19Pensjon = 20
+        vektetKapittel19Pensjon = 21
+        basispensjon = 22
+        basisGrunnpensjon = 23.0
+        basisTilleggspensjon = 24.0
+        basisPensjonstillegg = 25.0
+        restBasisPensjon = 26
+    }

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/spec/AfpEtterfulgtAvAlderspensjonSpecMapperV0Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/spec/AfpEtterfulgtAvAlderspensjonSpecMapperV0Test.kt
@@ -14,6 +14,13 @@ import java.time.LocalDate
 
 class AfpEtterfulgtAvAlderspensjonSpecMapperV0Test : StringSpec({
 
+    /**
+     * Funksjonen 'fromDto' skal bl.a.:
+     * - mappe fra spesifikasjons-DTO til motsvarende domeneobjekt
+     * - sette isHentPensjonsbeholdninger 'true' (slik at garantipensjonsbeholdning kan utledes)
+     * - sette isOutputSimulertBeregningsinformasjonForAllKnekkpunkter 'true'
+     * - innhente inntekten for måneden før AFP-uttak
+     */
     "fromDto mapper AfpEtterfulgtAvAlderspensjonValidatedSpecV0 korrekt til SimuleringSpec" {
         val dto = AfpEtterfulgtAvAlderspensjonSpecV0.AfpEtterfulgtAvAlderspensjonValidatedSpecV0(
             personId = pid.value,
@@ -43,6 +50,7 @@ class AfpEtterfulgtAvAlderspensjonSpecMapperV0Test : StringSpec({
             inntektEtterHeltUttakAntallAar shouldBe null
             forventetInntektBeloep shouldBe dto.fremtidigAarligInntektTilAfpUttak
             utlandAntallAar shouldBe dto.aarIUtlandetEtter16
+            isHentPensjonsbeholdninger shouldBe true
             with(pre2025OffentligAfp!!) {
                 inntektUnderAfpUttakBeloep shouldBe dto.fremtidigAarligInntektUnderAfpUttak
                 inntektMaanedenFoerAfpUttakBeloep shouldBe 100000

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/spec/AfpEtterfulgtAvAlderspensjonSpecMapperV0Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp_etterfulgt_ap/api/tpo/acl/v0/spec/AfpEtterfulgtAvAlderspensjonSpecMapperV0Test.kt
@@ -6,9 +6,11 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.inntekt.Inntekt
 import no.nav.pensjon.simulator.inntekt.InntektService
 import no.nav.pensjon.simulator.testutil.Arrange
 import no.nav.pensjon.simulator.testutil.TestObjects.pid
+import java.time.LocalDate
 
 class AfpEtterfulgtAvAlderspensjonSpecMapperV0Test : StringSpec({
 
@@ -41,14 +43,16 @@ class AfpEtterfulgtAvAlderspensjonSpecMapperV0Test : StringSpec({
             inntektEtterHeltUttakAntallAar shouldBe null
             forventetInntektBeloep shouldBe dto.fremtidigAarligInntektTilAfpUttak
             utlandAntallAar shouldBe dto.aarIUtlandetEtter16
-            pre2025OffentligAfp?.inntektUnderAfpUttakBeloep shouldBe dto.fremtidigAarligInntektUnderAfpUttak
-            pre2025OffentligAfp?.inntektMaanedenFoerAfpUttakBeloep shouldBe 100000
+            with(pre2025OffentligAfp!!) {
+                inntektUnderAfpUttakBeloep shouldBe dto.fremtidigAarligInntektUnderAfpUttak
+                inntektMaanedenFoerAfpUttakBeloep shouldBe 100000
+            }
         }
     }
 })
 
 private fun arrangeInntekt(): InntektService =
     mockk<InntektService>().apply {
-        every { hentSisteLignetInntekt(pid) } returns 12345
+        every { hentSisteLignetInntekt(pid) } returns Inntekt(aarligBeloep = 12345, fom = LocalDate.of(2025, 1, 1))
         every { hentSisteMaanedsInntektOver1G(harInntektSisteMaanedOver1G = true) } returns 100000
     }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/result/PensjonPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/result/PensjonPeriodeTest.kt
@@ -1,0 +1,18 @@
+package no.nav.pensjon.simulator.core.result
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class PensjonPeriodeTest : FunSpec({
+
+    test("foerstePensjonsbeholdningFoerUttak should be første non-null 'pensjonBeholdningFoerUttak'") {
+        PensjonPeriode().apply {
+            simulertBeregningInformasjonListe = mutableListOf(
+                SimulertBeregningInformasjon().apply { pensjonBeholdningFoerUttak = null },
+                SimulertBeregningInformasjon().apply { pensjonBeholdningFoerUttak = 2 },
+                SimulertBeregningInformasjon().apply { pensjonBeholdningFoerUttak = 3 },
+                SimulertBeregningInformasjon().apply { pensjonBeholdningFoerUttak = 1 }
+            )
+        }.foerstePensjonsbeholdningFoerUttak shouldBe 2
+    }
+})

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimulertAlderspensjonTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimulertAlderspensjonTest.kt
@@ -1,0 +1,70 @@
+package no.nav.pensjon.simulator.core.result
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.core.beregn.BeholdningPeriode
+import java.time.LocalDate
+
+class SimulertAlderspensjonTest : FunSpec({
+
+    /**
+     * Forutsetninger:
+     * - flere garantipensjonsbeholdninger med f.o.m.-dato før angitt dato
+     * - en garantipensjonsbeholdninger med f.o.m.-dato veldig nært, men etter, angitt dato
+     * Da skal funksjonen 'garantipensjonsbeholdningVedDato':
+     * - velge garantipensjonsbeholdningen med f.o.m.-dato nærmest før angitt dato
+     * - returnere heltallsverdien (avrundet nedover) av valgt garantipensjonsbeholdning
+     */
+    test("garantipensjonsbeholdningVedDato should return integer av garantipensjonsbeholdning med f.o.m.-dato nærmest før angitt dato") {
+        SimulertAlderspensjon().apply {
+            pensjonBeholdningListe = listOf(
+                // veldig nært, men etter, angitt dato:
+                beholdningPeriode(fom = LocalDate.of(2021, 7, 1), garantipensjonsbeholdning = 7.9),
+                // før og ganske nært angitt dato (denne skal velges):
+                beholdningPeriode(fom = LocalDate.of(2021, 4, 1), garantipensjonsbeholdning = 4.9),
+                // før, men ikke nært, angitt dato:
+                beholdningPeriode(fom = LocalDate.of(2020, 1, 1), garantipensjonsbeholdning = 1.9)
+            )
+        }.garantipensjonsbeholdningVedDato(dato = LocalDate.of(2021, 6, 1)) shouldBe 4 // avrundet nedover
+    }
+
+    /**
+     * Forutsetninger:
+     * - ingen garantipensjonsbeholdning med f.o.m.-dato før angitt dato
+     * - flere garantipensjonsbeholdninger med f.o.m.-dato etter angitt dato
+     * Da skal funksjonen 'garantipensjonsbeholdningVedDato':
+     * - velge garantipensjonsbeholdningen med f.o.m.-dato nærmest angitt dato
+     * - returnere heltallsverdien av valgt garantipensjonsbeholdning
+     */
+    test("garantipensjonsbeholdningVedDato hvis ingen med f.o.m.-dato før angitt dato") {
+        SimulertAlderspensjon().apply {
+            pensjonBeholdningListe = listOf(
+                // etter og veldig nært angitt dato:
+                beholdningPeriode(fom = LocalDate.of(2021, 7, 1), garantipensjonsbeholdning = 7.8),
+                // etter og ikke nært angitt dato:
+                beholdningPeriode(fom = LocalDate.of(2025, 1, 1), garantipensjonsbeholdning = 1.8)
+            )
+        }.garantipensjonsbeholdningVedDato(dato = LocalDate.of(2021, 6, 1)) shouldBe 7 // avrundet nedover
+    }
+
+    test("Hvis ingen beholdninger, garantipensjonsbeholdningVedDato should return null") {
+        SimulertAlderspensjon().apply {
+            pensjonBeholdningListe = listOf(
+                beholdningPeriode(fom = LocalDate.of(2021, 7, 1), garantipensjonsbeholdning = null)
+            )
+        }.garantipensjonsbeholdningVedDato(dato = LocalDate.of(2021, 6, 1)) shouldBe null
+
+        SimulertAlderspensjon().apply {
+            pensjonBeholdningListe = emptyList()
+        }.garantipensjonsbeholdningVedDato(dato = LocalDate.of(2021, 6, 1)) shouldBe null
+    }
+})
+
+private fun beholdningPeriode(fom: LocalDate, garantipensjonsbeholdning: Double?) =
+    BeholdningPeriode(
+        datoFom = fom,
+        pensjonsbeholdning = null,
+        garantipensjonsbeholdning,
+        garantitilleggsbeholdning = null,
+        garantipensjonsniva = null
+    )

--- a/src/test/kotlin/no/nav/pensjon/simulator/inntekt/InntektServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/inntekt/InntektServiceTest.kt
@@ -20,7 +20,7 @@ class InntektServiceTest : FunSpec({
     )
 
     test("hentSisteLignetInntekt should return inntekt") {
-        service.hentSisteLignetInntekt(pid) shouldBe 321000
+        service.hentSisteLignetInntekt(pid) shouldBe Inntekt(aarligBeloep = 321000, fom = LocalDate.of(2025, 1, 1))
     }
 
     test("hentSisteMaanedsInntektOver1G should return amount higher than 1G if harInntektSisteMaanedOver1G is true") {


### PR DESCRIPTION
Oppdatering av API i.h.t. [dokumentasjon for v0.95](https://confluence.adeo.no/spaces/PEN/pages/679381624/API+-+AFP+etterfulgt+av+AP):

### Endringer i responsen:

Lagt til:

- `sisteLignetInntektBrukt`
- `sisteLignetInntektAar`
- `garantipensjonsbeholdningForUttak`

Fjernet:

- `fremtidigAarligInntektTilAfpUttak`
- `garantipensjonssats`
- `saertilleggsats`
- `delingstall`
- `forholdstall`

Endret:

- `pensjonsbeholdningFoerUttak` -> `pensjonsbeholdningForUttak`

### Andre endringer:

- Flyttet noe logikk fra `AfpEtterfulgtAvAlderspensjonResultMapperV0` til domeneklassene `PensjonPeriode` og `SimulertAlderspensjon`
- Delt opp lange funksjoner i mindre funksjoner
- Fjernet `+ 1` i nevneren i testen for `afpGrad` (for å matche formelen brukt)
