### PR TITLE
PEK-1325 Include kap.19-gjenlevendetillegg in response

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
@@ -4,7 +4,6 @@ import no.nav.pensjon.simulator.core.beholdning.OpptjeningGrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
 import java.time.LocalDate
 
-// PEN: SimulatorSimulertPensjon
 data class SimulertPensjon(
     val alderspensjon: List<SimulertAarligAlderspensjon>,
     val alderspensjonFraFolketrygden: List<SimulertAlderspensjonFraFolketrygden>,
@@ -37,6 +36,7 @@ data class SimulertAarligAlderspensjon(
     val tilleggspensjon: Int?,
     val pensjonstillegg: Int?,
     val skjermingstillegg: Int?,
+    val kapittel19Gjenlevendetillegg: Int?
 )
 
 data class SimulertAlderspensjonFraFolketrygden(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.result
 
+import no.nav.pensjon.simulator.alderspensjon.Uttaksgrad
 import no.nav.pensjon.simulator.alderspensjon.alternativ.*
 import no.nav.pensjon.simulator.core.beholdning.OpptjeningGrunnlag
 
@@ -42,12 +43,13 @@ object NavSimuleringResultMapperV3 {
             tilleggspensjon = source.tilleggspensjon,
             pensjonstillegg = source.pensjonstillegg,
             skjermingstillegg = source.skjermingstillegg,
+            kapittel19Gjenlevendetillegg = source.kapittel19Gjenlevendetillegg
         )
 
     private fun maanedsbeloep(source: List<SimulertAlderspensjonFraFolketrygden>) =
         NavMaanedsbeloepV3(
-            gradertUttakBeloep = source.firstOrNull { it.uttakGrad != 100 }?.maanedligBeloep,
-            heltUttakBeloep = source.firstOrNull { it.uttakGrad == 100 }?.maanedligBeloep ?: 0
+            gradertUttakBeloep = source.firstOrNull(::erGradert)?.maanedligBeloep,
+            heltUttakBeloep = source.firstOrNull(::erHel)?.maanedligBeloep ?: 0
         )
 
     private fun pre2025OffentligAfp(source: SimulertPre2025OffentligAfp) =
@@ -112,4 +114,10 @@ object NavSimuleringResultMapperV3 {
             aar = source.alder.aar,
             maaneder = source.alder.maaneder
         )
+
+    private fun erGradert(pensjon: SimulertAlderspensjonFraFolketrygden): Boolean =
+        erHel(pensjon).not()
+
+    private fun erHel(pensjon: SimulertAlderspensjonFraFolketrygden): Boolean =
+        pensjon.uttakGrad == Uttaksgrad.HUNDRE_PROSENT.prosentsats
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
@@ -3,8 +3,7 @@ package no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.result
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
 
-// Corresponds to SimulatorPersonligSimuleringResult in pensjonskalulator-backend
-// (and previously to SimuleringsresultatAlderspensjon1963Plus in PEN)
+// Corresponds to SimulatorPersonligSimuleringResult in pensjonskalkulator-backend
 @JsonInclude(NON_NULL)
 data class NavSimuleringResultV3(
     val alderspensjonListe: List<NavAlderspensjonV3>,
@@ -16,10 +15,9 @@ data class NavSimuleringResultV3(
     val tilstrekkeligTrygdetidForGarantipensjon: Boolean?,
     val trygdetid: Int,
     val opptjeningGrunnlagListe: List<NavOpptjeningGrunnlagV3>,
-    val error: NavSimuleringErrorV3? = null,
+    val error: NavSimuleringErrorV3? = null
 )
 
-// no.nav.pensjon.pen.domain.api.simulering.dto.SimulertAlderspensjon
 @JsonInclude(NON_NULL)
 data class NavAlderspensjonV3(
     val alderAar: Int,
@@ -40,6 +38,7 @@ data class NavAlderspensjonV3(
     val tilleggspensjon: Int?,
     val pensjonstillegg: Int?,
     val skjermingstillegg: Int?,
+    val kapittel19Gjenlevendetillegg: Int?
 )
 
 @JsonInclude(NON_NULL)
@@ -77,7 +76,7 @@ data class NavPre2025OffentligAfp(
     val afpTillegg: Int,
     val saertillegg: Int,
     val afpGrad: Int,
-    val afpAvkortetTil70Prosent: Boolean,
+    val afpAvkortetTil70Prosent: Boolean
 )
 
 @JsonInclude(NON_NULL)
@@ -86,7 +85,6 @@ data class NavVilkaarsproevingResultatV3(
     val alternativ: NavAlternativtResultatV3?
 )
 
-// PEN: no.nav.pensjon.pen.domain.api.simulering.SimulatorOpptjeningGrunnlag
 data class NavOpptjeningGrunnlagV3(
     val aar: Int,
     val pensjonsgivendeInntektBeloep: Int

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
@@ -97,6 +97,7 @@ object SimulatorOutputConverter {
             tilleggspensjon = info?.tilleggspensjon,
             pensjonstillegg = info?.pensjonstillegg,
             skjermingstillegg = info?.skjermingstillegg,
+            kapittel19Gjenlevendetillegg = info?.gjtAPKap19
         )
     }
 

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
@@ -11,6 +11,11 @@ import java.time.LocalDate
 
 class NavSimuleringResultMapperV3Test : FunSpec({
 
+    /**
+     * Test av mapping ved gradert uttak.
+     * Forventet resultat er bl.a.:
+     * - alderspensjonMaanedsbeloep heltUttakBeloep skal være 0
+     */
     test("toDto for gradert uttak med alternativ") {
         NavSimuleringResultMapperV3.toDto(
             SimulertPensjonEllerAlternativ(
@@ -34,7 +39,8 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                             grunnpensjon = 567,
                             tilleggspensjon = 678,
                             pensjonstillegg = 789,
-                            skjermingstillegg = 890
+                            skjermingstillegg = 890,
+                            kapittel19Gjenlevendetillegg = 321
                         )
                     ),
                     alderspensjonFraFolketrygden = listOf(
@@ -43,13 +49,43 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                             delytelseListe = listOf(
                                 SimulertDelytelse(type = YtelseskomponentTypeEnum.GAP, beloep = 567)
                             ),
-                            uttakGrad = 50,
-                            maanedligBeloep = 678
+                            uttakGrad = 50, // => gradert
+                            maanedligBeloep = 678 // skal mappes til gradertUttakBeloep
                         )
                     ),
-                    privatAfp = listOf(SimulertPrivatAfp(alderAar = 66, beloep = 789, kompensasjonstillegg = 123, kronetillegg = 5, livsvarig = 93, maanedligBeloep = 100)),
-                    pre2025OffentligAfp = SimulertPre2025OffentligAfp(alderAar = 62, totaltAfpBeloep = 890, tidligereArbeidsinntekt = 123, grunnbeloep = 456, sluttpoengtall = 7.8, trygdetid = 30, poengaarTom1991 = 10, poengaarFom1992 = 20, grunnpensjon = 567, tilleggspensjon = 678, afpTillegg = 789, saertillegg = 890, afpGrad = 80, afpAvkortetTil70Prosent = false),
-                    livsvarigOffentligAfp = listOf(SimulertLivsvarigOffentligAfp(alderAar = 63, beloep = 901, maanedligBeloep = 100)),
+                    privatAfp = listOf(
+                        SimulertPrivatAfp(
+                            alderAar = 66,
+                            beloep = 789,
+                            kompensasjonstillegg = 123,
+                            kronetillegg = 5,
+                            livsvarig = 93,
+                            maanedligBeloep = 100
+                        )
+                    ),
+                    pre2025OffentligAfp = SimulertPre2025OffentligAfp(
+                        alderAar = 62,
+                        totaltAfpBeloep = 890,
+                        tidligereArbeidsinntekt = 123,
+                        grunnbeloep = 456,
+                        sluttpoengtall = 7.8,
+                        trygdetid = 30,
+                        poengaarTom1991 = 10,
+                        poengaarFom1992 = 20,
+                        grunnpensjon = 567,
+                        tilleggspensjon = 678,
+                        afpTillegg = 789,
+                        saertillegg = 890,
+                        afpGrad = 80,
+                        afpAvkortetTil70Prosent = false
+                    ),
+                    livsvarigOffentligAfp = listOf(
+                        SimulertLivsvarigOffentligAfp(
+                            alderAar = 63,
+                            beloep = 901,
+                            maanedligBeloep = 100
+                        )
+                    ),
                     pensjonBeholdningPeriodeListe = listOf(
                         SimulertPensjonBeholdningPeriode(
                             pensjonBeholdning = 2.3,
@@ -102,7 +138,8 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                     grunnpensjon = 567,
                     tilleggspensjon = 678,
                     pensjonstillegg = 789,
-                    skjermingstillegg = 890
+                    skjermingstillegg = 890,
+                    kapittel19Gjenlevendetillegg = 321
                 )
             ),
             alderspensjonMaanedsbeloep = NavMaanedsbeloepV3(
@@ -125,8 +162,23 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                 afpGrad = 80,
                 afpAvkortetTil70Prosent = false
             ),
-            privatAfpListe = listOf(NavPrivatAfpV3(alderAar = 66, beloep = 789, kompensasjonstillegg = 123, kronetillegg = 5, livsvarig = 93, maanedligBeloep = 100)),
-            livsvarigOffentligAfpListe = listOf(NavLivsvarigOffentligAfpV3(alderAar = 63, beloep = 901, maanedligBeloep = 100)),
+            privatAfpListe = listOf(
+                NavPrivatAfpV3(
+                    alderAar = 66,
+                    beloep = 789,
+                    kompensasjonstillegg = 123,
+                    kronetillegg = 5,
+                    livsvarig = 93,
+                    maanedligBeloep = 100
+                )
+            ),
+            livsvarigOffentligAfpListe = listOf(
+                NavLivsvarigOffentligAfpV3(
+                    alderAar = 63,
+                    beloep = 901,
+                    maanedligBeloep = 100
+                )
+            ),
             vilkaarsproeving = NavVilkaarsproevingResultatV3(
                 vilkaarErOppfylt = false, // since alternativ exists
                 alternativ = NavAlternativtResultatV3(
@@ -138,6 +190,42 @@ class NavSimuleringResultMapperV3Test : FunSpec({
             tilstrekkeligTrygdetidForGarantipensjon = true,
             trygdetid = 39,
             opptjeningGrunnlagListe = listOf(NavOpptjeningGrunnlagV3(aar = 1999, pensjonsgivendeInntektBeloep = 1002))
+        )
+    }
+
+    /**
+     * Test av mapping av maanedsbeloep ved ugradert uttak.
+     * Forventet resultat:
+     * - alderspensjonMaanedsbeloep heltUttakBeloep skal være større enn 0
+     * - alderspensjonMaanedsbeloep gradertUttakBeloep skal være null
+     */
+    test("toDto for ugradert maanedsbeloep") {
+        NavSimuleringResultMapperV3.toDto(
+            SimulertPensjonEllerAlternativ(
+                pensjon = SimulertPensjon(
+                    alderspensjon = emptyList(),
+                    alderspensjonFraFolketrygden = listOf(
+                        SimulertAlderspensjonFraFolketrygden(
+                            datoFom = LocalDate.of(2021, 1, 1),
+                            delytelseListe = emptyList(),
+                            uttakGrad = 100, // => ugradert
+                            maanedligBeloep = 678 // skal mappes til heltUttakBeloep
+                        )
+                    ),
+                    privatAfp = emptyList(),
+                    pre2025OffentligAfp = null,
+                    livsvarigOffentligAfp = emptyList(),
+                    pensjonBeholdningPeriodeListe = emptyList(),
+                    harUttak = true,
+                    harNokTrygdetidForGarantipensjon = true,
+                    trygdetid = 0,
+                    opptjeningGrunnlagListe = emptyList()
+                ),
+                alternativ = null
+            )
+        ).alderspensjonMaanedsbeloep shouldBe NavMaanedsbeloepV3(
+            gradertUttakBeloep = null, // ugradert
+            heltUttakBeloep = 678
         )
     }
 })

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
@@ -96,7 +96,8 @@ private object NavSimuleringResultMapperV3Test2Objects {
                         grunnpensjon = 15,
                         tilleggspensjon = 16,
                         pensjonstillegg = 17,
-                        skjermingstillegg = 18
+                        skjermingstillegg = 18,
+                        kapittel19Gjenlevendetillegg = 19
                     )
                 ),
                 alderspensjonFraFolketrygden,
@@ -192,6 +193,7 @@ private object NavSimuleringResultMapperV3Test2Assert {
             tilleggspensjon shouldBe 16
             pensjonstillegg shouldBe 17
             skjermingstillegg shouldBe 18
+            kapittel19Gjenlevendetillegg shouldBe 19
         }
 
         result.privatAfpListe.size shouldBe 1

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
@@ -48,7 +48,8 @@ class TpoAlderspensjonResultMapperTest : FunSpec({
                             grunnpensjon = 567,
                             tilleggspensjon = 678,
                             pensjonstillegg = 789,
-                            skjermingstillegg = 890
+                            skjermingstillegg = 890,
+                            kapittel19Gjenlevendetillegg = 321
                         )
                     ),
                     alderspensjonFraFolketrygden = listOf(

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverterTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverterTest.kt
@@ -54,6 +54,7 @@ class SimulatorOutputConverterTest : FunSpec({
                                     tilleggspensjon = 500
                                     pensjonstillegg = 600
                                     skjermingstillegg = 700
+                                    gjtAPKap19 = 800
                                 })
                             uttakGradListe = listOf(
                                 Uttaksgrad().apply {
@@ -87,7 +88,8 @@ class SimulatorOutputConverterTest : FunSpec({
                     grunnpensjon = 400,
                     tilleggspensjon = 500,
                     pensjonstillegg = 600,
-                    skjermingstillegg = 700
+                    skjermingstillegg = 700,
+                    kapittel19Gjenlevendetillegg = 800
                 )
             ),
             alderspensjonFraFolketrygden = listOf(


### PR DESCRIPTION
Inkluderer gjenlevendetillegg for kapittel 19-beregning i responsen for alderspensjonssimulering for ny kalkulator ("Nav V3").