### PR TITLE
PEK-1329 Use latest beregningsinformasjon

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
@@ -47,7 +47,7 @@ object SimulatorOutputConverter {
         val trygdetid = anvendtKapittel20Trygdetid(pensjonsperioder)
 
         return SimulertPensjon(
-            alderspensjon = pensjonsperioder.map { alderspensjon(it, alderspensjon) },
+            alderspensjon = pensjonsperioder.map { aarligAlderspensjon(it, alderspensjon) },
             alderspensjonFraFolketrygden = alderspensjon?.simulertBeregningInformasjonListe.orEmpty()
                 .map(::alderspensjonFraFolketrygden),
             pre2025OffentligAfp = source.pre2025OffentligAfp?.beregning?.let {
@@ -72,11 +72,11 @@ object SimulatorOutputConverter {
     private fun anvendtKapittel20Trygdetid(perioder: List<PensjonPeriode>): Int =
         perioder.firstOrNull()?.simulertBeregningInformasjonListe?.firstOrNull()?.tt_anv_kap20 ?: 0
 
-    private fun alderspensjon(
+    private fun aarligAlderspensjon(
         source: PensjonPeriode,
-        simulertAlderspensjon: SimulertAlderspensjon?
+        pensjon: SimulertAlderspensjon?
     ): SimulertAarligAlderspensjon {
-        val info = source.simulertBeregningInformasjonListe.firstOrNull()
+        val info = source.latestBeregningInformasjon
 
         return SimulertAarligAlderspensjon(
             alderAar = source.alderAar ?: ALDER_REPRESENTING_LOPENDE_YTELSER,
@@ -85,8 +85,8 @@ object SimulatorOutputConverter {
             garantipensjon = info?.garantipensjon,
             delingstall = info?.delingstall,
             pensjonBeholdningFoerUttak = beholdningFoerUttak(source.simulertBeregningInformasjonListe),
-            andelsbroekKap19 = simulertAlderspensjon?.kapittel19Andel ?: 0.0,
-            andelsbroekKap20 = simulertAlderspensjon?.kapittel20Andel ?: 0.0,
+            andelsbroekKap19 = pensjon?.kapittel19Andel ?: 0.0,
+            andelsbroekKap20 = pensjon?.kapittel20Andel ?: 0.0,
             sluttpoengtall = info?.spt,
             trygdetidKap19 = info?.tt_anv_kap19,
             trygdetidKap20 = info?.tt_anv_kap20,

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/PensjonPeriode.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/PensjonPeriode.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.result
 
-// no.nav.domain.pensjon.kjerne.simulering.Pensjonsperiode
+// PEN: no.nav.domain.pensjon.kjerne.simulering.Pensjonsperiode
 class PensjonPeriode {
     //TODO data class
     /**
@@ -20,4 +20,11 @@ class PensjonPeriode {
      * Vil finnes dersom der har skjedd en uttaksgradsendring og/eller bruker blir 67 år i løpet av perioden.
      */
     var simulertBeregningInformasjonListe: MutableList<SimulertBeregningInformasjon> = mutableListOf()
+
+    /**
+     * Ref. pensjon-pselv: BeregningFormDecorator.getLatestSimulertBeregningsinfo
+     */
+    val latestBeregningInformasjon: SimulertBeregningInformasjon?
+        get() = simulertBeregningInformasjonListe.filter { it.startMaaned != null }.maxByOrNull { it.startMaaned!! }
+            ?: simulertBeregningInformasjonListe.firstOrNull()
 }

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
@@ -207,6 +207,7 @@ private object NavSimuleringResultMapperV3Test2Assert {
         with(result.livsvarigOffentligAfpListe[0]) {
             alderAar shouldBe 13
             beloep shouldBe 14
+            maanedligBeloep shouldBe 1
         }
 
         result.vilkaarsproeving.alternativ shouldBe null

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/result/PensjonPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/result/PensjonPeriodeTest.kt
@@ -1,0 +1,49 @@
+package no.nav.pensjon.simulator.core.result
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class PensjonPeriodeTest : FunSpec({
+
+    test("latestBeregningInformasjon should pick element with highest startMaaned") {
+        PensjonPeriode().apply {
+            simulertBeregningInformasjonListe = mutableListOf(
+                SimulertBeregningInformasjon().apply {
+                    startMaaned = 2
+                    aarligBeloep = 200
+                },
+                SimulertBeregningInformasjon().apply {
+                    startMaaned = 1
+                    aarligBeloep = 100
+                },
+                SimulertBeregningInformasjon().apply {
+                    startMaaned = 3
+                    aarligBeloep = 300
+                },
+                SimulertBeregningInformasjon().apply {
+                    startMaaned = null
+                    aarligBeloep = 0
+                })
+        }.latestBeregningInformasjon?.aarligBeloep shouldBe 300
+    }
+
+    test("if all startMaaned undefined then latestBeregningInformasjon should pick first element") {
+        PensjonPeriode().apply {
+            simulertBeregningInformasjonListe = mutableListOf(
+                SimulertBeregningInformasjon().apply {
+                    startMaaned = null
+                    aarligBeloep = 100
+                },
+                SimulertBeregningInformasjon().apply {
+                    startMaaned = null
+                    aarligBeloep = 200
+                })
+        }.latestBeregningInformasjon?.aarligBeloep shouldBe 100
+    }
+
+    test("if empty list then latestBeregningInformasjon should return null") {
+        PensjonPeriode().apply {
+            simulertBeregningInformasjonListe = mutableListOf()
+        }.latestBeregningInformasjon shouldBe null
+    }
+})


### PR DESCRIPTION
Dersom pensjonsperioden inneholder et knekkpunkt, så vil det være to stk. beregningsinformasjon for perioden (før og etter knekkpunktet). Et knekkpunkt kan f.eks. skyldes overgang fra gradert til helt uttak.

Hvis det er mer enn ett beregningsinformasjon-element i perioden, så skal det med høyest startmåned-verdi velges (ikke som nå, hvor den første velges). Det tilsvarer logikken i pensjon-pselv (`BeregningFormDecorator.getLatestSimulertBeregningsinfo`)

Pluss litt refaktorering (alderspensjon -> aarligAlderspensjon).
