### PR TITLE
Use trygdetid = max of kapittel 19 and kapittel 20

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
@@ -12,7 +12,13 @@ data class SimulertPensjon(
     val livsvarigOffentligAfp: List<SimulertLivsvarigOffentligAfp>,
     val pensjonBeholdningPeriodeListe: List<SimulertPensjonBeholdningPeriode>,
     val harUttak: Boolean,
-    val harNokTrygdetidForGarantipensjon: Boolean,
+
+    /**
+     * Kapittel 19: Angir om personen har nok trygdetid for alderspensjon
+     * Kapittel 20: Angir om personen har nok trygdetid for garantipensjon
+     */
+    val harTilstrekkeligTrygdetid: Boolean,
+
     val trygdetid: Int,
     val opptjeningGrunnlagListe: List<OpptjeningGrunnlag>
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
@@ -18,7 +18,7 @@ object NavSimuleringResultMapperV3 {
             privatAfpListe = source?.pensjon?.privatAfp.orEmpty().map(::privatAfp),
             livsvarigOffentligAfpListe = source?.pensjon?.livsvarigOffentligAfp.orEmpty().map(::livsvarigOffentligAfp),
             vilkaarsproeving = vilkaarsproevingResultat(source?.alternativ),
-            tilstrekkeligTrygdetidForGarantipensjon = source?.pensjon?.harNokTrygdetidForGarantipensjon,
+            tilstrekkeligTrygdetidForGarantipensjon = source?.pensjon?.harTilstrekkeligTrygdetid,
             trygdetid = source?.pensjon?.trygdetid ?: 0,
             opptjeningGrunnlagListe = source?.pensjon?.opptjeningGrunnlagListe.orEmpty().map(::opptjeningGrunnlag)
         )

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultV3.kt
@@ -12,7 +12,13 @@ data class NavSimuleringResultV3(
     val privatAfpListe: List<NavPrivatAfpV3>,
     val livsvarigOffentligAfpListe: List<NavLivsvarigOffentligAfpV3>,
     val vilkaarsproeving: NavVilkaarsproevingResultatV3,
-    val tilstrekkeligTrygdetidForGarantipensjon: Boolean?,
+
+    /**
+     * Kapittel 19: Angir om nok trygdetid for alderspensjon
+     * Kapittel 20: Angir om nok trygdetid for garantipensjon
+     */
+    val tilstrekkeligTrygdetidForGarantipensjon: Boolean?, //TODO rename to harTilstrekkeligTrygdetid
+
     val trygdetid: Int,
     val opptjeningGrunnlagListe: List<NavOpptjeningGrunnlagV3>,
     val error: NavSimuleringErrorV3? = null

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
@@ -30,8 +30,14 @@ import java.util.*
 object SimulatorOutputConverter {
 
     /**
-     * https://lovdata.no/dokument/NL/lov/1997-02-28-19/KAPITTEL_7-2#KAPITTEL_7-2
-     * § 20-10.Garantipensjon – trygdetid
+     * Folketrygdloven kapittel 19, https://lovdata.no/lov/1997-02-28-19/§19-2:
+     * "Det er et vilkår for rett til alderspensjon at vedkommende har minst fem års trygdetid" (med noen unntak)
+     */
+    private const val KAPITTEL19_MINIMUM_TRYGDETID_ANTALL_AAR = 5
+
+    /**
+     * Folketrygdloven kapittel 20, https://lovdata.no/lov/1997-02-28-19/§20-10:
+     * "Det er et vilkår for rett til garantipensjon at vedkommende har minst fem års trygdetid"
      */
     private const val MINIMUM_TRYGDETID_FOR_GARANTIPENSJON_ANTALL_AAR = 5
 
@@ -62,7 +68,7 @@ object SimulatorOutputConverter {
             pensjonBeholdningPeriodeListe = alderspensjon?.pensjonBeholdningListe.orEmpty()
                 .map(::beholdningPeriode),
             harUttak = alderspensjon?.uttakGradListe.orEmpty().any { harUttakToday(it, today) },
-            harNokTrygdetidForGarantipensjon = trygdetid.kapittel20 >= MINIMUM_TRYGDETID_FOR_GARANTIPENSJON_ANTALL_AAR,
+            harTilstrekkeligTrygdetid = trygdetid.erTilstrekkelig,
             trygdetid = trygdetid.kapittel19.coerceAtLeast(trygdetid.kapittel20), //TODO sjekk det faglige her
             opptjeningGrunnlagListe = source.persongrunnlag?.opptjeningsgrunnlagListe.orEmpty()
                 .map(::opptjeningGrunnlag).sortedBy { it.aar }
@@ -256,5 +262,9 @@ object SimulatorOutputConverter {
     private data class Trygdetid(
         val kapittel19: Int,
         val kapittel20: Int
-    )
+    ) {
+        val erTilstrekkelig: Boolean
+            get() = kapittel19 >= KAPITTEL19_MINIMUM_TRYGDETID_ANTALL_AAR ||
+                    kapittel20 >= MINIMUM_TRYGDETID_FOR_GARANTIPENSJON_ANTALL_AAR
+    }
 }

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakServiceTest.kt
@@ -55,7 +55,7 @@ class AlternativtUttakServiceTest : FunSpec({
                 livsvarigOffentligAfp = emptyList(),
                 pensjonBeholdningPeriodeListe = emptyList(),
                 harUttak = false,
-                harNokTrygdetidForGarantipensjon = false,
+                harTilstrekkeligTrygdetid = false,
                 trygdetid = 0,
                 opptjeningGrunnlagListe = emptyList()
             ),

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
@@ -101,7 +101,7 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                         )
                     ),
                     harUttak = true,
-                    harNokTrygdetidForGarantipensjon = true,
+                    harTilstrekkeligTrygdetid = true,
                     trygdetid = 39,
                     opptjeningGrunnlagListe = listOf(OpptjeningGrunnlag(aar = 1999, pensjonsgivendeInntekt = 1002))
                 ),
@@ -217,7 +217,7 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                     livsvarigOffentligAfp = emptyList(),
                     pensjonBeholdningPeriodeListe = emptyList(),
                     harUttak = true,
-                    harNokTrygdetidForGarantipensjon = true,
+                    harTilstrekkeligTrygdetid = true,
                     trygdetid = 0,
                     opptjeningGrunnlagListe = emptyList()
                 ),

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
@@ -149,7 +149,7 @@ private object NavSimuleringResultMapperV3Test2Objects {
                     )
                 ),
                 harUttak = true,
-                harNokTrygdetidForGarantipensjon = true,
+                harTilstrekkeligTrygdetid = true,
                 trygdetid = 21,
                 opptjeningGrunnlagListe = listOf(
                     OpptjeningGrunnlag(

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/direct/TpoAlderspensjonResultMapperTest.kt
@@ -80,7 +80,7 @@ class TpoAlderspensjonResultMapperTest : FunSpec({
                         )
                     ),
                     harUttak = true,
-                    harNokTrygdetidForGarantipensjon = true,
+                    harTilstrekkeligTrygdetid = true,
                     trygdetid = 40,
                     opptjeningGrunnlagListe = listOf(
                         OpptjeningGrunnlag(aar = 2024, pensjonsgivendeInntekt = 50000)
@@ -234,7 +234,7 @@ private fun simulertPensjon(alderspensjonFraFolketrygden: List<SimulertAlderspen
             livsvarigOffentligAfp = emptyList(),
             pensjonBeholdningPeriodeListe = emptyList(),
             harUttak = true,
-            harNokTrygdetidForGarantipensjon = true,
+            harTilstrekkeligTrygdetid = true,
             trygdetid = 40,
             opptjeningGrunnlagListe = emptyList()
         ),

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverterTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverterTest.kt
@@ -23,6 +23,7 @@ class SimulatorOutputConverterTest : FunSpec({
      * Also tests that:
      * - harUttak = false if no uttaksgrad covers today's date
      * - harNokTrygdetidForGarantipensjon = false if mindre enn 5 år 'kapittel 20'-trygdetid
+     * - trygdetid = max av kapittel 19-trygdetid og kapittel 20-trygdetid
      */
     test("'pensjon' should map SimulatorOutput to SimulertPensjon") {
         SimulatorOutputConverter.pensjon(
@@ -106,7 +107,7 @@ class SimulatorOutputConverterTest : FunSpec({
             pensjonBeholdningPeriodeListe = emptyList(),
             harUttak = false,
             harNokTrygdetidForGarantipensjon = false,
-            trygdetid = 4, // NB: Mapped twice (also to trygdetidKap20)
+            trygdetid = 19, // NB: Max of trygdetidKap19 and trygdetidKap20
             opptjeningGrunnlagListe = emptyList()
         )
     }

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverterTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverterTest.kt
@@ -22,7 +22,7 @@ class SimulatorOutputConverterTest : FunSpec({
      * - pensjonPeriodeListe to alderspensjon
      * Also tests that:
      * - harUttak = false if no uttaksgrad covers today's date
-     * - harNokTrygdetidForGarantipensjon = false if mindre enn 5 år 'kapittel 20'-trygdetid
+     * - harNokTrygdetidForGarantipensjon = false if mindre enn 5 år trygdetid
      * - trygdetid = max av kapittel 19-trygdetid og kapittel 20-trygdetid
      */
     test("'pensjon' should map SimulatorOutput to SimulertPensjon") {
@@ -106,7 +106,7 @@ class SimulatorOutputConverterTest : FunSpec({
             livsvarigOffentligAfp = emptyList(),
             pensjonBeholdningPeriodeListe = emptyList(),
             harUttak = false,
-            harNokTrygdetidForGarantipensjon = false,
+            harTilstrekkeligTrygdetid = true,
             trygdetid = 19, // NB: Max of trygdetidKap19 and trygdetidKap20
             opptjeningGrunnlagListe = emptyList()
         )
@@ -164,6 +164,6 @@ class SimulatorOutputConverterTest : FunSpec({
                 }
             },
             today = LocalDate.of(2025, 2, 15)
-        ).harNokTrygdetidForGarantipensjon shouldBe true
+        ).harTilstrekkeligTrygdetid shouldBe true
     }
 })


### PR DESCRIPTION
Dette er en foreløpig løsning for å unngå 0 trygdetid for kapittel 19-tilfeller.

NB: Flagget `harNokTrygdetidForGarantipensjon` vil være `true` også hvis kapittel 19-trygdetid er minst 5 år (selv om 'garantipensjon' er et kapittel 20-begrep). Navnet på flagget kan vi endre på senere.