### PR TITLE
Temp. fix for "Java agent has been loaded dynamically" warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
+                <configuration>
+                    <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
Midlertidig fix.

For ordentlig fix, så foreslår Google:

> The long-term solution involves configuring libraries that use agents to load them as proper Java agents at application startup using the -javaagent flag. This requires understanding how the specific library or framework handles agent configuration. For example, Mockito can be configured to use its agent explicitly. 