### PR TITLE
Use own class for validating Pre2025OffentligAfpSpec

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/OffentligAfpBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/OffentligAfpBeregner.kt
@@ -25,7 +25,6 @@ class OffentligAfpBeregner(
         spec: SimuleringSpec,
         kravhode: Kravhode,
         ytelser: LoependeYtelser,
-        grunnbeloep: Int,
         foedselsdato: LocalDate?,
         pid: Pid?
     ): OffentligAfpResult =
@@ -34,8 +33,7 @@ class OffentligAfpBeregner(
                 val result = pre2025FoerstegangBeregner.beregnAfp(
                     spec,
                     kravhode,
-                    ytelser.forrigeAlderspensjonBeregningResultat,
-                    grunnbeloep
+                    ytelser.forrigeAlderspensjonBeregningResultat
                 )
                 OffentligAfpResult(pre2025 = result, livsvarig = null, result.kravhode)
             }

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpSpecValidator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpSpecValidator.kt
@@ -1,0 +1,57 @@
+package no.nav.pensjon.simulator.afp.offentlig.pre2025
+
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.simulering.Simulering
+import no.nav.pensjon.simulator.core.exception.BadSpecException
+import no.nav.pensjon.simulator.core.exception.PersonForUngException
+import no.nav.pensjon.simulator.core.util.NorwegianCalendar
+import java.util.*
+
+/**
+ * Validerer spesifikasjonen for simulering av førstegangsuttak av offentlig AFP
+ * i henhold til reglene som gjaldt før 2025 ("gammel offentlig AFP").
+ */
+object Pre2025OffentligAfpSpecValidator {
+
+    private const val AFP_MIN_AGE: Int = 62
+
+    // PEN: SimulerPensjonsberegningCommand.validateInput
+    fun validateInput(spec: Simulering, normalder: Alder) {
+        val simuleringType = spec.simuleringTypeEnum ?: throw BadSpecException("Pre2025-AFP-spec mangler simuleringType")
+        val uttaksdato: Date = spec.uttaksdato ?: throw BadSpecException("Pre2025-AFP-spec mangler uttaksdato")
+
+        if (SimuleringTypeEnum.AFP == simuleringType && spec.afpOrdningEnum == null) {
+            throw BadSpecException("Pre2025-AFP-spec mangler AFP-ordning")
+        }
+
+        // PEN: SimulerPensjonsberegningCommand.findPersongrunnlagWithGivenRole
+        val soekerGrunnlag: Persongrunnlag =
+            spec.persongrunnlagListe.firstOrNull { hasRolle(persongrunnlag = it, rolle = GrunnlagsrolleEnum.SOKER) }
+                ?: throw BadSpecException("Pre2025-AFP-spec mangler persongrunnlag for søker")
+
+        val soekerFoedselsdato: Calendar = NorwegianCalendar.forNoon(soekerGrunnlag.fodselsdato!!)
+        val uttakDato: Calendar = NorwegianCalendar.forNoon(uttaksdato)
+        val foedselMaaned = soekerFoedselsdato[Calendar.MONTH]
+        val uttakMaaned = uttakDato[Calendar.MONTH]
+        val uttakAlderAar = uttakDato[Calendar.YEAR] - soekerFoedselsdato[Calendar.YEAR]
+
+        if (SimuleringTypeEnum.ALDER == simuleringType) {
+            //TODO should 'uttakMaaned <= foedselMaaned' be 'uttakMaaned <= foedselMaaned + normalder.maaneder'?
+            if (uttakAlderAar < normalder.aar || uttakAlderAar == normalder.aar && uttakMaaned <= foedselMaaned) {
+                throw PersonForUngException("Alderspensjon;${normalder.aar};${normalder.maaneder}")
+            }
+        }
+
+        if (SimuleringTypeEnum.AFP == simuleringType) {
+            if (uttakAlderAar < AFP_MIN_AGE || uttakAlderAar == AFP_MIN_AGE && uttakMaaned <= foedselMaaned) {
+                throw PersonForUngException("AFP;$AFP_MIN_AGE;0")
+            }
+        }
+    }
+
+    private fun hasRolle(persongrunnlag: Persongrunnlag, rolle: GrunnlagsrolleEnum) =
+        persongrunnlag.personDetaljListe.any { rolle == it.grunnlagsrolleEnum }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorCore.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorCore.kt
@@ -25,12 +25,12 @@ import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDatoCombo
 import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDatoRepopulator
 import no.nav.pensjon.simulator.core.ytelse.LoependeYtelser
+import no.nav.pensjon.simulator.g.GrunnbeloepService
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
 import no.nav.pensjon.simulator.person.GeneralPersonService
 import no.nav.pensjon.simulator.person.PersonService
 import no.nav.pensjon.simulator.person.Pid
 import no.nav.pensjon.simulator.sak.SakService
-import no.nav.pensjon.simulator.tech.time.Time
 import no.nav.pensjon.simulator.uttak.UttakUtil.uttakDato
 import no.nav.pensjon.simulator.ytelse.YtelseService
 import org.springframework.stereotype.Component
@@ -41,7 +41,6 @@ import java.time.LocalDate
  */
 @Component
 class SimulatorCore(
-    private val context: SimulatorContext,
     private val kravhodeCreator: KravhodeCreator,
     private val kravhodeUpdater: KravhodeUpdater,
     private val knekkpunktFinder: KnekkpunktFinder,
@@ -52,9 +51,9 @@ class SimulatorCore(
     private val sakService: SakService,
     private val ytelseService: YtelseService,
     private val offentligAfpBeregner: OffentligAfpBeregner,
+    private val grunnbeloepService: GrunnbeloepService,
     private val normalderService: NormertPensjonsalderService,
-    private val resultPreparer: SimuleringResultPreparer,
-    private val time: Time
+    private val resultPreparer: SimuleringResultPreparer
 ) : UttakAlderDiscriminator {
 
     private val log = KotlinLogging.logger {}
@@ -67,7 +66,7 @@ class SimulatorCore(
             EndringValidator.validate(initialSpec)
         }
 
-        val grunnbeloep: Int = fetchGrunnbeloep()
+        val grunnbeloep: Int = grunnbeloepService.naavaerendeGrunnbeloep()
 
         log.debug { "Simulator steg 1 - Hent løpende ytelser" }
 
@@ -160,7 +159,6 @@ class SimulatorCore(
                 spec,
                 kravhode,
                 ytelser,
-                grunnbeloep,
                 foedselsdato,
                 pid = person?.pid
             )
@@ -234,7 +232,4 @@ class SimulatorCore(
 
     override fun fetchFoedselsdato(pid: Pid): LocalDate =
         generalPersonService.foedselsdato(pid)
-
-    private fun fetchGrunnbeloep(): Int =
-        context.fetchGrunnbeloepListe(time.today()).satsResultater.firstOrNull()?.verdi?.toInt() ?: 0
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/afp/AfpOrdningType.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/afp/AfpOrdningType.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.simulator.core.afp
 
+//TODO replace by AFPtypeEnum
 // no.nav.domain.pensjon.kjerne.kodetabeller.AfpOrdningTypeCode
 enum class AfpOrdningType {
     /**

--- a/src/main/kotlin/no/nav/pensjon/simulator/g/GrunnbeloepService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/g/GrunnbeloepService.kt
@@ -3,12 +3,16 @@ package no.nav.pensjon.simulator.g
 import no.nav.pensjon.simulator.regel.client.RegelClient
 import no.nav.pensjon.simulator.tech.time.Time
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class GrunnbeloepService(
     private val regelClient: RegelClient,
     private val time: Time
 ) {
+    fun grunnbeloep(dato: LocalDate): Int =
+        regelClient.fetchGrunnbeloepListe(dato).satsResultater.first().verdi.toInt()
+
     fun naavaerendeGrunnbeloep(): Int =
-        regelClient.fetchGrunnbeloepListe(time.today()).satsResultater.first().verdi.toInt()
+        grunnbeloep(time.today())
 }

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/OffentligAfpBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/OffentligAfpBeregnerTest.kt
@@ -67,7 +67,6 @@ class OffentligAfpBeregnerTest : FunSpec({
             spec = simuleringSpec(type = SimuleringTypeEnum.AFP_ETTERF_ALDER), // pre-2025 offentlig AFP
             kravhode = originalKravhode,
             ytelser = noYtelser,
-            grunnbeloep = 123000,
             foedselsdato = pre2025Foedselsdato,
             pid
         ) shouldBe OffentligAfpResult(
@@ -90,7 +89,6 @@ class OffentligAfpBeregnerTest : FunSpec({
             spec = simuleringSpec(type = SimuleringTypeEnum.ENDR_ALDER), // endring uten livsvarig offentlig AFP
             kravhode,
             ytelser = noYtelser,
-            grunnbeloep = 123000,
             foedselsdato = pre2025Foedselsdato,
             pid
         ) shouldBe OffentligAfpResult(
@@ -111,7 +109,6 @@ class OffentligAfpBeregnerTest : FunSpec({
             spec = simuleringSpec(type = SimuleringTypeEnum.ALDER), // krever terminering av pre-2025 offentlig AFP
             kravhode,
             ytelser = noYtelser,
-            grunnbeloep = 123000,
             foedselsdato = pre2025Foedselsdato,
             pid
         ) shouldBe OffentligAfpResult(
@@ -138,7 +135,6 @@ class OffentligAfpBeregnerTest : FunSpec({
             spec = simuleringSpec(type = SimuleringTypeEnum.ALDER), // => ingen AFP involvert hvis født 1963 eller senere
             kravhode,
             ytelser = noYtelser,
-            grunnbeloep = 123000,
             foedselsdato = LocalDate.of(1963, 1, 1), // => født 1963 eller senere
             pid
         ) shouldBe OffentligAfpResult(
@@ -160,7 +156,6 @@ class OffentligAfpBeregnerTest : FunSpec({
             spec = simuleringSpec(type = SimuleringTypeEnum.ALDER_MED_AFP_OFFENTLIG_LIVSVARIG),
             kravhode,
             ytelser = noYtelser,
-            grunnbeloep = 123000,
             foedselsdato = LocalDate.of(1963, 1, 1),
             pid
         ) shouldBe OffentligAfpResult(
@@ -178,7 +173,7 @@ private fun arrangeLivsvarig(result: LivsvarigOffentligAfpResult): LivsvarigOffe
 
 private fun arrangePre2025Foerstegang(result: Pre2025OffentligAfpResult): Pre2025OffentligAfpFoerstegangBeregner =
     mockk<Pre2025OffentligAfpFoerstegangBeregner>().apply {
-        every { beregnAfp(any(), any(), any(), any()) } returns result
+        every { beregnAfp(any(), any(), any()) } returns result
     }
 
 private fun arrangePre2025Endring(result: Pre2025OffentligAfpResult): Pre2025OffentligAfpEndringBeregner =

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpFoerstegangBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpFoerstegangBeregnerTest.kt
@@ -1,0 +1,45 @@
+package no.nav.pensjon.simulator.afp.offentlig.pre2025
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.pensjon.simulator.core.SimulatorContext
+import no.nav.pensjon.simulator.core.afp.AfpOrdningType
+import no.nav.pensjon.simulator.core.domain.regler.enum.VedtakResultatEnum
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresultat
+import no.nav.pensjon.simulator.g.GrunnbeloepService
+import no.nav.pensjon.simulator.testutil.Arrange
+import no.nav.pensjon.simulator.testutil.TestObjects.persongrunnlag
+import no.nav.pensjon.simulator.testutil.TestObjects.simuleringSpec
+import java.time.LocalDate
+
+class Pre2025OffentligAfpFoerstegangBeregnerTest : FunSpec({
+
+    test("beregnAfp skal gi innvilget vedtak hvis simulering OK") {
+        Pre2025OffentligAfpFoerstegangBeregner(
+            context = arrangeSimuleringsresultat(),
+            normalderService = Arrange.normalder(),
+            ufoereService = mockk(),
+            grunnbeloepService = arrangeGrunnbeloep()
+        ).beregnAfp(
+            spec = simuleringSpec(afpOrdning = AfpOrdningType.AFPSTAT), // foersteUttakDato = 2029-01-01
+            kravhode = Kravhode().apply { persongrunnlagListe = mutableListOf(persongrunnlag) },
+            forrigeAlderspensjonBeregningResultat = null
+        ).simuleringResult?.statusEnum shouldBe VedtakResultatEnum.INNV
+    }
+})
+
+private fun arrangeSimuleringsresultat(): SimulatorContext =
+    mockk<SimulatorContext>().apply {
+        every { simulerVilkarsprovPre2025OffentligAfp(any()) } returns Simuleringsresultat()
+        every { simulerPre2025OffentligAfp(any()) } returns Simuleringsresultat()
+    }
+
+private fun arrangeGrunnbeloep(): GrunnbeloepService =
+    mockk<GrunnbeloepService>().apply {
+        every {
+            grunnbeloep(dato = LocalDate.of(2029, 1, 1)) // virkningFom, foersteUttakDato
+        } returns 123000
+    }

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpSpecValidatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpSpecValidatorTest.kt
@@ -1,0 +1,131 @@
+package no.nav.pensjon.simulator.afp.offentlig.pre2025
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.domain.regler.enum.AFPtypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.simulering.Simulering
+import no.nav.pensjon.simulator.core.exception.BadSpecException
+import no.nav.pensjon.simulator.core.exception.PersonForUngException
+import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
+
+class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
+
+    val normalder = Alder(aar = 67, maaneder = 0)
+    val dato = dateAtNoon(2025, 1, 1)
+    val soeker = mutableListOf(PersonDetalj().apply { grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER })
+
+    test("Manglende simuleringType skal forhindres med BadSpecException") {
+        shouldThrow<BadSpecException> {
+            Pre2025OffentligAfpSpecValidator.validateInput(
+                spec = Simulering().apply { simuleringTypeEnum = null },
+                normalder
+            )
+        }.message shouldBe "Pre2025-AFP-spec mangler simuleringType"
+    }
+
+    test("Manglende uttaksdato skal forhindres med BadSpecException") {
+        shouldThrow<BadSpecException> {
+            Pre2025OffentligAfpSpecValidator.validateInput(
+                spec = Simulering().apply {
+                    simuleringTypeEnum = SimuleringTypeEnum.ALDER
+                    uttaksdato = null
+                },
+                normalder
+            )
+        }.message shouldBe "Pre2025-AFP-spec mangler uttaksdato"
+    }
+
+    test("AFP-simulering med manglende AFP-ordning skal forhindres med BadSpecException") {
+        shouldThrow<BadSpecException> {
+            Pre2025OffentligAfpSpecValidator.validateInput(
+                spec = Simulering().apply {
+                    simuleringTypeEnum = SimuleringTypeEnum.AFP
+                    uttaksdato = dato
+                    afpOrdningEnum = null
+                },
+                normalder
+            )
+        }.message shouldBe "Pre2025-AFP-spec mangler AFP-ordning"
+    }
+
+    test("Manglende persongrunnlag skal forhindres med BadSpecException") {
+        shouldThrow<BadSpecException> {
+            Pre2025OffentligAfpSpecValidator.validateInput(
+                spec = Simulering().apply {
+                    simuleringTypeEnum = SimuleringTypeEnum.ALDER
+                    uttaksdato = dato
+                    persongrunnlagListe = mutableListOf()
+                },
+                normalder
+            )
+        }.message shouldBe "Pre2025-AFP-spec mangler persongrunnlag for søker"
+    }
+
+    test("Manglende persondetalj skal forhindres med BadSpecException") {
+        shouldThrow<BadSpecException> {
+            Pre2025OffentligAfpSpecValidator.validateInput(
+                spec = Simulering().apply {
+                    simuleringTypeEnum = SimuleringTypeEnum.ALDER
+                    uttaksdato = dato
+                    persongrunnlagListe = mutableListOf(Persongrunnlag().apply { personDetaljListe = mutableListOf() })
+                },
+                normalder
+            )
+        }.message shouldBe "Pre2025-AFP-spec mangler persongrunnlag for søker"
+    }
+
+    test("Manglende søker-persondetalj skal forhindres med BadSpecException") {
+        shouldThrow<BadSpecException> {
+            Pre2025OffentligAfpSpecValidator.validateInput(
+                spec = Simulering().apply {
+                    simuleringTypeEnum = SimuleringTypeEnum.ALDER
+                    uttaksdato = dato
+                    persongrunnlagListe = mutableListOf(Persongrunnlag().apply {
+                        personDetaljListe =
+                            mutableListOf(PersonDetalj().apply { grunnlagsrolleEnum = GrunnlagsrolleEnum.BARN })
+                    })
+                },
+                normalder
+            )
+        }.message shouldBe "Pre2025-AFP-spec mangler persongrunnlag for søker"
+    }
+
+    test("Alderspensjonsimulering med søker yngre enn normalder skal forhindres med PersonForUngException") {
+        shouldThrow<PersonForUngException> {
+            Pre2025OffentligAfpSpecValidator.validateInput(
+                spec = Simulering().apply {
+                    simuleringTypeEnum = SimuleringTypeEnum.ALDER
+                    uttaksdato = dateAtNoon(2025, 6, 1)
+                    persongrunnlagListe = mutableListOf(Persongrunnlag().apply {
+                        fodselsdato = dateAtNoon(1958, 6, 15) // blir 67 år 2 måneder 2025-08-15 => for ung
+                        personDetaljListe = soeker
+                    })
+                },
+                normalder = Alder(aar = 67, maaneder = 2)
+            )
+        }.message shouldBe "Alderspensjon;67;2"
+    }
+
+    test("AFP-simulering med søker yngre enn 62 år skal forhindres med PersonForUngException") {
+        shouldThrow<PersonForUngException> {
+            Pre2025OffentligAfpSpecValidator.validateInput(
+                spec = Simulering().apply {
+                    simuleringTypeEnum = SimuleringTypeEnum.AFP
+                    afpOrdningEnum = AFPtypeEnum.AFPSTAT
+                    uttaksdato = dateAtNoon(2025, 6, 1)
+                    persongrunnlagListe = mutableListOf(Persongrunnlag().apply {
+                        fodselsdato = dateAtNoon(1963, 6, 15) // blir 62 år 2025-06-15 => for ung
+                        personDetaljListe = soeker
+                    })
+                },
+                normalder // irrelevant i denne sammenheng
+            )
+        }.message shouldBe "AFP;62;0"
+    }
+})

--- a/src/test/kotlin/no/nav/pensjon/simulator/testutil/Arrange.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/testutil/Arrange.kt
@@ -32,6 +32,11 @@ object Arrange {
             every { normalder(foedselsdato) } returns Alder(67, 0)
         }
 
+    fun normalder(): NormertPensjonsalderService =
+        mockk<NormertPensjonsalderService>().apply {
+            every { normalder(pid) } returns Alder(67, 0)
+        }
+
     fun security() {
         SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext())
 

--- a/src/test/kotlin/no/nav/pensjon/simulator/testutil/TestObjects.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/testutil/TestObjects.kt
@@ -1,17 +1,25 @@
 package no.nav.pensjon.simulator.testutil
 
+import no.nav.pensjon.simulator.core.afp.AfpOrdningType
 import no.nav.pensjon.simulator.core.domain.Avdoed
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
+import no.nav.pensjon.simulator.core.domain.regler.PenPerson
+import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.krav.FremtidigInntekt
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.spec.Pre2025OffentligAfpSpec
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.trygd.UtlandPeriode
 import no.nav.pensjon.simulator.generelt.organisasjon.Organisasjonsnummer
 import no.nav.pensjon.simulator.person.Pid
+import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
 import org.springframework.security.oauth2.jwt.Jwt
 import java.time.LocalDate
+import java.util.*
 
 object TestObjects {
     val jwt = Jwt("j.w.t", null, null, mapOf("k" to "v"), mapOf("k" to "v"))
@@ -20,6 +28,19 @@ object TestObjects {
 
     val pid = Pid("12345678910")
 
+    val persongrunnlag =
+        Persongrunnlag().apply {
+            penPerson = PenPerson()
+            fodselsdato = dateAtNoon(1963, Calendar.JANUARY, 1)
+            personDetaljListe = mutableListOf(
+                PersonDetalj().apply {
+                    bruk = true
+                    grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
+                    penRolleTom = dateAtNoon(2026, Calendar.JANUARY, 1)
+                }
+            )
+        }
+
     val simuleringSpec = simuleringSpec()
 
     fun simuleringSpec(
@@ -27,7 +48,8 @@ object TestObjects {
         sivilstatus: SivilstatusType = SivilstatusType.UGIF,
         epsHarPensjon: Boolean = false,
         foersteUttakDato: LocalDate? = LocalDate.of(2029, 1, 1),
-        inntektSpecListe: List<FremtidigInntekt> = emptyList()
+        inntektSpecListe: List<FremtidigInntekt> = emptyList(),
+        afpOrdning: AfpOrdningType? = null
     ) = SimuleringSpec(
         type,
         sivilstatus,
@@ -73,7 +95,13 @@ object TestObjects {
         flyktning = false,
         epsHarInntektOver2G = true,
         rettTilOffentligAfpFom = null,
-        pre2025OffentligAfp = null,
+        pre2025OffentligAfp = afpOrdning?.let {
+            Pre2025OffentligAfpSpec(
+                afpOrdning = it,
+                inntektMaanedenFoerAfpUttakBeloep = 2000,
+                inntektUnderAfpUttakBeloep = 1000
+            )
+        },
         erAnonym = false,
         ignoreAvslag = false,
         isHentPensjonsbeholdninger = true,


### PR DESCRIPTION
Trekker ut `Pre2025OffentligAfpSpecValidator` fra `Pre2025OffentligAfpFoerstegangBeregner`, og legger til tester for begge.

Bruker grunnbeløp-service istedenfor å sende grunnbeløp som argument gjennom flere funksjonslag.

Pluss noe refaktorering.