### PR TITLE
PEK-1243 dekke core.beregn pakke med unittester

### DIFF
--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2011SisteBeregningCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2011SisteBeregningCreatorTest.kt
@@ -20,9 +20,10 @@ import java.util.*
 
 class Alderspensjon2011SisteBeregningCreatorTest : FunSpec({
 
-    // ===========================================
-    // Tests for ytelseskomponenter filtering
-    // ===========================================
+    /**
+     * Test filter for irrelevante ytelseskomponenter.
+     * En ytelseskomponent er irrelevant hvis den er opphørt eller ubrukt.
+     */
 
     test("createBeregning should filter out irrelevante ytelseskomponenter") {
         val beregning = createBeregning(

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2011SisteBeregningCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2011SisteBeregningCreatorTest.kt
@@ -2,46 +2,52 @@ package no.nav.pensjon.simulator.core.beregn
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.mockk
+import no.nav.pensjon.simulator.core.domain.regler.PenPerson
 import no.nav.pensjon.simulator.core.domain.regler.beregning.AfpTillegg
 import no.nav.pensjon.simulator.core.domain.regler.beregning.Familietillegg
 import no.nav.pensjon.simulator.core.domain.regler.beregning.Ytelseskomponent
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
+import no.nav.pensjon.simulator.core.domain.regler.enum.*
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravlinje
+import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
+import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
+import java.util.*
 
 class Alderspensjon2011SisteBeregningCreatorTest : FunSpec({
 
-    /**
-     * Test filter for irrelevante ytelseskomponenter.
-     * En ytelseskomponent er irrelevant hvis den er opphørt eller ubrukt.
-     */
+    // ===========================================
+    // Tests for ytelseskomponenter filtering
+    // ===========================================
+
     test("createBeregning should filter out irrelevante ytelseskomponenter") {
-        val beregning =
-            Alderspensjon2011SisteBeregningCreator(kravService = mockk()).createBeregning(
-                beregningSpec(
-                    ytelseskomponentListe = mutableListOf(
-                        Garantipensjon().apply {
-                            brukt = true
-                            opphort = false
-                            brutto = 1
-                        },
-                        AfpTillegg().apply {
-                            brukt = true
-                            opphort = true // => irrelevant
-                            brutto = 2
-                        },
-                        Familietillegg().apply {
-                            brukt = false // => irrelevant
-                            opphort = false
-                            brutto = 3
-                        },
-                        Skjermingstillegg().apply {
-                            brukt = true
-                            opphort = false
-                            brutto = 4
-                        })
-                ),
-                BeregningsResultatAlderspensjon2011()
-            ) as SisteAldersberegning2011
+        val beregning = createBeregning(
+            ytelseskomponentListe = mutableListOf(
+                Garantipensjon().apply {
+                    brukt = true
+                    opphort = false
+                    brutto = 1
+                },
+                AfpTillegg().apply {
+                    brukt = true
+                    opphort = true // => irrelevant
+                    brutto = 2
+                },
+                Familietillegg().apply {
+                    brukt = false // => irrelevant
+                    opphort = false
+                    brutto = 3
+                },
+                Skjermingstillegg().apply {
+                    brukt = true
+                    opphort = false
+                    brutto = 4
+                })
+        )
 
         with(beregning.pensjonUnderUtbetaling!!) {
             ytelseskomponenter.size shouldBe 2
@@ -49,16 +55,359 @@ class Alderspensjon2011SisteBeregningCreatorTest : FunSpec({
             ytelseskomponenter[1].brutto shouldBe 4
         }
     }
+
+    test("createBeregning should keep all ytelseskomponenter when all are relevant") {
+        val beregning = createBeregning(
+            ytelseskomponentListe = mutableListOf(
+                Garantipensjon().apply { brukt = true; opphort = false; brutto = 100 },
+                Skjermingstillegg().apply { brukt = true; opphort = false; brutto = 200 }
+            )
+        )
+
+        beregning.pensjonUnderUtbetaling!!.ytelseskomponenter.size shouldBe 2
+    }
+
+    // ===========================================
+    // Tests for regelverkTypeEnum
+    // ===========================================
+
+    test("createBeregning should set regelverkTypeEnum from spec") {
+        val beregning = createBeregning(regelverkType = RegelverkTypeEnum.N_REG_G_OPPTJ)
+        beregning.regelverkTypeEnum shouldBe RegelverkTypeEnum.N_REG_G_OPPTJ
+    }
+
+    test("createBeregning should handle null regelverkTypeEnum") {
+        val beregning = createBeregning(regelverkType = null)
+        beregning.regelverkTypeEnum shouldBe null
+    }
+
+    // ===========================================
+    // Tests for virkDato
+    // ===========================================
+
+    test("createBeregning should set virkDato from beregningsresultat virkFom") {
+        val virkFom = dateAtNoon(2024, Calendar.MARCH, 1)
+        val beregning = createBeregning(virkFom = virkFom)
+        beregning.virkDato shouldBe virkFom
+    }
+
+    test("createBeregning should not set virkDato when virkFom is null") {
+        val beregning = createBeregning(virkFom = null)
+        beregning.virkDato shouldBe null
+    }
+
+    // ===========================================
+    // Tests for benyttetSivilstandEnum
+    // ===========================================
+
+    test("createBeregning should set benyttetSivilstandEnum from beregningsresultat") {
+        val beregning = createBeregning(benyttetSivilstand = BorMedTypeEnum.J_EKTEF)
+        beregning.benyttetSivilstandEnum shouldBe BorMedTypeEnum.J_EKTEF
+    }
+
+    test("createBeregning should handle null benyttetSivilstandEnum") {
+        val beregning = createBeregning(benyttetSivilstand = null)
+        beregning.benyttetSivilstandEnum shouldBe null
+    }
+
+    // ===========================================
+    // Tests for Kapittel 19 data
+    // ===========================================
+
+    test("createBeregning should set tt_anv from beregningKapittel19") {
+        val beregning = createBeregning(kap19TtAnv = 40)
+        beregning.tt_anv shouldBe 40
+    }
+
+    test("createBeregning should set resultatTypeEnum from beregningKapittel19") {
+        val beregning = createBeregning(kap19ResultatType = ResultattypeEnum.AP2011)
+        beregning.resultatTypeEnum shouldBe ResultattypeEnum.AP2011
+    }
+
+    test("createBeregning should copy basispensjon from beregningKapittel19") {
+        val basispensjon = Basispensjon().apply { totalbelop = 150000.0 }
+        val beregning = createBeregning(kap19Basispensjon = basispensjon)
+
+        beregning.basispensjon shouldNotBe null
+        beregning.basispensjon!!.totalbelop shouldBe 150000.0
+    }
+
+    test("createBeregning should copy restpensjon from beregningKapittel19") {
+        val restpensjon = Basispensjon().apply { totalbelop = 50000.0 }
+        val beregning = createBeregning(kap19Restpensjon = restpensjon)
+
+        beregning.restpensjon shouldNotBe null
+        beregning.restpensjon!!.totalbelop shouldBe 50000.0
+    }
+
+    test("createBeregning should handle null Kapittel 19 values") {
+        val beregning = createBeregning(
+            kap19TtAnv = null,
+            kap19ResultatType = null,
+            kap19Basispensjon = null,
+            kap19Restpensjon = null
+        )
+
+        beregning.tt_anv shouldBe 0 // default value
+        beregning.resultatTypeEnum shouldBe null
+        beregning.basispensjon shouldBe null
+        beregning.restpensjon shouldBe null
+    }
+
+    // ===========================================
+    // Tests for BeregningsInformasjon
+    // ===========================================
+
+    test("createBeregning should set epsMottarPensjon true from beregningsInformasjonKapittel19") {
+        val beregning = createBeregning(epsMottarPensjon = true)
+        beregning.epsMottarPensjon shouldBe true
+    }
+
+    test("createBeregning should set epsMottarPensjon false from beregningsInformasjonKapittel19") {
+        val beregning = createBeregning(epsMottarPensjon = false)
+        beregning.epsMottarPensjon shouldBe false
+    }
+
+    test("createBeregning should set gjenlevenderettAnvendt true from beregningsInformasjonKapittel19") {
+        val beregning = createBeregning(gjenlevenderettAnvendt = true)
+        beregning.gjenlevenderettAnvendt shouldBe true
+    }
+
+    test("createBeregning should set gjenlevenderettAnvendt false from beregningsInformasjonKapittel19") {
+        val beregning = createBeregning(gjenlevenderettAnvendt = false)
+        beregning.gjenlevenderettAnvendt shouldBe false
+    }
+
+    // ===========================================
+    // Tests for anvendtGjenlevenderettVedtak
+    // ===========================================
+
+    test("createBeregning should set anvendtGjenlevenderettVedtak from GJR vedtak in filtrertVilkarsvedtakList") {
+        val gjrVedtak = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.GJR }
+        val beregning = createBeregning(filtrertVilkarsvedtakList = listOf(gjrVedtak))
+
+        beregning.anvendtGjenlevenderettVedtak shouldBe gjrVedtak
+    }
+
+    test("createBeregning should not set anvendtGjenlevenderettVedtak when no GJR vedtak") {
+        val apVedtak = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+        val beregning = createBeregning(filtrertVilkarsvedtakList = listOf(apVedtak))
+
+        beregning.anvendtGjenlevenderettVedtak shouldBe null
+    }
+
+    test("createBeregning should find first GJR vedtak when multiple vedtak present") {
+        val gjrVedtak1 = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.GJR }
+        val gjrVedtak2 = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.GJR }
+        val apVedtak = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+        val beregning = createBeregning(filtrertVilkarsvedtakList = listOf(apVedtak, gjrVedtak1, gjrVedtak2))
+
+        beregning.anvendtGjenlevenderettVedtak shouldBe gjrVedtak1
+    }
+
+    // ===========================================
+    // Tests for base class populate() - sivilstand
+    // ===========================================
+
+    test("createBeregning should set sivilstandTypeEnum from soker PersonDetalj") {
+        val kravhode = createKravhodeWithSoker(sivilstand = SivilstandEnum.ENKE)
+        val beregning = createBeregning(forrigeKravhode = kravhode)
+
+        beregning.sivilstandTypeEnum shouldBe SivilstandEnum.ENKE
+    }
+
+    test("createBeregning should not set sivilstandTypeEnum when soker detalj is null") {
+        val beregning = createBeregning(forrigeKravhode = null)
+        beregning.sivilstandTypeEnum shouldBe null
+    }
+
+    // ===========================================
+    // Tests for base class populate() - vilkarsvedtakEktefelletillegg
+    // ===========================================
+
+    test("createBeregning should set vilkarsvedtakEktefelletillegg from ET vedtak") {
+        val etVedtak = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.ET }
+        val beregning = createBeregning(filtrertVilkarsvedtakList = listOf(etVedtak))
+
+        beregning.vilkarsvedtakEktefelletillegg shouldBe etVedtak
+    }
+
+    test("createBeregning should not set vilkarsvedtakEktefelletillegg when no ET vedtak") {
+        val apVedtak = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+        val beregning = createBeregning(filtrertVilkarsvedtakList = listOf(apVedtak))
+
+        beregning.vilkarsvedtakEktefelletillegg shouldBe null
+    }
+
+    // ===========================================
+    // Tests for base class populate() - avdodesPersongrunnlag
+    // ===========================================
+
+    test("createBeregning should set avdodesPersongrunnlag from kravhode") {
+        val avdodGrunnlag = createPersongrunnlag(GrunnlagsrolleEnum.AVDOD)
+        val kravhode = Kravhode().apply {
+            persongrunnlagListe = mutableListOf(avdodGrunnlag)
+        }
+        val beregning = createBeregning(forrigeKravhode = kravhode)
+
+        beregning.avdodesPersongrunnlag shouldNotBe null
+    }
+
+    test("createBeregning should not set avdodesPersongrunnlag when no avdod in kravhode") {
+        val sokerGrunnlag = createPersongrunnlag(GrunnlagsrolleEnum.SOKER)
+        val kravhode = Kravhode().apply {
+            persongrunnlagListe = mutableListOf(sokerGrunnlag)
+        }
+        val beregning = createBeregning(forrigeKravhode = kravhode)
+
+        beregning.avdodesPersongrunnlag shouldBe null
+    }
+
+    // ===========================================
+    // Tests for base class populate() - eps grunnlag
+    // ===========================================
+
+    test("createBeregning should set eps from kravhode when no gjenlevenderettighet") {
+        val epsGrunnlag = createPersongrunnlag(GrunnlagsrolleEnum.EKTEF)
+        val kravhode = Kravhode().apply {
+            persongrunnlagListe = mutableListOf(epsGrunnlag)
+            kravlinjeListe = mutableListOf() // no GJR kravlinje
+        }
+        val beregning = createBeregning(forrigeKravhode = kravhode)
+
+        beregning.eps shouldNotBe null
+    }
+
+    test("createBeregning should not set eps when no eps in kravhode") {
+        val sokerGrunnlag = createPersongrunnlag(GrunnlagsrolleEnum.SOKER)
+        val kravhode = Kravhode().apply {
+            persongrunnlagListe = mutableListOf(sokerGrunnlag)
+        }
+        val beregning = createBeregning(forrigeKravhode = kravhode)
+
+        beregning.eps shouldBe null
+    }
+
+    // ===========================================
+    // Tests for beregningsresultat type handling
+    // ===========================================
+
+    test("createBeregning should not populate from beregningsresultat when not BeregningsResultatAlderspensjon2011") {
+        val beregning = Alderspensjon2011SisteBeregningCreator(kravService = mockk()).createBeregning(
+            SisteBeregningSpec(
+                beregningsresultat = null, // not a BeregningsResultatAlderspensjon2011
+                regelverkKodePaNyttKrav = RegelverkTypeEnum.N_REG_G_OPPTJ,
+                forrigeKravhode = null,
+                filtrertVilkarsvedtakList = emptyList(),
+                isRegelverk1967 = false,
+                vilkarsvedtakListe = emptyList(),
+                kravhode = null,
+                beregning = null,
+                fomDato = null,
+                tomDato = null,
+                regelverk1967VirkToEarly = false
+            ),
+            null
+        ) as SisteAldersberegning2011
+
+        beregning.regelverkTypeEnum shouldBe RegelverkTypeEnum.N_REG_G_OPPTJ
+        beregning.virkDato shouldBe null
+        beregning.pensjonUnderUtbetaling shouldBe null
+    }
+
+    // ===========================================
+    // Integration test
+    // ===========================================
+
+    test("createBeregning should populate all fields from complete spec") {
+        val gjrVedtak = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.GJR }
+        val etVedtak = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.ET }
+        val vedtakList = listOf(gjrVedtak, etVedtak)
+
+        val epsGrunnlag = createPersongrunnlag(GrunnlagsrolleEnum.EKTEF)
+        val avdodGrunnlag = createPersongrunnlag(GrunnlagsrolleEnum.AVDOD)
+        val sokerGrunnlag = createPersongrunnlag(GrunnlagsrolleEnum.SOKER, sivilstand = SivilstandEnum.ENKE)
+
+        val kravhode = Kravhode().apply {
+            persongrunnlagListe = mutableListOf(sokerGrunnlag, epsGrunnlag, avdodGrunnlag)
+        }
+
+        val beregning = createBeregning(
+            regelverkType = RegelverkTypeEnum.N_REG_G_OPPTJ,
+            virkFom = dateAtNoon(2024, Calendar.JANUARY, 1),
+            benyttetSivilstand = BorMedTypeEnum.J_EKTEF,
+            kap19TtAnv = 35,
+            kap19ResultatType = ResultattypeEnum.AP2011,
+            kap19Basispensjon = Basispensjon().apply { totalbelop = 200000.0 },
+            kap19Restpensjon = Basispensjon().apply { totalbelop = 75000.0 },
+            epsMottarPensjon = true,
+            gjenlevenderettAnvendt = true,
+            filtrertVilkarsvedtakList = vedtakList,
+            forrigeKravhode = kravhode,
+            ytelseskomponentListe = mutableListOf(
+                Garantipensjon().apply { brukt = true; opphort = false; brutto = 5000 }
+            )
+        )
+
+        beregning.regelverkTypeEnum shouldBe RegelverkTypeEnum.N_REG_G_OPPTJ
+        beregning.virkDato shouldBe dateAtNoon(2024, Calendar.JANUARY, 1)
+        beregning.benyttetSivilstandEnum shouldBe BorMedTypeEnum.J_EKTEF
+        beregning.tt_anv shouldBe 35
+        beregning.resultatTypeEnum shouldBe ResultattypeEnum.AP2011
+        beregning.basispensjon!!.totalbelop shouldBe 200000.0
+        beregning.restpensjon!!.totalbelop shouldBe 75000.0
+        beregning.epsMottarPensjon shouldBe true
+        beregning.gjenlevenderettAnvendt shouldBe true
+        beregning.anvendtGjenlevenderettVedtak shouldBe gjrVedtak
+        beregning.vilkarsvedtakEktefelletillegg shouldBe etVedtak
+        beregning.sivilstandTypeEnum shouldBe SivilstandEnum.ENKE
+        beregning.avdodesPersongrunnlag shouldNotBe null
+        beregning.eps shouldNotBe null
+        beregning.pensjonUnderUtbetaling!!.ytelseskomponenter.size shouldBe 1
+    }
 })
 
-private fun beregningSpec(ytelseskomponentListe: MutableList<Ytelseskomponent>) =
-    SisteBeregningSpec(
-        beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-            pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply { ytelseskomponenter = ytelseskomponentListe }
-        },
-        regelverkKodePaNyttKrav = null,
-        forrigeKravhode = null,
-        filtrertVilkarsvedtakList = emptyList(),
+// ===========================================
+// Helper functions
+// ===========================================
+
+private fun createBeregning(
+    regelverkType: RegelverkTypeEnum? = null,
+    virkFom: Date? = null,
+    benyttetSivilstand: BorMedTypeEnum? = null,
+    kap19TtAnv: Int? = null,
+    kap19ResultatType: ResultattypeEnum? = null,
+    kap19Basispensjon: Basispensjon? = null,
+    kap19Restpensjon: Basispensjon? = null,
+    epsMottarPensjon: Boolean? = null,
+    gjenlevenderettAnvendt: Boolean? = null,
+    filtrertVilkarsvedtakList: List<VilkarsVedtak> = emptyList(),
+    forrigeKravhode: Kravhode? = null,
+    ytelseskomponentListe: MutableList<Ytelseskomponent> = mutableListOf()
+): SisteAldersberegning2011 {
+    val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
+        this.virkFom = virkFom
+        this.benyttetSivilstandEnum = benyttetSivilstand
+        this.pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
+            ytelseskomponenter = ytelseskomponentListe
+        }
+        this.beregningKapittel19 = AldersberegningKapittel19().apply {
+            kap19TtAnv?.let { this.tt_anv = it }
+            kap19ResultatType?.let { this.resultatTypeEnum = it }
+            this.basispensjon = kap19Basispensjon
+            this.restpensjon = kap19Restpensjon
+        }
+        this.beregningsInformasjonKapittel19 = BeregningsInformasjon().apply {
+            epsMottarPensjon?.let { this.epsMottarPensjon = it }
+            gjenlevenderettAnvendt?.let { this.gjenlevenderettAnvendt = it }
+        }
+    }
+
+    val spec = SisteBeregningSpec(
+        beregningsresultat = beregningsresultat,
+        regelverkKodePaNyttKrav = regelverkType,
+        forrigeKravhode = forrigeKravhode,
+        filtrertVilkarsvedtakList = filtrertVilkarsvedtakList,
         isRegelverk1967 = false,
         vilkarsvedtakListe = emptyList(),
         kravhode = null,
@@ -67,3 +416,33 @@ private fun beregningSpec(ytelseskomponentListe: MutableList<Ytelseskomponent>) 
         tomDato = null,
         regelverk1967VirkToEarly = false
     )
+
+    return Alderspensjon2011SisteBeregningCreator(kravService = mockk()).createBeregning(
+        spec,
+        beregningsresultat
+    ) as SisteAldersberegning2011
+}
+
+private fun createKravhodeWithSoker(sivilstand: SivilstandEnum? = null): Kravhode {
+    val sokerGrunnlag = createPersongrunnlag(GrunnlagsrolleEnum.SOKER, sivilstand)
+    return Kravhode().apply {
+        persongrunnlagListe = mutableListOf(sokerGrunnlag)
+    }
+}
+
+private fun createPersongrunnlag(
+    rolle: GrunnlagsrolleEnum,
+    sivilstand: SivilstandEnum? = null
+): Persongrunnlag =
+    Persongrunnlag().apply {
+        fodselsdato = dateAtNoon(1960, Calendar.JANUARY, 1)
+        penPerson = PenPerson().apply { penPersonId = 1L }
+        personDetaljListe = mutableListOf(
+            PersonDetalj().apply {
+                bruk = true
+                grunnlagsrolleEnum = rolle
+                virkFom = dateAtNoon(2020, Calendar.JANUARY, 1)
+                sivilstand?.let { sivilstandTypeEnum = it }
+            }
+        )
+    }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2016SisteBeregningCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2016SisteBeregningCreatorTest.kt
@@ -1,0 +1,473 @@
+package no.nav.pensjon.simulator.core.beregn
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
+import no.nav.pensjon.simulator.core.domain.regler.PenPerson
+import no.nav.pensjon.simulator.core.domain.regler.beregning.BeregningRelasjon
+import no.nav.pensjon.simulator.core.domain.regler.beregning.Ytelseskomponent
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
+import no.nav.pensjon.simulator.core.domain.regler.enum.*
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Beholdninger
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.domain.regler.trygdetid.Brok
+import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
+import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
+import java.util.*
+
+class Alderspensjon2016SisteBeregningCreatorTest : FunSpec({
+
+    // --- Tests for ytelseskomponenter filtering ---
+
+    test("createBeregning should filter out irrelevante ytelseskomponenter from 2011 result") {
+        val beregning = createBeregning(
+            ytelseskomponentListe2011 = mutableListOf(
+                Garantipensjon().apply { brukt = true; opphort = false; brutto = 1 },
+                Skjermingstillegg().apply { brukt = true; opphort = true; brutto = 2 }, // irrelevant
+                Inntektspensjon().apply { brukt = false; opphort = false; brutto = 3 }, // irrelevant
+                Garantitillegg().apply { brukt = true; opphort = false; brutto = 4 }
+            )
+        )
+
+        with(beregning.pensjonUnderUtbetaling2011!!) {
+            ytelseskomponenter.size shouldBe 2
+            ytelseskomponenter[0].brutto shouldBe 1
+            ytelseskomponenter[1].brutto shouldBe 4
+        }
+    }
+
+    test("createBeregning should filter out irrelevante ytelseskomponenter from 2025 result") {
+        val beregning = createBeregning(
+            ytelseskomponentListe2025 = mutableListOf(
+                Inntektspensjon().apply { brukt = true; opphort = false; brutto = 10 },
+                Garantipensjon().apply { brukt = true; opphort = true; brutto = 20 }, // irrelevant
+                Garantitillegg().apply { brukt = true; opphort = false; brutto = 30 }
+            )
+        )
+
+        with(beregning.pensjonUnderUtbetaling2025!!) {
+            ytelseskomponenter.size shouldBe 2
+            ytelseskomponenter[0].brutto shouldBe 10
+            ytelseskomponenter[1].brutto shouldBe 30
+        }
+    }
+
+    test("createBeregning should filter pensjonUnderUtbetaling2011UtenGJR") {
+        val beregning = createBeregning(
+            pensjonUnderUtbetalingUtenGJR = PensjonUnderUtbetaling().apply {
+                ytelseskomponenter = mutableListOf(
+                    Garantipensjon().apply { brukt = true; opphort = false; brutto = 100 },
+                    Inntektspensjon().apply { brukt = false; opphort = false; brutto = 200 } // irrelevant
+                )
+            }
+        )
+
+        with(beregning.pensjonUnderUtbetaling2011UtenGJR!!) {
+            ytelseskomponenter.size shouldBe 1
+            ytelseskomponenter[0].brutto shouldBe 100
+        }
+    }
+
+    test("createBeregning should filter top-level pensjonUnderUtbetaling") {
+        val beregning = createBeregning(
+            topLevelPensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
+                ytelseskomponenter = mutableListOf(
+                    Garantipensjon().apply { brukt = true; opphort = false; brutto = 500 },
+                    Inntektspensjon().apply { brukt = true; opphort = true; brutto = 600 } // irrelevant
+                )
+            }
+        )
+
+        with(beregning.pensjonUnderUtbetaling!!) {
+            ytelseskomponenter.size shouldBe 1
+            ytelseskomponenter[0].brutto shouldBe 500
+        }
+    }
+
+    // --- Tests for regelverkTypeEnum ---
+
+    test("createBeregning should set regelverkTypeEnum from spec") {
+        val beregning = createBeregning(regelverkType = RegelverkTypeEnum.N_REG_G_N_OPPTJ)
+        beregning.regelverkTypeEnum shouldBe RegelverkTypeEnum.N_REG_G_N_OPPTJ
+    }
+
+    // --- Tests for virkDato ---
+
+    test("createBeregning should set virkDato from beregningsresultat") {
+        val virkFom = dateAtNoon(2025, Calendar.MARCH, 1)
+        val beregning = createBeregning(virkFom = virkFom)
+        beregning.virkDato shouldBe virkFom
+    }
+
+    // --- Tests for kapittel 19 data ---
+
+    test("createBeregning should copy tt_anv from beregningKapittel19") {
+        val beregning = createBeregning(tt_anv_kapittel19 = 40)
+        beregning.tt_anv shouldBe 40
+    }
+
+    test("createBeregning should copy restpensjon from beregningKapittel19") {
+        val beregning = createBeregning(
+            restpensjon = Basispensjon().apply { totalbelop = 5000.0 }
+        )
+        beregning.restpensjon shouldNotBe null
+        beregning.restpensjon?.totalbelop shouldBe 5000.0
+    }
+
+    test("createBeregning should copy basispensjon from beregningKapittel19") {
+        val beregning = createBeregning(
+            basispensjon = Basispensjon().apply { totalbelop = 7500.0 }
+        )
+        beregning.basispensjon shouldNotBe null
+        beregning.basispensjon?.totalbelop shouldBe 7500.0
+    }
+
+    test("createBeregning should copy restpensjonUtenGJR from beregningKapittel19") {
+        val beregning = createBeregning(
+            restpensjonUtenGJR = Basispensjon().apply { totalbelop = 6000.0 }
+        )
+        beregning.restpensjonUtenGJR shouldNotBe null
+        beregning.restpensjonUtenGJR?.totalbelop shouldBe 6000.0
+    }
+
+    test("createBeregning should copy basispensjonUtenGJR from beregningKapittel19") {
+        val beregning = createBeregning(
+            basispensjonUtenGJR = Basispensjon().apply { totalbelop = 8000.0 }
+        )
+        beregning.basispensjonUtenGJR shouldNotBe null
+        beregning.basispensjonUtenGJR?.totalbelop shouldBe 8000.0
+    }
+
+    // --- Tests for kapittel 20 data ---
+
+    test("createBeregning should set beregningsMetodeEnum from beregningKapittel20") {
+        val beregning = createBeregning(beregningsMetode = BeregningsmetodeEnum.FOLKETRYGD)
+        beregning.beregningsMetodeEnum shouldBe BeregningsmetodeEnum.FOLKETRYGD
+    }
+
+    test("createBeregning should set prorataBrok_kap_20 from beregningKapittel20") {
+        val brok = Brok().apply { teller = 30; nevner = 40 }
+        val beregning = createBeregning(prorataBrok = brok)
+        beregning.prorataBrok_kap_20?.teller shouldBe 30
+        beregning.prorataBrok_kap_20?.nevner shouldBe 40
+    }
+
+    test("createBeregning should set tt_anv_kap_20 from beregningKapittel20") {
+        val beregning = createBeregning(tt_anv_kapittel20 = 35)
+        beregning.tt_anv_kap_20 shouldBe 35
+    }
+
+    test("createBeregning should set beholdninger from beregningKapittel20") {
+        val beholdninger = Beholdninger()
+        val beregning = createBeregning(beholdninger = beholdninger)
+        beregning.beholdninger shouldBe beholdninger
+    }
+
+    test("createBeregning should prefer resultatTypeEnum from kapittel19 over kapittel20") {
+        val beregning = createBeregning(
+            resultatTypeKapittel19 = ResultattypeEnum.AP,
+            resultatTypeKapittel20 = ResultattypeEnum.AFP
+        )
+        beregning.resultatTypeEnum shouldBe ResultattypeEnum.AP
+    }
+
+    test("createBeregning should fallback to resultatTypeEnum from kapittel20 when kapittel19 is null") {
+        val beregning = createBeregning(
+            resultatTypeKapittel19 = null,
+            resultatTypeKapittel20 = ResultattypeEnum.AFP,
+            includeKapittel19 = false
+        )
+        beregning.resultatTypeEnum shouldBe ResultattypeEnum.AFP
+    }
+
+    // --- Tests for benyttetSivilstand ---
+
+    test("createBeregning should set benyttetSivilstandEnum from resultat2011") {
+        val beregning = createBeregning(benyttetSivilstand2011 = BorMedTypeEnum.J_EKTEF)
+        beregning.benyttetSivilstandEnum shouldBe BorMedTypeEnum.J_EKTEF
+    }
+
+    test("createBeregning should fallback to benyttetSivilstandEnum from resultat2025") {
+        val beregning = createBeregning(
+            benyttetSivilstand2011 = null,
+            benyttetSivilstand2025 = BorMedTypeEnum.SAMBOER1_5,
+            includeKapittel19 = false
+        )
+        beregning.benyttetSivilstandEnum shouldBe BorMedTypeEnum.SAMBOER1_5
+    }
+
+    // --- Tests for beregningsInformasjon ---
+
+    test("createBeregning should set epsMottarPensjon from beregningsInformasjonKapittel19") {
+        val beregning = createBeregning(epsMottarPensjon19 = true)
+        beregning.epsMottarPensjon shouldBe true
+    }
+
+    test("createBeregning should fallback to epsMottarPensjon from beregningsInformasjonKapittel20") {
+        val beregning = createBeregning(
+            epsMottarPensjon19 = null,
+            epsMottarPensjon20 = true,
+            includeKapittel19 = false
+        )
+        beregning.epsMottarPensjon shouldBe true
+    }
+
+    test("createBeregning should set gjenlevenderettAnvendt from beregningsInformasjonKapittel19") {
+        val beregning = createBeregning(gjenlevenderettAnvendt19 = true)
+        beregning.gjenlevenderettAnvendt shouldBe true
+    }
+
+    test("createBeregning should fallback to gjenlevenderettAnvendt from beregningsInformasjonKapittel20") {
+        val beregning = createBeregning(
+            gjenlevenderettAnvendt19 = null,
+            gjenlevenderettAnvendt20 = true,
+            includeKapittel19 = false
+        )
+        beregning.gjenlevenderettAnvendt shouldBe true
+    }
+
+    // --- Tests for anvendtGjenlevenderettVedtak ---
+
+    test("createBeregning should set anvendtGjenlevenderettVedtak from filtrertVilkarsvedtakList") {
+        val gjrVedtak = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.GJR }
+        val beregning = createBeregning(
+            filtrertVilkarsvedtakList = listOf(
+                VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP },
+                gjrVedtak,
+                VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.ET }
+            )
+        )
+        beregning.anvendtGjenlevenderettVedtak shouldBe gjrVedtak
+    }
+
+    test("createBeregning should not set anvendtGjenlevenderettVedtak when no GJR vedtak present") {
+        val beregning = createBeregning(
+            filtrertVilkarsvedtakList = listOf(
+                VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+            )
+        )
+        beregning.anvendtGjenlevenderettVedtak shouldBe null
+    }
+
+    // --- Tests for alternativ konvensjon data (tapende delberegning) ---
+
+    test("createBeregning should set alternativ konvensjon data from tapende delberegning") {
+        val tapendeYtelseskomponenter = mutableListOf<Ytelseskomponent>(
+            Garantipensjon().apply { brukt = true; opphort = false; brutto = 999 }
+        )
+        val tapendeBeholdninger = Beholdninger()
+        val tapendeBrok = Brok().apply { teller = 10; nevner = 20 }
+
+        val beregning = createBeregning(
+            beregningsMetode = BeregningsmetodeEnum.FOLKETRYGD,
+            tapendeDelberegning = AldersberegningKapittel20().apply {
+                beregningsMetodeEnum = BeregningsmetodeEnum.EOS // different from winning
+                pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
+                    ytelseskomponenter = tapendeYtelseskomponenter
+                }
+                beholdninger = tapendeBeholdninger
+                prorataBrok = tapendeBrok
+                tt_anv = 25
+            }
+        )
+
+        beregning.pensjonUnderUtbetaling2025AltKonv shouldNotBe null
+        beregning.pensjonUnderUtbetaling2025AltKonv?.ytelseskomponenter?.size shouldBe 1
+        beregning.pensjonUnderUtbetaling2025AltKonv?.ytelseskomponenter?.get(0)?.brutto shouldBe 999
+        beregning.beholdningerAltKonv shouldBe tapendeBeholdninger
+        beregning.prorataBrok_kap_20AltKonv?.teller shouldBe 10
+        beregning.prorataBrok_kap_20AltKonv?.nevner shouldBe 20
+        beregning.tt_anv_kap_20AltKonv shouldBe 25
+    }
+
+    // --- Tests from base class populate() ---
+
+    test("createBeregning should set sivilstandTypeEnum from forrigeKravhode søker detalj") {
+        val beregning = createBeregning(
+            forrigeKravhode = kravhodeWithSoker(SivilstandEnum.GIFT)
+        )
+        beregning.sivilstandTypeEnum shouldBe SivilstandEnum.GIFT
+    }
+
+    test("createBeregning should set vilkarsvedtakEktefelletillegg from filtrertVilkarsvedtakList") {
+        val etVedtak = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.ET }
+        val beregning = createBeregning(
+            filtrertVilkarsvedtakList = listOf(
+                VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP },
+                etVedtak
+            ),
+            includeKapittel19 = false // to avoid GJR vedtak logic
+        )
+        beregning.vilkarsvedtakEktefelletillegg shouldBe etVedtak
+    }
+
+    test("createBeregning should set avdodesPersongrunnlag from forrigeKravhode") {
+        val avdodGrunnlag = Persongrunnlag().apply {
+            penPerson = PenPerson().apply { penPersonId = 99L }
+            personDetaljListe = mutableListOf(
+                PersonDetalj().apply {
+                    bruk = true
+                    grunnlagsrolleEnum = GrunnlagsrolleEnum.AVDOD
+                }
+            )
+        }
+        val beregning = createBeregning(
+            forrigeKravhode = Kravhode().apply {
+                persongrunnlagListe = mutableListOf(avdodGrunnlag)
+            }
+        )
+        beregning.avdodesPersongrunnlag shouldBe avdodGrunnlag
+    }
+
+    test("createBeregning should set eps from forrigeKravhode") {
+        val epsGrunnlag = Persongrunnlag().apply {
+            penPerson = PenPerson().apply { penPersonId = 88L }
+            personDetaljListe = mutableListOf(
+                PersonDetalj().apply {
+                    bruk = true
+                    grunnlagsrolleEnum = GrunnlagsrolleEnum.EKTEF
+                }
+            )
+        }
+        val beregning = createBeregning(
+            forrigeKravhode = Kravhode().apply {
+                persongrunnlagListe = mutableListOf(epsGrunnlag)
+            }
+        )
+        beregning.eps shouldNotBe null
+    }
+})
+
+private fun createBeregning(
+    ytelseskomponentListe2011: MutableList<Ytelseskomponent> = mutableListOf(),
+    ytelseskomponentListe2025: MutableList<Ytelseskomponent> = mutableListOf(),
+    regelverkType: RegelverkTypeEnum = RegelverkTypeEnum.N_REG_G_N_OPPTJ,
+    virkFom: Date? = null,
+    tt_anv_kapittel19: Int? = null,
+    tt_anv_kapittel20: Int? = null,
+    restpensjon: Basispensjon? = null,
+    basispensjon: Basispensjon? = null,
+    restpensjonUtenGJR: Basispensjon? = null,
+    basispensjonUtenGJR: Basispensjon? = null,
+    beregningsMetode: BeregningsmetodeEnum? = null,
+    prorataBrok: Brok? = null,
+    beholdninger: Beholdninger? = null,
+    resultatTypeKapittel19: ResultattypeEnum? = null,
+    resultatTypeKapittel20: ResultattypeEnum? = null,
+    benyttetSivilstand2011: BorMedTypeEnum? = null,
+    benyttetSivilstand2025: BorMedTypeEnum? = null,
+    epsMottarPensjon19: Boolean? = null,
+    epsMottarPensjon20: Boolean? = null,
+    gjenlevenderettAnvendt19: Boolean? = null,
+    gjenlevenderettAnvendt20: Boolean? = null,
+    pensjonUnderUtbetalingUtenGJR: PensjonUnderUtbetaling? = null,
+    topLevelPensjonUnderUtbetaling: PensjonUnderUtbetaling? = null,
+    filtrertVilkarsvedtakList: List<VilkarsVedtak> = emptyList(),
+    tapendeDelberegning: AldersberegningKapittel20? = null,
+    forrigeKravhode: Kravhode? = null,
+    includeKapittel19: Boolean = true
+): SisteAldersberegning2016 {
+    val beregningsResultat2011 = if (includeKapittel19 || ytelseskomponentListe2011.isNotEmpty() ||
+        pensjonUnderUtbetalingUtenGJR != null || tt_anv_kapittel19 != null ||
+        restpensjon != null || basispensjon != null || restpensjonUtenGJR != null ||
+        basispensjonUtenGJR != null || resultatTypeKapittel19 != null ||
+        benyttetSivilstand2011 != null || epsMottarPensjon19 != null || gjenlevenderettAnvendt19 != null
+    ) {
+        BeregningsResultatAlderspensjon2011().apply {
+            if (ytelseskomponentListe2011.isNotEmpty()) {
+                pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
+                    ytelseskomponenter = ytelseskomponentListe2011
+                }
+            }
+            this.pensjonUnderUtbetalingUtenGJR = pensjonUnderUtbetalingUtenGJR
+            benyttetSivilstandEnum = benyttetSivilstand2011
+
+            beregningKapittel19 = AldersberegningKapittel19().apply {
+                tt_anv = tt_anv_kapittel19 ?: 0
+                this.restpensjon = restpensjon
+                this.basispensjon = basispensjon
+                this.restpensjonUtenGJR = restpensjonUtenGJR
+                this.basispensjonUtenGJR = basispensjonUtenGJR
+                resultatTypeEnum = resultatTypeKapittel19
+            }
+
+            beregningsInformasjonKapittel19 = BeregningsInformasjon().apply {
+                epsMottarPensjon = epsMottarPensjon19 ?: false
+                gjenlevenderettAnvendt = gjenlevenderettAnvendt19 ?: false
+            }
+        }
+    } else null
+
+    val beregningsResultat2025 = BeregningsResultatAlderspensjon2025().apply {
+        if (ytelseskomponentListe2025.isNotEmpty()) {
+            pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
+                ytelseskomponenter = ytelseskomponentListe2025
+            }
+        }
+        benyttetSivilstandEnum = benyttetSivilstand2025
+
+        beregningKapittel20 = AldersberegningKapittel20().apply {
+            beregningsMetodeEnum = beregningsMetode
+            this.prorataBrok = prorataBrok
+            tt_anv = tt_anv_kapittel20 ?: 0
+            this.beholdninger = beholdninger
+            resultatTypeEnum = resultatTypeKapittel20
+
+            if (tapendeDelberegning != null) {
+                delberegning2011Liste = mutableListOf(
+                    BeregningRelasjon().apply {
+                        beregning2011 = tapendeDelberegning
+                    }
+                )
+            }
+        }
+
+        beregningsInformasjonKapittel20 = BeregningsInformasjon().apply {
+            epsMottarPensjon = epsMottarPensjon20 ?: false
+            gjenlevenderettAnvendt = gjenlevenderettAnvendt20 ?: false
+        }
+    }
+
+    val spec = SisteBeregningSpec(
+        beregningsresultat = BeregningsResultatAlderspensjon2016().apply {
+            this.virkFom = virkFom
+            this.beregningsResultat2011 = beregningsResultat2011
+            this.beregningsResultat2025 = beregningsResultat2025
+            this.pensjonUnderUtbetaling = topLevelPensjonUnderUtbetaling
+        },
+        regelverkKodePaNyttKrav = regelverkType,
+        forrigeKravhode = forrigeKravhode,
+        filtrertVilkarsvedtakList = filtrertVilkarsvedtakList,
+        isRegelverk1967 = false,
+        vilkarsvedtakListe = emptyList(),
+        kravhode = null,
+        beregning = null,
+        fomDato = null,
+        tomDato = null,
+        regelverk1967VirkToEarly = false
+    )
+
+    return Alderspensjon2016SisteBeregningCreator(kravService = mockk()).createBeregning(
+        spec,
+        BeregningsResultatAlderspensjon2016()
+    ) as SisteAldersberegning2016
+}
+
+private fun kravhodeWithSoker(sivilstand: SivilstandEnum): Kravhode =
+    Kravhode().apply {
+        persongrunnlagListe = mutableListOf(
+            Persongrunnlag().apply {
+                penPerson = PenPerson().apply { penPersonId = 1L }
+                personDetaljListe = mutableListOf(
+                    PersonDetalj().apply {
+                        bruk = true
+                        grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
+                        sivilstandTypeEnum = sivilstand
+                    }
+                )
+            }
+        )
+    }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2025SisteBeregningCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2025SisteBeregningCreatorTest.kt
@@ -1,0 +1,433 @@
+package no.nav.pensjon.simulator.core.beregn
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
+import no.nav.pensjon.simulator.core.domain.regler.PenPerson
+import no.nav.pensjon.simulator.core.domain.regler.beregning.BeregningRelasjon
+import no.nav.pensjon.simulator.core.domain.regler.beregning.Ytelseskomponent
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
+import no.nav.pensjon.simulator.core.domain.regler.enum.*
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Beholdninger
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.domain.regler.trygdetid.Brok
+import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
+import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
+import java.util.*
+
+class Alderspensjon2025SisteBeregningCreatorTest : FunSpec({
+
+    // --- Tests for ytelseskomponenter filtering ---
+
+    test("createBeregning should filter out irrelevante ytelseskomponenter") {
+        val beregning = createBeregning(
+            ytelseskomponentListe = mutableListOf(
+                Inntektspensjon().apply { brukt = true; opphort = false; brutto = 100 },
+                Garantipensjon().apply { brukt = true; opphort = true; brutto = 200 }, // irrelevant - opphort
+                Garantitillegg().apply { brukt = false; opphort = false; brutto = 300 }, // irrelevant - not brukt
+                Skjermingstillegg().apply { brukt = true; opphort = false; brutto = 400 }
+            )
+        )
+
+        with(beregning.pensjonUnderUtbetaling!!) {
+            ytelseskomponenter.size shouldBe 2
+            ytelseskomponenter[0].brutto shouldBe 100
+            ytelseskomponenter[1].brutto shouldBe 400
+        }
+    }
+
+    test("createBeregning should handle empty ytelseskomponenter list") {
+        val beregning = createBeregning(
+            ytelseskomponentListe = mutableListOf(
+                Garantipensjon().apply { brukt = true; opphort = true; brutto = 100 } // all irrelevant
+            )
+        )
+
+        beregning.pensjonUnderUtbetaling?.ytelseskomponenter?.size shouldBe 0
+    }
+
+    // --- Tests for regelverkTypeEnum ---
+
+    test("createBeregning should set regelverkTypeEnum from spec") {
+        val beregning = createBeregning(regelverkType = RegelverkTypeEnum.N_REG_N_OPPTJ)
+        beregning.regelverkTypeEnum shouldBe RegelverkTypeEnum.N_REG_N_OPPTJ
+    }
+
+    test("createBeregning should handle null regelverkTypeEnum") {
+        val beregning = createBeregning(regelverkType = null)
+        beregning.regelverkTypeEnum shouldBe null
+    }
+
+    // --- Tests for virkDato ---
+
+    test("createBeregning should set virkDato from beregningsresultat") {
+        val virkFom = dateAtNoon(2025, Calendar.MARCH, 1)
+        val beregning = createBeregning(virkFom = virkFom)
+        beregning.virkDato shouldBe virkFom
+    }
+
+    test("createBeregning should handle null virkFom") {
+        val beregning = createBeregning(virkFom = null)
+        beregning.virkDato shouldBe null
+    }
+
+    // --- Tests for benyttetSivilstand ---
+
+    test("createBeregning should set benyttetSivilstandEnum from beregningsresultat") {
+        val beregning = createBeregning(benyttetSivilstand = BorMedTypeEnum.J_EKTEF)
+        beregning.benyttetSivilstandEnum shouldBe BorMedTypeEnum.J_EKTEF
+    }
+
+    test("createBeregning should handle different benyttetSivilstand values") {
+        val beregning = createBeregning(benyttetSivilstand = BorMedTypeEnum.SAMBOER1_5)
+        beregning.benyttetSivilstandEnum shouldBe BorMedTypeEnum.SAMBOER1_5
+    }
+
+    // --- Tests for kapittel 20 data ---
+
+    test("createBeregning should set beregningsMetodeEnum from beregningKapittel20") {
+        val beregning = createBeregning(beregningsMetode = BeregningsmetodeEnum.FOLKETRYGD)
+        beregning.beregningsMetodeEnum shouldBe BeregningsmetodeEnum.FOLKETRYGD
+    }
+
+    test("createBeregning should set EOS beregningsMetodeEnum") {
+        val beregning = createBeregning(beregningsMetode = BeregningsmetodeEnum.EOS)
+        beregning.beregningsMetodeEnum shouldBe BeregningsmetodeEnum.EOS
+    }
+
+    test("createBeregning should set prorataBrok_kap_20 from beregningKapittel20") {
+        val brok = Brok().apply { teller = 30; nevner = 40 }
+        val beregning = createBeregning(prorataBrok = brok)
+        beregning.prorataBrok_kap_20?.teller shouldBe 30
+        beregning.prorataBrok_kap_20?.nevner shouldBe 40
+    }
+
+    test("createBeregning should set tt_anv_kap_20 from beregningKapittel20") {
+        val beregning = createBeregning(tt_anv_kapittel20 = 35)
+        beregning.tt_anv_kap_20 shouldBe 35
+    }
+
+    test("createBeregning should set resultatTypeEnum from beregningKapittel20") {
+        val beregning = createBeregning(resultatType = ResultattypeEnum.AP2025)
+        beregning.resultatTypeEnum shouldBe ResultattypeEnum.AP2025
+    }
+
+    test("createBeregning should set beholdninger from beregningKapittel20") {
+        val beholdninger = Beholdninger()
+        val beregning = createBeregning(beholdninger = beholdninger)
+        beregning.beholdninger shouldBe beholdninger
+    }
+
+    // --- Tests for beregningsInformasjon ---
+
+    test("createBeregning should set epsMottarPensjon from beregningsInformasjonKapittel20") {
+        val beregning = createBeregning(epsMottarPensjon = true)
+        beregning.epsMottarPensjon shouldBe true
+    }
+
+    test("createBeregning should set epsMottarPensjon false") {
+        val beregning = createBeregning(epsMottarPensjon = false)
+        beregning.epsMottarPensjon shouldBe false
+    }
+
+    test("createBeregning should set gjenlevenderettAnvendt from beregningsInformasjonKapittel20") {
+        val beregning = createBeregning(gjenlevenderettAnvendt = true)
+        beregning.gjenlevenderettAnvendt shouldBe true
+    }
+
+    test("createBeregning should set gjenlevenderettAnvendt false") {
+        val beregning = createBeregning(gjenlevenderettAnvendt = false)
+        beregning.gjenlevenderettAnvendt shouldBe false
+    }
+
+    // --- Tests for alternativ konvensjon data (tapende delberegning) ---
+
+    test("createBeregning should set alternativ konvensjon data from tapende delberegning") {
+        val tapendeYtelseskomponenter = mutableListOf<Ytelseskomponent>(
+            Garantipensjon().apply { brukt = true; opphort = false; brutto = 999 }
+        )
+        val tapendeBeholdninger = Beholdninger()
+        val tapendeBrok = Brok().apply { teller = 10; nevner = 20 }
+
+        val beregning = createBeregning(
+            beregningsMetode = BeregningsmetodeEnum.FOLKETRYGD,
+            tapendeDelberegning = AldersberegningKapittel20().apply {
+                beregningsMetodeEnum = BeregningsmetodeEnum.EOS // different from winning
+                pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
+                    ytelseskomponenter = tapendeYtelseskomponenter
+                }
+                beholdninger = tapendeBeholdninger
+                prorataBrok = tapendeBrok
+                tt_anv = 25
+            }
+        )
+
+        beregning.pensjonUnderUtbetaling2025AltKonv shouldNotBe null
+        beregning.pensjonUnderUtbetaling2025AltKonv?.ytelseskomponenter?.size shouldBe 1
+        beregning.pensjonUnderUtbetaling2025AltKonv?.ytelseskomponenter?.get(0)?.brutto shouldBe 999
+        beregning.beholdningerAltKonv shouldBe tapendeBeholdninger
+        beregning.prorataBrok_kap_20AltKonv?.teller shouldBe 10
+        beregning.prorataBrok_kap_20AltKonv?.nevner shouldBe 20
+        beregning.tt_anv_kap_20AltKonv shouldBe 25
+    }
+
+    test("createBeregning should not set alternativ konvensjon data when no tapende delberegning") {
+        val beregning = createBeregning(
+            beregningsMetode = BeregningsmetodeEnum.FOLKETRYGD,
+            tapendeDelberegning = null
+        )
+
+        beregning.pensjonUnderUtbetaling2025AltKonv shouldBe null
+        beregning.beholdningerAltKonv shouldBe null
+    }
+
+    test("createBeregning should filter alternativ konvensjon ytelseskomponenter") {
+        val beregning = createBeregning(
+            beregningsMetode = BeregningsmetodeEnum.FOLKETRYGD,
+            tapendeDelberegning = AldersberegningKapittel20().apply {
+                beregningsMetodeEnum = BeregningsmetodeEnum.EOS
+                pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
+                    ytelseskomponenter = mutableListOf(
+                        Garantipensjon().apply { brukt = true; opphort = false; brutto = 100 },
+                        Inntektspensjon().apply { brukt = false; opphort = false; brutto = 200 } // irrelevant
+                    )
+                }
+            }
+        )
+
+        beregning.pensjonUnderUtbetaling2025AltKonv?.ytelseskomponenter?.size shouldBe 1
+        beregning.pensjonUnderUtbetaling2025AltKonv?.ytelseskomponenter?.get(0)?.brutto shouldBe 100
+    }
+
+    // --- Tests from base class populate() ---
+
+    test("createBeregning should set sivilstandTypeEnum from forrigeKravhode søker detalj") {
+        val beregning = createBeregning(
+            forrigeKravhode = kravhodeWithSoker(SivilstandEnum.GIFT)
+        )
+        beregning.sivilstandTypeEnum shouldBe SivilstandEnum.GIFT
+    }
+
+    test("createBeregning should set sivilstandTypeEnum UGIF") {
+        val beregning = createBeregning(
+            forrigeKravhode = kravhodeWithSoker(SivilstandEnum.UGIF)
+        )
+        beregning.sivilstandTypeEnum shouldBe SivilstandEnum.UGIF
+    }
+
+    test("createBeregning should set vilkarsvedtakEktefelletillegg from filtrertVilkarsvedtakList") {
+        val etVedtak = VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.ET }
+        val beregning = createBeregning(
+            filtrertVilkarsvedtakList = listOf(
+                VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP },
+                etVedtak
+            )
+        )
+        beregning.vilkarsvedtakEktefelletillegg shouldBe etVedtak
+    }
+
+    test("createBeregning should not set vilkarsvedtakEktefelletillegg when no ET vedtak") {
+        val beregning = createBeregning(
+            filtrertVilkarsvedtakList = listOf(
+                VilkarsVedtak().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+            )
+        )
+        beregning.vilkarsvedtakEktefelletillegg shouldBe null
+    }
+
+    test("createBeregning should set avdodesPersongrunnlag from forrigeKravhode") {
+        val avdodGrunnlag = Persongrunnlag().apply {
+            penPerson = PenPerson().apply { penPersonId = 99L }
+            personDetaljListe = mutableListOf(
+                PersonDetalj().apply {
+                    bruk = true
+                    grunnlagsrolleEnum = GrunnlagsrolleEnum.AVDOD
+                }
+            )
+        }
+        val beregning = createBeregning(
+            forrigeKravhode = Kravhode().apply {
+                persongrunnlagListe = mutableListOf(avdodGrunnlag)
+            }
+        )
+        beregning.avdodesPersongrunnlag shouldBe avdodGrunnlag
+    }
+
+    test("createBeregning should not set avdodesPersongrunnlag when no AVDOD role") {
+        val beregning = createBeregning(
+            forrigeKravhode = Kravhode().apply {
+                persongrunnlagListe = mutableListOf(
+                    Persongrunnlag().apply {
+                        penPerson = PenPerson().apply { penPersonId = 1L }
+                        personDetaljListe = mutableListOf(
+                            PersonDetalj().apply {
+                                bruk = true
+                                grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
+                            }
+                        )
+                    }
+                )
+            }
+        )
+        beregning.avdodesPersongrunnlag shouldBe null
+    }
+
+    test("createBeregning should set eps from forrigeKravhode with EKTEF role") {
+        val epsGrunnlag = Persongrunnlag().apply {
+            penPerson = PenPerson().apply { penPersonId = 88L }
+            personDetaljListe = mutableListOf(
+                PersonDetalj().apply {
+                    bruk = true
+                    grunnlagsrolleEnum = GrunnlagsrolleEnum.EKTEF
+                }
+            )
+        }
+        val beregning = createBeregning(
+            forrigeKravhode = Kravhode().apply {
+                persongrunnlagListe = mutableListOf(epsGrunnlag)
+            }
+        )
+        beregning.eps shouldNotBe null
+    }
+
+    test("createBeregning should set eps from forrigeKravhode with SAMBO role") {
+        val epsGrunnlag = Persongrunnlag().apply {
+            penPerson = PenPerson().apply { penPersonId = 88L }
+            personDetaljListe = mutableListOf(
+                PersonDetalj().apply {
+                    bruk = true
+                    grunnlagsrolleEnum = GrunnlagsrolleEnum.SAMBO
+                }
+            )
+        }
+        val beregning = createBeregning(
+            forrigeKravhode = Kravhode().apply {
+                persongrunnlagListe = mutableListOf(epsGrunnlag)
+            }
+        )
+        beregning.eps shouldNotBe null
+    }
+
+    // --- Integration-style tests ---
+
+    test("createBeregning should correctly populate all fields from full spec") {
+        val virkFom = dateAtNoon(2025, Calendar.JUNE, 1)
+        val beholdninger = Beholdninger()
+        val brok = Brok().apply { teller = 35; nevner = 40 }
+
+        val beregning = createBeregning(
+            regelverkType = RegelverkTypeEnum.N_REG_N_OPPTJ,
+            virkFom = virkFom,
+            benyttetSivilstand = BorMedTypeEnum.J_EKTEF,
+            beregningsMetode = BeregningsmetodeEnum.FOLKETRYGD,
+            prorataBrok = brok,
+            tt_anv_kapittel20 = 40,
+            resultatType = ResultattypeEnum.AP2025,
+            beholdninger = beholdninger,
+            epsMottarPensjon = true,
+            gjenlevenderettAnvendt = false,
+            ytelseskomponentListe = mutableListOf(
+                Inntektspensjon().apply { brukt = true; opphort = false; brutto = 5000 }
+            ),
+            forrigeKravhode = kravhodeWithSoker(SivilstandEnum.GIFT)
+        )
+
+        beregning.regelverkTypeEnum shouldBe RegelverkTypeEnum.N_REG_N_OPPTJ
+        beregning.virkDato shouldBe virkFom
+        beregning.benyttetSivilstandEnum shouldBe BorMedTypeEnum.J_EKTEF
+        beregning.beregningsMetodeEnum shouldBe BeregningsmetodeEnum.FOLKETRYGD
+        beregning.prorataBrok_kap_20?.teller shouldBe 35
+        beregning.tt_anv_kap_20 shouldBe 40
+        beregning.resultatTypeEnum shouldBe ResultattypeEnum.AP2025
+        beregning.beholdninger shouldBe beholdninger
+        beregning.epsMottarPensjon shouldBe true
+        beregning.gjenlevenderettAnvendt shouldBe false
+        beregning.pensjonUnderUtbetaling?.ytelseskomponenter?.size shouldBe 1
+        beregning.sivilstandTypeEnum shouldBe SivilstandEnum.GIFT
+    }
+})
+
+private fun createBeregning(
+    ytelseskomponentListe: MutableList<Ytelseskomponent> = mutableListOf(),
+    regelverkType: RegelverkTypeEnum? = RegelverkTypeEnum.N_REG_N_OPPTJ,
+    virkFom: Date? = null,
+    benyttetSivilstand: BorMedTypeEnum? = null,
+    beregningsMetode: BeregningsmetodeEnum? = null,
+    prorataBrok: Brok? = null,
+    tt_anv_kapittel20: Int? = null,
+    resultatType: ResultattypeEnum? = null,
+    beholdninger: Beholdninger? = null,
+    epsMottarPensjon: Boolean? = null,
+    gjenlevenderettAnvendt: Boolean? = null,
+    tapendeDelberegning: AldersberegningKapittel20? = null,
+    filtrertVilkarsvedtakList: List<VilkarsVedtak> = emptyList(),
+    forrigeKravhode: Kravhode? = null
+): SisteAldersberegning2011 {
+    val spec = SisteBeregningSpec(
+        beregningsresultat = BeregningsResultatAlderspensjon2025().apply {
+            this.virkFom = virkFom
+            this.benyttetSivilstandEnum = benyttetSivilstand
+
+            if (ytelseskomponentListe.isNotEmpty()) {
+                pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
+                    ytelseskomponenter = ytelseskomponentListe
+                }
+            }
+
+            beregningKapittel20 = AldersberegningKapittel20().apply {
+                beregningsMetodeEnum = beregningsMetode
+                this.prorataBrok = prorataBrok
+                tt_anv = tt_anv_kapittel20 ?: 0
+                this.beholdninger = beholdninger
+                resultatTypeEnum = resultatType
+
+                if (tapendeDelberegning != null) {
+                    delberegning2011Liste = mutableListOf(
+                        BeregningRelasjon().apply {
+                            beregning2011 = tapendeDelberegning
+                        }
+                    )
+                }
+            }
+
+            beregningsInformasjonKapittel20 = BeregningsInformasjon().apply {
+                this.epsMottarPensjon = epsMottarPensjon ?: false
+                this.gjenlevenderettAnvendt = gjenlevenderettAnvendt ?: false
+            }
+        },
+        regelverkKodePaNyttKrav = regelverkType,
+        forrigeKravhode = forrigeKravhode,
+        filtrertVilkarsvedtakList = filtrertVilkarsvedtakList,
+        isRegelverk1967 = false,
+        vilkarsvedtakListe = emptyList(),
+        kravhode = null,
+        beregning = null,
+        fomDato = null,
+        tomDato = null,
+        regelverk1967VirkToEarly = false
+    )
+
+    return Alderspensjon2025SisteBeregningCreator(kravService = mockk()).createBeregning(
+        spec,
+        BeregningsResultatAlderspensjon2025()
+    ) as SisteAldersberegning2011
+}
+
+private fun kravhodeWithSoker(sivilstand: SivilstandEnum): Kravhode =
+    Kravhode().apply {
+        persongrunnlagListe = mutableListOf(
+            Persongrunnlag().apply {
+                penPerson = PenPerson().apply { penPersonId = 1L }
+                personDetaljListe = mutableListOf(
+                    PersonDetalj().apply {
+                        bruk = true
+                        grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
+                        sivilstandTypeEnum = sivilstand
+                    }
+                )
+            }
+        )
+    }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonBeregnerTest.kt
@@ -1,59 +1,732 @@
 package no.nav.pensjon.simulator.core.beregn
 
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.every
-import io.mockk.mockk
+import io.kotest.matchers.shouldNotBe
+import io.mockk.*
 import no.nav.pensjon.simulator.core.SimulatorContext
 import no.nav.pensjon.simulator.core.domain.regler.Merknad
-import no.nav.pensjon.simulator.core.domain.regler.beregning2011.SisteAldersberegning2011
-import no.nav.pensjon.simulator.core.domain.regler.enum.KravlinjeTypeEnum
-import no.nav.pensjon.simulator.core.domain.regler.enum.RegelverkTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
+import no.nav.pensjon.simulator.core.domain.regler.enum.*
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravlinje
+import no.nav.pensjon.simulator.core.domain.regler.to.*
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import no.nav.pensjon.simulator.core.exception.RegelmotorValideringException
 import no.nav.pensjon.simulator.testutil.TestObjects.simuleringSpec
 import no.nav.pensjon.simulator.validity.BadSpecException
 import java.time.LocalDate
 
-class AlderspensjonBeregnerTest : ShouldSpec({
+class AlderspensjonBeregnerTest : FunSpec({
 
-    should("gi klar feilmelding når gjenlevenderett ikke støttes") {
+    // ===========================================
+    // Tests for first uttak with different regelverkTypes
+    // ===========================================
+
+    test("beregnAlderspensjon should call beregnAlderspensjon2011FoersteUttak for N_REG_G_OPPTJ") {
+        val expectedResult = BeregningsResultatAlderspensjon2011()
         val context = mockk<SimulatorContext> {
-            every {
-                revurderAlderspensjon2016(any(), any())
-            } throws RegelmotorValideringException(
-                message = "",
+            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } returns expectedResult
+        }
+
+        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = null,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = 123L,
+            isFoersteUttak = true,
+            ignoreAvslag = false
+        )
+
+        result shouldBe expectedResult
+        verify(exactly = 1) { context.beregnAlderspensjon2011FoersteUttak(any(), eq(123L)) }
+    }
+
+    test("beregnAlderspensjon should call beregnAlderspensjon2016FoersteUttak for N_REG_G_N_OPPTJ") {
+        val expectedResult = BeregningsResultatAlderspensjon2016()
+        val context = mockk<SimulatorContext> {
+            every { beregnAlderspensjon2016FoersteUttak(any(), any()) } returns expectedResult
+        }
+
+        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = null,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = true,
+            ignoreAvslag = false
+        )
+
+        result shouldBe expectedResult
+        verify(exactly = 1) { context.beregnAlderspensjon2016FoersteUttak(any(), isNull()) }
+    }
+
+    test("beregnAlderspensjon should call beregnAlderspensjon2025FoersteUttak for N_REG_N_OPPTJ") {
+        val expectedResult = BeregningsResultatAlderspensjon2025()
+        val context = mockk<SimulatorContext> {
+            every { beregnAlderspensjon2025FoersteUttak(any(), any()) } returns expectedResult
+        }
+
+        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = null,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = true,
+            ignoreAvslag = false
+        )
+
+        result shouldBe expectedResult
+        verify(exactly = 1) { context.beregnAlderspensjon2025FoersteUttak(any(), isNull()) }
+    }
+
+    test("beregnAlderspensjon should throw for G_REG regelverkType on first uttak") {
+        val context = mockk<SimulatorContext>()
+
+        shouldThrow<RuntimeException> {
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.G_REG),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = null,
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = true,
+                ignoreAvslag = false
+            )
+        }.message shouldBe "Unexpected regelverkType: G_REG"
+    }
+
+    test("beregnAlderspensjon should throw for null regelverkType on first uttak") {
+        val context = mockk<SimulatorContext>()
+
+        shouldThrow<RuntimeException> {
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = Kravhode(), // no regelverkType
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = null,
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = true,
+                ignoreAvslag = false
+            )
+        }.message shouldBe "Undefined regelverkTypeEnum"
+    }
+
+    // ===========================================
+    // Tests for revurdering with different regelverkTypes
+    // ===========================================
+
+    test("beregnAlderspensjon should call revurderAlderspensjon2011 for N_REG_G_OPPTJ revurdering") {
+        val expectedResult = BeregningsResultatAlderspensjon2011()
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2011(any(), any()) } returns expectedResult
+        }
+
+        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = SisteAldersberegning2011(),
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = 456L,
+            isFoersteUttak = false,
+            ignoreAvslag = false
+        )
+
+        result shouldBe expectedResult
+        verify(exactly = 1) { context.revurderAlderspensjon2011(any(), eq(456L)) }
+    }
+
+    test("beregnAlderspensjon should call revurderAlderspensjon2016 for N_REG_G_N_OPPTJ revurdering") {
+        val expectedResult = BeregningsResultatAlderspensjon2016()
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2016(any(), any()) } returns expectedResult
+        }
+
+        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = SisteAldersberegning2016(),
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = false,
+            ignoreAvslag = false
+        )
+
+        result shouldBe expectedResult
+        verify(exactly = 1) { context.revurderAlderspensjon2016(any(), isNull()) }
+    }
+
+    test("beregnAlderspensjon should call revurderAlderspensjon2025 for N_REG_N_OPPTJ revurdering") {
+        val expectedResult = BeregningsResultatAlderspensjon2025()
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2025(any(), any()) } returns expectedResult
+        }
+
+        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = SisteAldersberegning2011(),
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = false,
+            ignoreAvslag = false
+        )
+
+        result shouldBe expectedResult
+        verify(exactly = 1) { context.revurderAlderspensjon2025(any(), isNull()) }
+    }
+
+    test("beregnAlderspensjon should throw for G_REG regelverkType on revurdering") {
+        val context = mockk<SimulatorContext>()
+
+        shouldThrow<RuntimeException> {
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.G_REG),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = SisteAldersberegning2011(),
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = false,
+                ignoreAvslag = false
+            )
+        }.message shouldBe "Unexpected regelverkType: G_REG"
+    }
+
+    // ===========================================
+    // Tests for ignoreAvslag functionality
+    // ===========================================
+
+    test("beregnAlderspensjon should innvilge vedtak when ignoreAvslag is true and vedtak is not innvilget") {
+        val vedtak = VilkarsVedtak().apply {
+            anbefaltResultatEnum = VedtakResultatEnum.AVSL
+            vilkarsvedtakResultatEnum = VedtakResultatEnum.AVSL
+            begrunnelseEnum = BegrunnelseTypeEnum.ANNULERING
+            merknadListe = mutableListOf(Merknad())
+        }
+        val vedtakListe = mutableListOf(vedtak)
+
+        val context = mockk<SimulatorContext> {
+            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+            vedtakListe = vedtakListe,
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = null,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = true,
+            ignoreAvslag = true
+        )
+
+        vedtakListe[0].anbefaltResultatEnum shouldBe VedtakResultatEnum.INNV
+        vedtakListe[0].vilkarsvedtakResultatEnum shouldBe VedtakResultatEnum.INNV
+        vedtakListe[0].begrunnelseEnum shouldBe null
+        vedtakListe[0].merknadListe shouldBe mutableListOf<Merknad>()
+    }
+
+    test("beregnAlderspensjon should not modify vedtak when ignoreAvslag is true and vedtak is already innvilget") {
+        val vedtak = VilkarsVedtak().apply {
+            anbefaltResultatEnum = VedtakResultatEnum.INNV
+            vilkarsvedtakResultatEnum = VedtakResultatEnum.INNV
+        }
+        val vedtakListe = mutableListOf(vedtak)
+
+        val context = mockk<SimulatorContext> {
+            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+            vedtakListe = vedtakListe,
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = null,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = true,
+            ignoreAvslag = true
+        )
+
+        vedtakListe[0].anbefaltResultatEnum shouldBe VedtakResultatEnum.INNV
+        vedtakListe[0].vilkarsvedtakResultatEnum shouldBe VedtakResultatEnum.INNV
+    }
+
+    test("beregnAlderspensjon should not modify vedtak when ignoreAvslag is false") {
+        val vedtak = VilkarsVedtak().apply {
+            anbefaltResultatEnum = VedtakResultatEnum.AVSL
+            vilkarsvedtakResultatEnum = VedtakResultatEnum.AVSL
+        }
+        val vedtakListe = mutableListOf(vedtak)
+
+        val context = mockk<SimulatorContext> {
+            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+            vedtakListe = vedtakListe,
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = null,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = true,
+            ignoreAvslag = false
+        )
+
+        vedtakListe[0].anbefaltResultatEnum shouldBe VedtakResultatEnum.AVSL
+        vedtakListe[0].vilkarsvedtakResultatEnum shouldBe VedtakResultatEnum.AVSL
+    }
+
+    // ===========================================
+    // Tests for exception handling with gjenlevenderett
+    // ===========================================
+
+    test("beregnAlderspensjon should throw BadSpecException when gjenlevenderett not supported") {
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2016(any(), any()) } throws RegelmotorValideringException(
+                message = "Original error",
                 merknadListe = listOf(
-                    logiskSammenhengMerknad(aarsak = "VilkarsVedtakKravlinjeMangler"),
-                    logiskSammenhengMerknad(aarsak = "VilkarsVedtakRelatertPersonFinnesIkke"),
+                    merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakKravlinjeMangler"),
+                    merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakRelatertPersonFinnesIkke"),
                 )
             )
         }
 
         shouldThrow<BadSpecException> {
             AlderspensjonBeregner(context).beregnAlderspensjon(
-                kravhode = alderspensjon2016Kravhode(),
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
                 vedtakListe = mutableListOf(gjenlevenderettVedtak()),
                 virkningDato = LocalDate.of(2025, 3, 1),
-                sisteAldersberegning2011 = SisteAldersberegning2011(),
+                sisteAldersberegning2011 = SisteAldersberegning2016(),
                 privatAfp = null,
                 livsvarigOffentligAfpGrunnlag = null,
-                simuleringSpec = simuleringSpec, // type ALDER_M_AFP_PRIVAT
+                simuleringSpec = simuleringSpec(type = SimuleringTypeEnum.ALDER_M_AFP_PRIVAT),
                 sakId = null,
-                isFoersteUttak = false, // dvs. revurdering
+                isFoersteUttak = false,
                 ignoreAvslag = false
             )
-        }.message shouldBe "Pensjonen involverer gjenlevenderett," +
-                " noe som ikke støttes for simuleringstype ALDER_M_AFP_PRIVAT"
+        }.message shouldBe "Pensjonen involverer gjenlevenderett, noe som ikke støttes for simuleringstype ALDER_M_AFP_PRIVAT"
+    }
+
+    test("beregnAlderspensjon should rethrow original exception when merknader do not indicate gjenlevende") {
+        val originalException = RegelmotorValideringException(
+            message = "Original error",
+            merknadListe = listOf(merknad("SOME_OTHER_ERROR"))
+        )
+
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2016(any(), any()) } throws originalException
+        }
+
+        shouldThrow<RegelmotorValideringException> {
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+                vedtakListe = mutableListOf(gjenlevenderettVedtak()),
+                virkningDato = LocalDate.of(2025, 3, 1),
+                sisteAldersberegning2011 = SisteAldersberegning2016(),
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = false,
+                ignoreAvslag = false
+            )
+        } shouldBe originalException
+    }
+
+    test("beregnAlderspensjon should rethrow original exception when no GJR vedtak") {
+        val originalException = RegelmotorValideringException(
+            message = "Original error",
+            merknadListe = listOf(
+                merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakKravlinjeMangler"),
+                merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakRelatertPersonFinnesIkke"),
+            )
+        )
+
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2016(any(), any()) } throws originalException
+        }
+
+        val apVedtak = VilkarsVedtak().apply {
+            kravlinje = Kravlinje().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+        }
+
+        shouldThrow<RegelmotorValideringException> {
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+                vedtakListe = mutableListOf(apVedtak), // no GJR vedtak
+                virkningDato = LocalDate.of(2025, 3, 1),
+                sisteAldersberegning2011 = SisteAldersberegning2016(),
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = false,
+                ignoreAvslag = false
+            )
+        } shouldBe originalException
+    }
+
+    test("beregnAlderspensjon should rethrow original exception when only one gjenlevende merknad present") {
+        val originalException = RegelmotorValideringException(
+            message = "Original error",
+            merknadListe = listOf(
+                merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakKravlinjeMangler"),
+                // missing VilkarsVedtakRelatertPersonFinnesIkke
+            )
+        )
+
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2016(any(), any()) } throws originalException
+        }
+
+        shouldThrow<RegelmotorValideringException> {
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+                vedtakListe = mutableListOf(gjenlevenderettVedtak()),
+                virkningDato = LocalDate.of(2025, 3, 1),
+                sisteAldersberegning2011 = SisteAldersberegning2016(),
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = false,
+                ignoreAvslag = false
+            )
+        } shouldBe originalException
+    }
+
+    // ===========================================
+    // Tests for EPS mottar pensjon functionality
+    // ===========================================
+
+    test("beregnAlderspensjon should not create InfoPavirkendeYtelse when EPS does not have pensjon") {
+        var capturedRequest: BeregnAlderspensjon2011ForsteUttakRequest? = null
+        val context = mockk<SimulatorContext> {
+            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } answers {
+                capturedRequest = firstArg()
+                BeregningsResultatAlderspensjon2011()
+            }
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = null,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(epsHarPensjon = false),
+            sakId = null,
+            isFoersteUttak = true,
+            ignoreAvslag = false
+        )
+
+        capturedRequest shouldNotBe null
+        capturedRequest!!.infoPavirkendeYtelse shouldBe null
+    }
+
+    // ===========================================
+    // Tests for privat AFP
+    // ===========================================
+
+    test("beregnAlderspensjon should pass privatAfp to request for first uttak") {
+        var capturedRequest: BeregnAlderspensjon2011ForsteUttakRequest? = null
+        val privatAfp = AfpPrivatLivsvarig()
+
+        val context = mockk<SimulatorContext> {
+            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } answers {
+                capturedRequest = firstArg()
+                BeregningsResultatAlderspensjon2011()
+            }
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = null,
+            privatAfp = privatAfp,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = true,
+            ignoreAvslag = false
+        )
+
+        capturedRequest!!.afpPrivatLivsvarig shouldBe privatAfp
+    }
+
+    test("beregnAlderspensjon should pass privatAfp to request for revurdering") {
+        var capturedRequest: RevurderingAlderspensjon2011Request? = null
+        val privatAfp = AfpPrivatLivsvarig()
+
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2011(any(), any()) } answers {
+                capturedRequest = firstArg()
+                BeregningsResultatAlderspensjon2011()
+            }
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = SisteAldersberegning2011(),
+            privatAfp = privatAfp,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = false,
+            ignoreAvslag = false
+        )
+
+        capturedRequest!!.afpPrivatLivsvarig shouldBe privatAfp
+    }
+
+    // ===========================================
+    // Tests for livsvarig offentlig AFP
+    // ===========================================
+
+    test("beregnAlderspensjon should pass livsvarigOffentligAfpGrunnlag to 2025 request") {
+        var capturedRequest: BeregnAlderspensjon2025ForsteUttakRequest? = null
+        val offentligAfp = AfpOffentligLivsvarigGrunnlag(sistRegulertG = 100000, bruttoPerAr = 50000.0)
+
+        val context = mockk<SimulatorContext> {
+            every { beregnAlderspensjon2025FoersteUttak(any(), any()) } answers {
+                capturedRequest = firstArg()
+                BeregningsResultatAlderspensjon2025()
+            }
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = null,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = offentligAfp,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = true,
+            ignoreAvslag = false
+        )
+
+        capturedRequest!!.afpOffentligLivsvarigGrunnlag shouldBe offentligAfp
+    }
+
+    test("beregnAlderspensjon should pass livsvarigOffentligAfpGrunnlag to 2025 revurdering request") {
+        var capturedRequest: RevurderingAlderspensjon2025Request? = null
+        val offentligAfp = AfpOffentligLivsvarigGrunnlag(sistRegulertG = 100000, bruttoPerAr = 50000.0)
+
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2025(any(), any()) } answers {
+                capturedRequest = firstArg()
+                BeregningsResultatAlderspensjon2025()
+            }
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = SisteAldersberegning2011(),
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = offentligAfp,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = false,
+            ignoreAvslag = false
+        )
+
+        capturedRequest!!.afpOffentligLivsvarigGrunnlag shouldBe offentligAfp
+    }
+
+    // ===========================================
+    // Tests for request virkFom
+    // ===========================================
+
+    test("beregnAlderspensjon should set virkFom in request for first uttak") {
+        var capturedRequest: BeregnAlderspensjon2011ForsteUttakRequest? = null
+        val context = mockk<SimulatorContext> {
+            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } answers {
+                capturedRequest = firstArg()
+                BeregningsResultatAlderspensjon2011()
+            }
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 6, 15),
+            sisteAldersberegning2011 = null,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = true,
+            ignoreAvslag = false
+        )
+
+        capturedRequest!!.virkFom shouldNotBe null
+    }
+
+    test("beregnAlderspensjon should set virkFom in request for revurdering") {
+        var capturedRequest: RevurderingAlderspensjon2016Request? = null
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2016(any(), any()) } answers {
+                capturedRequest = firstArg()
+                BeregningsResultatAlderspensjon2016()
+            }
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 6, 15),
+            sisteAldersberegning2011 = SisteAldersberegning2016(),
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = false,
+            ignoreAvslag = false
+        )
+
+        capturedRequest!!.virkFom shouldNotBe null
+    }
+
+    // ===========================================
+    // Tests for forrige aldersberegning in revurdering
+    // ===========================================
+
+    test("beregnAlderspensjon should pass forrigeAldersBeregning to 2011 revurdering request") {
+        var capturedRequest: RevurderingAlderspensjon2011Request? = null
+        val sisteBeregning = SisteAldersberegning2011().apply { tt_anv = 40 }
+
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2011(any(), any()) } answers {
+                capturedRequest = firstArg()
+                BeregningsResultatAlderspensjon2011()
+            }
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = sisteBeregning,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = false,
+            ignoreAvslag = false
+        )
+
+        capturedRequest!!.forrigeAldersBeregning shouldBe sisteBeregning
+    }
+
+    test("beregnAlderspensjon should pass forrigeAldersBeregning to 2016 revurdering request") {
+        var capturedRequest: RevurderingAlderspensjon2016Request? = null
+        val sisteBeregning = SisteAldersberegning2016()
+
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2016(any(), any()) } answers {
+                capturedRequest = firstArg()
+                BeregningsResultatAlderspensjon2016()
+            }
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = sisteBeregning,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = false,
+            ignoreAvslag = false
+        )
+
+        capturedRequest!!.forrigeAldersBeregning shouldBe sisteBeregning
+    }
+
+    test("beregnAlderspensjon should pass sisteAldersBeregning2011 to 2025 revurdering request") {
+        var capturedRequest: RevurderingAlderspensjon2025Request? = null
+        val sisteBeregning = SisteAldersberegning2011()
+
+        val context = mockk<SimulatorContext> {
+            every { revurderAlderspensjon2025(any(), any()) } answers {
+                capturedRequest = firstArg()
+                BeregningsResultatAlderspensjon2025()
+            }
+        }
+
+        AlderspensjonBeregner(context).beregnAlderspensjon(
+            kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
+            vedtakListe = mutableListOf(),
+            virkningDato = LocalDate.of(2025, 1, 1),
+            sisteAldersberegning2011 = sisteBeregning,
+            privatAfp = null,
+            livsvarigOffentligAfpGrunnlag = null,
+            simuleringSpec = simuleringSpec(),
+            sakId = null,
+            isFoersteUttak = false,
+            ignoreAvslag = false
+        )
+
+        capturedRequest!!.sisteAldersBeregning2011 shouldBe sisteBeregning
     }
 })
 
-private fun alderspensjon2016Kravhode() =
+// ===========================================
+// Helper functions
+// ===========================================
+
+private fun kravhode(regelverkType: RegelverkTypeEnum) =
     Kravhode().apply {
-        regelverkTypeEnum = RegelverkTypeEnum.N_REG_G_N_OPPTJ
+        regelverkTypeEnum = regelverkType
     }
 
 private fun gjenlevenderettVedtak() =
@@ -61,7 +734,7 @@ private fun gjenlevenderettVedtak() =
         kravlinje = Kravlinje().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.GJR }
     }
 
-private fun logiskSammenhengMerknad(aarsak: String) =
+private fun merknad(kode: String) =
     Merknad().apply {
-        kode = "VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.$aarsak"
+        this.kode = kode
     }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregnerTest.kt
@@ -1,0 +1,1035 @@
+package no.nav.pensjon.simulator.core.beregn
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.*
+import no.nav.pensjon.simulator.afp.offentlig.fra2025.grunnlag.LivsvarigOffentligAfpGrunnlagService
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.core.SimulatorContext
+import no.nav.pensjon.simulator.core.domain.regler.PenPerson
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Beholdning
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Beholdninger
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Pensjonsbeholdning
+import no.nav.pensjon.simulator.core.domain.regler.enum.*
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravlinje
+import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
+import no.nav.pensjon.simulator.core.knekkpunkt.KnekkpunktAarsak
+import no.nav.pensjon.simulator.core.krav.KravGjelder
+import no.nav.pensjon.simulator.core.vilkaar.Vilkaarsproever
+import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
+import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
+import no.nav.pensjon.simulator.testutil.TestObjects.simuleringSpec
+import no.nav.pensjon.simulator.trygdetid.TrygdetidBeregnerProxy
+import no.nav.pensjon.simulator.trygdetid.TrygdetidCombo
+import java.time.LocalDate
+import java.util.*
+
+class AlderspensjonVilkaarsproeverOgBeregnerTest : FunSpec({
+
+    // ===========================================
+    // Tests for AFP_FPP simulation type
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should return empty result for AFP_FPP simulation type") {
+        val beregner = createBeregner()
+
+        val spec = createSpec(
+            simulering = simuleringSpec(type = SimuleringTypeEnum.AFP_FPP)
+        )
+
+        val result = beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        result.beregningsresultater.shouldBeEmpty()
+        result.pensjonsbeholdningPerioder.shouldBeEmpty()
+    }
+
+    // ===========================================
+    // Tests for basic knekkpunkt processing
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should process single UTG knekkpunkt") {
+        val expectedResult = BeregningsResultatAlderspensjon2011()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+        val kravhode = createKravhodeWithSoker()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns expectedResult
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            )
+        )
+
+        val result = beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        result.beregningsresultater shouldHaveSize 1
+        result.beregningsresultater[0] shouldBe expectedResult
+        verify(exactly = 1) { vilkaarsproever.vilkaarsproevKrav(any()) }
+        verify(exactly = 1) { alderspensjonBeregner.beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    test("vilkaarsproevOgBeregnAlder should process multiple knekkpunkter") {
+        val result1 = BeregningsResultatAlderspensjon2011()
+        val result2 = BeregningsResultatAlderspensjon2011()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+        val kravhode = createKravhodeWithSoker()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returnsMany listOf(result1, result2)
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns SisteAldersberegning2011()
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG),
+                LocalDate.of(2026, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            )
+        )
+
+        val result = beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        result.beregningsresultater shouldHaveSize 2
+        verify(exactly = 2) { vilkaarsproever.vilkaarsproevKrav(any()) }
+        verify(exactly = 2) { alderspensjonBeregner.beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    // ===========================================
+    // Tests for onlyVilkaarsproeving
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should return early when onlyVilkaarsproeving is true") {
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+        val kravhode = createKravhodeWithSoker()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner>()
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator>(relaxed = true)
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            ),
+            onlyVilkaarsproeving = true
+        )
+
+        val result = beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        result.beregningsresultater.shouldBeEmpty()
+        verify(exactly = 1) { vilkaarsproever.vilkaarsproevKrav(any()) }
+        verify(exactly = 0) { alderspensjonBeregner.beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    // ===========================================
+    // Tests for trygdetid updates
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should update trygdetid for soker when TTBRUKER knekkpunkt") {
+        val kravhode = createKravhodeWithSoker()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy> {
+            every { fastsettTrygdetidForPeriode(any(), any(), any(), any()) } returns TrygdetidCombo(null, null)
+        }
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG, KnekkpunktAarsak.TTBRUKER)
+            )
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        verify(exactly = 1) { trygdetidBeregner.fastsettTrygdetidForPeriode(any(), eq(GrunnlagsrolleEnum.SOKER), any(), any()) }
+    }
+
+    test("vilkaarsproevOgBeregnAlder should update trygdetid for avdod when TTAVDOD knekkpunkt") {
+        val avdodGrunnlag = createPersongrunnlag(GrunnlagsrolleEnum.AVDOD)
+        val kravhode = createKravhodeWithSoker().apply {
+            persongrunnlagListe.add(avdodGrunnlag)
+        }
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy> {
+            every { fastsettTrygdetidForPeriode(any(), any(), any(), any()) } returns TrygdetidCombo(null, null)
+        }
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG, KnekkpunktAarsak.TTAVDOD)
+            ),
+            avdodForsteVirk = LocalDate.of(2020, 1, 1)
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        verify(exactly = 1) { trygdetidBeregner.fastsettTrygdetidForPeriode(any(), eq(GrunnlagsrolleEnum.AVDOD), any(), any()) }
+    }
+
+    // ===========================================
+    // Tests for vilkaarsproving trigger
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should only vilkaarsprov when UTG knekkpunkt present") {
+        val kravhode = createKravhodeWithSoker()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy> {
+            every { fastsettTrygdetidForPeriode(any(), any(), any(), any()) } returns TrygdetidCombo(null, null)
+        }
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        // Knekkpunkt without UTG - should not trigger vilkaarsproving
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.TTBRUKER)
+            ),
+            forrigeVilkarsvedtakListe = mutableListOf(VilkarsVedtak())
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        verify(exactly = 0) { vilkaarsproever.vilkaarsproevKrav(any()) }
+        verify(exactly = 1) { alderspensjonBeregner.beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    // ===========================================
+    // Tests for sisteBeregning handling
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should use sisteBeregning for revurdering") {
+        val kravhode = createKravhodeWithSoker()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+        val sisteBeregning = SisteAldersberegning2011()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns sisteBeregning
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG),
+                LocalDate.of(2026, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            )
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // First call should be foersteUttak=true, second should be foersteUttak=false
+        verify(exactly = 1) { alderspensjonBeregner.beregnAlderspensjon(any(), any(), any(), isNull(), any(), any(), any(), any(), eq(true), any()) }
+        verify(exactly = 1) { alderspensjonBeregner.beregnAlderspensjon(any(), any(), any(), eq(sisteBeregning), any(), any(), any(), any(), eq(false), any()) }
+    }
+
+    // ===========================================
+    // Tests for virkTom setting
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should set virkTom on beregningsresultat from previous iteration") {
+        val kravhode = createKravhodeWithSoker()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+        // This result will be returned by beregner in first iteration
+        // and should have virkTom set in second iteration
+        val firstIterationResult = BeregningsResultatAlderspensjon2011()
+        val secondIterationResult = BeregningsResultatAlderspensjon2011()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returnsMany listOf(firstIterationResult, secondIterationResult)
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns SisteAldersberegning2011()
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG),
+                LocalDate.of(2026, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            )
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // The result from first iteration should have virkTom set to day before second knekkpunkt
+        // virkTom is set on forrigeAlderspensjonBeregningResultat (line 89) which is the result from previous iteration
+        firstIterationResult.virkTom shouldNotBe null
+    }
+
+    // ===========================================
+    // Tests for sisteGyldigeOpptjeningsAr update
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should update sisteGyldigeOpptjeningsAr on persongrunnlag") {
+        val kravhode = createKravhodeWithSoker()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            )
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // sisteGyldigeOpptjeningsAr should be knekkpunkt year - 2 (OPPTJENING_ETTERSLEP_ANTALL_AAR)
+        kravhode.persongrunnlagListe[0].sisteGyldigeOpptjeningsAr shouldBe 2023
+    }
+
+    // ===========================================
+    // Tests for ignoreAvslag
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should pass ignoreAvslag to beregner") {
+        val kravhode = createKravhodeWithSoker()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+
+        var capturedIgnoreAvslag: Boolean? = null
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } answers {
+                capturedIgnoreAvslag = arg(9)
+                BeregningsResultatAlderspensjon2011()
+            }
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            ),
+            ignoreAvslag = true
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        capturedIgnoreAvslag shouldBe true
+    }
+
+    // ===========================================
+    // Tests for livsvarig offentlig AFP
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should pass livsvarig offentlig AFP to beregner") {
+        val kravhode = createKravhodeWithSoker()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+        val offentligAfp = AfpOffentligLivsvarigGrunnlag(sistRegulertG = 100000, bruttoPerAr = 50000.0)
+
+        var capturedOffentligAfp: AfpOffentligLivsvarigGrunnlag? = null
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } answers {
+                capturedOffentligAfp = arg(5)
+                BeregningsResultatAlderspensjon2011()
+            }
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockk<LivsvarigOffentligAfpGrunnlagService> {
+            every { livsvarigOffentligAfpGrunnlag(any(), any(), any(), any()) } returns offentligAfp
+        }
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            )
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        capturedOffentligAfp shouldBe offentligAfp
+    }
+
+    // ===========================================
+    // Tests for isCriteriaForDoingKap20ForSimulerForTpFullfilled (simulerForTp hack)
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should do additional Kap20 beregning when simulerForTp criteria are met") {
+        // This test verifies the "hack" for TP integrations that can't parse Kap 20 results
+        // When simulerForTp=true, heltUttakDato < normertPensjoneringsdato, and knekkpunktDato < heltUttakDato,
+        // an additional beregning is performed with simulerForTp temporarily set to false
+
+        val kravhode = createKravhodeWithSoker()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+        var beregningCallCount = 0
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } answers {
+                beregningCallCount++
+                BeregningsResultatAlderspensjon2011()
+            }
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns SisteAldersberegning2011()
+        }
+        // normertPensjoneringsdato returns 2030-01-01
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        // Create spec with simulerForTp=true and heltUttakDato=2029-06-01 (before 2030-01-01)
+        val simSpec = simuleringSpec(heltUttakDato = LocalDate.of(2029, 6, 1)).apply {
+            simulerForTp = true
+        }
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            simulering = simSpec,
+            knekkpunkter = sortedMapOf(
+                // knekkpunktDato=2025-01-01 is before heltUttakDato=2029-06-01
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            )
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // Should be called twice: once for main beregning, once for the Kap20 hack
+        beregningCallCount shouldBe 2
+    }
+
+    test("vilkaarsproevOgBeregnAlder should not do additional Kap20 beregning when simulerForTp is false") {
+        val kravhode = createKravhodeWithSoker()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+        var beregningCallCount = 0
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } answers {
+                beregningCallCount++
+                BeregningsResultatAlderspensjon2011()
+            }
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        // simulerForTp=false (default)
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            )
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // Should only be called once (no additional Kap20 beregning)
+        beregningCallCount shouldBe 1
+    }
+
+    test("vilkaarsproevOgBeregnAlder should not do additional Kap20 beregning when knekkpunktDato is after heltUttakDato") {
+        val kravhode = createKravhodeWithSoker()
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+        var beregningCallCount = 0
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } answers {
+                beregningCallCount++
+                BeregningsResultatAlderspensjon2011()
+            }
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        // heltUttakDato=2024-06-01, knekkpunktDato=2025-01-01 (knekkpunkt AFTER heltUttak)
+        val simSpec = simuleringSpec(heltUttakDato = LocalDate.of(2024, 6, 1)).apply {
+            simulerForTp = true
+        }
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            simulering = simSpec,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            )
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // Should only be called once (condition not met)
+        beregningCallCount shouldBe 1
+    }
+
+    // ===========================================
+    // Tests for shouldAddPensjonBeholdningPerioder
+    // ===========================================
+
+    test("vilkaarsproevOgBeregnAlder should add pensjonsbeholdning perioder when criteria are met with 2025 result") {
+        val kravhode = Kravhode().apply {
+            regelverkTypeEnum = RegelverkTypeEnum.N_REG_N_OPPTJ // Required for shouldAddPensjonBeholdningPerioder
+            persongrunnlagListe = mutableListOf(createPersongrunnlag(GrunnlagsrolleEnum.SOKER))
+            kravlinjeListe = mutableListOf(
+                Kravlinje().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+            )
+        }
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+
+        // Create beholdninger for the result
+        val beholdninger = Beholdninger().apply {
+            beholdninger = listOf(
+                Pensjonsbeholdning().apply {
+                    totalbelop = 1000000.0
+                }
+            )
+        }
+
+        val beregningsresultat2025 = BeregningsResultatAlderspensjon2025().apply {
+            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            beregningKapittel20 = AldersberegningKapittel20().apply {
+                beholdningerForForsteuttak = beholdninger
+            }
+        }
+
+        val context = mockk<SimulatorContext> {
+            every { beregnOpptjening(any(), any(), any()) } returns mutableListOf()
+        }
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            // First call returns 2011 result (main beregning), second call returns 2025 result (beholdning beregning)
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returnsMany listOf(
+                BeregningsResultatAlderspensjon2011(),
+                beregningsresultat2025
+            )
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+            every { innvilgetVedtak(any(), any()) } returns VilkarsVedtak()
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            ),
+            isHentPensjonsbeholdninger = true
+        )
+
+        val result = beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // Should have one beholdning periode added
+        result.pensjonsbeholdningPerioder shouldHaveSize 1
+        result.pensjonsbeholdningPerioder[0].datoFom shouldBe LocalDate.of(2025, 1, 1)
+    }
+
+    test("vilkaarsproevOgBeregnAlder should add pensjonsbeholdning perioder when criteria are met with 2016 result") {
+        val kravhode = Kravhode().apply {
+            regelverkTypeEnum = RegelverkTypeEnum.N_REG_G_N_OPPTJ // Also valid for shouldAddPensjonBeholdningPerioder
+            persongrunnlagListe = mutableListOf(createPersongrunnlag(GrunnlagsrolleEnum.SOKER))
+            kravlinjeListe = mutableListOf(
+                Kravlinje().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+            )
+        }
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+
+        // Create beholdninger for the result
+        val beholdninger = Beholdninger().apply {
+            beholdninger = listOf(
+                Pensjonsbeholdning().apply {
+                    totalbelop = 500000.0
+                }
+            )
+        }
+
+        val beregningsresultat2016 = BeregningsResultatAlderspensjon2016().apply {
+            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            beregningsResultat2025 = BeregningsResultatAlderspensjon2025().apply {
+                beregningKapittel20 = AldersberegningKapittel20().apply {
+                    beholdningerForForsteuttak = beholdninger
+                }
+            }
+        }
+
+        val context = mockk<SimulatorContext> {
+            every { beregnOpptjening(any(), any(), any()) } returns mutableListOf()
+        }
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            // First call returns 2011 result (main beregning), second call returns 2016 result (beholdning beregning)
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returnsMany listOf(
+                BeregningsResultatAlderspensjon2011(),
+                beregningsresultat2016
+            )
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+            every { innvilgetVedtak(any(), any()) } returns VilkarsVedtak()
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            ),
+            isHentPensjonsbeholdninger = true
+        )
+
+        val result = beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // Should have one beholdning periode added
+        result.pensjonsbeholdningPerioder shouldHaveSize 1
+    }
+
+    test("vilkaarsproevOgBeregnAlder should not add pensjonsbeholdning perioder when isHentPensjonsbeholdninger is false") {
+        val kravhode = Kravhode().apply {
+            regelverkTypeEnum = RegelverkTypeEnum.N_REG_N_OPPTJ
+            persongrunnlagListe = mutableListOf(createPersongrunnlag(GrunnlagsrolleEnum.SOKER))
+            kravlinjeListe = mutableListOf(
+                Kravlinje().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+            )
+        }
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            ),
+            isHentPensjonsbeholdninger = false // Disabled
+        )
+
+        val result = beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // Should have no beholdning perioder
+        result.pensjonsbeholdningPerioder.shouldBeEmpty()
+    }
+
+    test("vilkaarsproevOgBeregnAlder should not add pensjonsbeholdning perioder when regelverkType is not new opptjening") {
+        // Using N_REG_G_OPPTJ which is NOT in the list of allowed types (N_REG_N_OPPTJ, N_REG_G_N_OPPTJ)
+        val kravhode = createKravhodeWithSoker() // Uses N_REG_G_OPPTJ
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            ),
+            isHentPensjonsbeholdninger = true // Enabled, but regelverkType is wrong
+        )
+
+        val result = beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // Should have no beholdning perioder
+        result.pensjonsbeholdningPerioder.shouldBeEmpty()
+    }
+
+    // ===========================================
+    // Tests for personDetalj filtering (periodiserGrunnlag)
+    // ===========================================
+
+    // Note: The periodiserDetaljer function in AlderspensjonVilkaarsproeverOgBeregner has a bug
+    // where it modifies the list while iterating (lines 518-524), causing ConcurrentModificationException.
+    // The filtering functionality cannot be properly tested due to this bug.
+    // If there are no personDetalj elements with bruk=false, no removal is attempted and no error occurs.
+    test("vilkaarsproevOgBeregnAlder should keep personDetalj with bruk=true") {
+        val kravhode = Kravhode().apply {
+            regelverkTypeEnum = RegelverkTypeEnum.N_REG_G_OPPTJ
+            persongrunnlagListe = mutableListOf(
+                Persongrunnlag().apply {
+                    fodselsdato = dateAtNoon(1960, Calendar.JANUARY, 1)
+                    penPerson = PenPerson().apply { penPersonId = 1L }
+                    personDetaljListe = mutableListOf(
+                        PersonDetalj().apply {
+                            bruk = true
+                            grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
+                        }
+                    )
+                }
+            )
+        }
+        val vedtakListe = mutableListOf<VilkarsVedtak>()
+
+        val context = mockk<SimulatorContext>(relaxed = true)
+        val alderspensjonBeregner = mockk<AlderspensjonBeregner> {
+            every { beregnAlderspensjon(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns BeregningsResultatAlderspensjon2011()
+        }
+        val vilkaarsproever = mockk<Vilkaarsproever> {
+            every { vilkaarsproevKrav(any()) } returns Tuple2(vedtakListe, kravhode)
+        }
+        val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+        val sisteBeregningCreator = mockk<SisteBeregningCreator> {
+            every { opprettSisteBeregning(any(), any(), any()) } returns null
+        }
+        val normalderService = mockNormalderService()
+        val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+        val beregner = AlderspensjonVilkaarsproeverOgBeregner(
+            context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+            sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+        )
+
+        val spec = createSpec(
+            kravhode = kravhode,
+            knekkpunkter = sortedMapOf(
+                LocalDate.of(2025, 1, 1) to mutableListOf(KnekkpunktAarsak.UTG)
+            )
+        )
+
+        beregner.vilkaarsproevOgBeregnAlder(spec)
+
+        // The detalj with bruk=true should be kept
+        kravhode.persongrunnlagListe[0].personDetaljListe shouldHaveSize 1
+        kravhode.persongrunnlagListe[0].personDetaljListe[0].grunnlagsrolleEnum shouldBe GrunnlagsrolleEnum.SOKER
+    }
+})
+
+// ===========================================
+// Helper functions
+// ===========================================
+
+private fun mockNormalderService(): NormertPensjonsalderService =
+    mockk {
+        every { normalder(any<LocalDate>()) } returns Alder(67, 0)
+        every { normertPensjoneringsdato(any()) } returns LocalDate.of(2030, 1, 1)
+    }
+
+private fun mockLivsvarigOffentligAfpService(): LivsvarigOffentligAfpGrunnlagService =
+    mockk {
+        every { livsvarigOffentligAfpGrunnlag(any(), any(), any(), any()) } returns null
+    }
+
+private fun createBeregner(): AlderspensjonVilkaarsproeverOgBeregner {
+    val context = mockk<SimulatorContext>(relaxed = true)
+    val alderspensjonBeregner = mockk<AlderspensjonBeregner>(relaxed = true)
+    val vilkaarsproever = mockk<Vilkaarsproever>(relaxed = true)
+    val trygdetidBeregner = mockk<TrygdetidBeregnerProxy>(relaxed = true)
+    val sisteBeregningCreator = mockk<SisteBeregningCreator>(relaxed = true)
+    val normalderService = mockNormalderService()
+    val livsvarigOffentligAfpService = mockLivsvarigOffentligAfpService()
+
+    return AlderspensjonVilkaarsproeverOgBeregner(
+        context, alderspensjonBeregner, vilkaarsproever, trygdetidBeregner,
+        sisteBeregningCreator, normalderService, livsvarigOffentligAfpService
+    )
+}
+
+private fun createSpec(
+    kravhode: Kravhode = createKravhodeWithSoker(),
+    knekkpunkter: SortedMap<LocalDate, MutableList<KnekkpunktAarsak>> = sortedMapOf(),
+    simulering: no.nav.pensjon.simulator.core.spec.SimuleringSpec = simuleringSpec(),
+    sokerForsteVirk: LocalDate = LocalDate.of(2025, 1, 1),
+    avdodForsteVirk: LocalDate? = null,
+    forrigeVilkarsvedtakListe: MutableList<VilkarsVedtak> = mutableListOf(),
+    forrigeAlderBeregningsresultat: AbstraktBeregningsResultat? = null,
+    sisteBeregning: SisteBeregning? = null,
+    afpPrivatBeregningsresultater: MutableList<BeregningsResultatAfpPrivat> = mutableListOf(),
+    gjeldendeAfpPrivatBeregningsresultat: BeregningsResultatAfpPrivat? = null,
+    forsteVirkAfpPrivat: LocalDate? = null,
+    isHentPensjonsbeholdninger: Boolean = false,
+    kravGjelder: KravGjelder = KravGjelder.FORSTEG_BH,
+    sakId: Long? = null,
+    sakType: SakTypeEnum? = null,
+    ignoreAvslag: Boolean = false,
+    onlyVilkaarsproeving: Boolean = false
+) = AlderspensjonVilkaarsproeverBeregnerSpec(
+    kravhode = kravhode,
+    knekkpunkter = knekkpunkter,
+    simulering = simulering,
+    sokerForsteVirk = sokerForsteVirk,
+    avdodForsteVirk = avdodForsteVirk,
+    forrigeVilkarsvedtakListe = forrigeVilkarsvedtakListe,
+    forrigeAlderBeregningsresultat = forrigeAlderBeregningsresultat,
+    sisteBeregning = sisteBeregning,
+    afpPrivatBeregningsresultater = afpPrivatBeregningsresultater,
+    gjeldendeAfpPrivatBeregningsresultat = gjeldendeAfpPrivatBeregningsresultat,
+    forsteVirkAfpPrivat = forsteVirkAfpPrivat,
+    isHentPensjonsbeholdninger = isHentPensjonsbeholdninger,
+    kravGjelder = kravGjelder,
+    sakId = sakId,
+    sakType = sakType,
+    afpOffentligLivsvarigBeregningsresultat = null,
+    ignoreAvslag = ignoreAvslag,
+    onlyVilkaarsproeving = onlyVilkaarsproeving
+)
+
+private fun createKravhodeWithSoker(): Kravhode {
+    val sokerGrunnlag = createPersongrunnlag(GrunnlagsrolleEnum.SOKER)
+    return Kravhode().apply {
+        regelverkTypeEnum = RegelverkTypeEnum.N_REG_G_OPPTJ
+        persongrunnlagListe = mutableListOf(sokerGrunnlag)
+        kravlinjeListe = mutableListOf(
+            Kravlinje().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+        )
+    }
+}
+
+private fun createPersongrunnlag(rolle: GrunnlagsrolleEnum): Persongrunnlag =
+    Persongrunnlag().apply {
+        fodselsdato = dateAtNoon(1960, Calendar.JANUARY, 1)
+        penPerson = PenPerson().apply { penPersonId = 1L }
+        personDetaljListe = mutableListOf(
+            PersonDetalj().apply {
+                bruk = true
+                grunnlagsrolleEnum = rolle
+                virkFom = dateAtNoon(2020, Calendar.JANUARY, 1)
+            }
+        )
+    }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/PeriodiseringUtilTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/PeriodiseringUtilTest.kt
@@ -1,0 +1,101 @@
+package no.nav.pensjon.simulator.core.beregn
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.core.domain.regler.PenPerson
+import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.KravlinjeTypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Pensjonsbeholdning
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravlinje
+import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
+import java.time.LocalDate
+import java.util.*
+
+class PeriodiseringUtilTest : FunSpec({
+
+    test("periodiserGrunnlagAndModifyKravhode should retain beholdninger with fom before or equal to virkning date") {
+        val sokerGrunnlag = sokerPersongrunnlag()
+
+        val kravhode = Kravhode().apply {
+            persongrunnlagListe = mutableListOf(sokerGrunnlag)
+        }
+
+        val beholdninger = listOf(
+            Pensjonsbeholdning().apply {
+                fom = dateAtNoon(2024, Calendar.JANUARY, 1)
+            },
+            Pensjonsbeholdning().apply {
+                fom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            },
+            Pensjonsbeholdning().apply {
+                fom = dateAtNoon(2026, Calendar.JANUARY, 1)
+            }
+        )
+
+        val result = PeriodiseringUtil.periodiserGrunnlagAndModifyKravhode(
+            virkningFom = LocalDate.of(2025, 1, 1),
+            kravhode = kravhode,
+            beholdningListe = beholdninger,
+            sakType = null
+        )
+
+        result.hentPersongrunnlagForSoker().beholdninger.size shouldBe 2
+    }
+
+    test("periodiserGrunnlagAndModifyKravhode should set full uttak with 100% uttaksgrad") {
+        val sokerGrunnlag = sokerPersongrunnlag()
+
+        val kravhode = Kravhode().apply {
+            persongrunnlagListe = mutableListOf(sokerGrunnlag)
+            uttaksgradListe = mutableListOf()
+        }
+
+        val result = PeriodiseringUtil.periodiserGrunnlagAndModifyKravhode(
+            virkningFom = LocalDate.of(2025, 1, 1),
+            kravhode = kravhode,
+            beholdningListe = emptyList(),
+            sakType = null
+        )
+
+        result.uttaksgradListe.size shouldBe 1
+        result.uttaksgradListe[0].uttaksgrad shouldBe 100
+    }
+
+    test("periodiserGrunnlagAndModifyKravhode should remove non-alderspensjon kravlinjer") {
+        val sokerGrunnlag = sokerPersongrunnlag()
+
+        val kravhode = Kravhode().apply {
+            persongrunnlagListe = mutableListOf(sokerGrunnlag)
+            kravlinjeListe = mutableListOf(
+                Kravlinje().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP },
+                Kravlinje().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.UT },
+                Kravlinje().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.GJP }
+            )
+        }
+
+        val result = PeriodiseringUtil.periodiserGrunnlagAndModifyKravhode(
+            virkningFom = LocalDate.of(2025, 1, 1),
+            kravhode = kravhode,
+            beholdningListe = emptyList(),
+            sakType = null
+        )
+
+        result.kravlinjeListe.size shouldBe 1
+        result.kravlinjeListe[0].kravlinjeTypeEnum shouldBe KravlinjeTypeEnum.AP
+    }
+})
+
+private fun sokerPersongrunnlag() = Persongrunnlag().apply {
+    fodselsdato = dateAtNoon(1960, Calendar.JANUARY, 1)
+    penPerson = PenPerson().apply { penPersonId = 1L }
+    personDetaljListe = mutableListOf(
+        PersonDetalj().apply {
+            bruk = true
+            grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
+            virkFom = dateAtNoon(2020, Calendar.JANUARY, 1)
+        }
+    )
+}

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreatorTest.kt
@@ -1,0 +1,758 @@
+package no.nav.pensjon.simulator.core.beregn
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.pensjon.simulator.core.domain.regler.PenPerson
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
+import no.nav.pensjon.simulator.core.domain.regler.enum.*
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravlinje
+import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
+import no.nav.pensjon.simulator.core.krav.KravlinjeStatus
+import no.nav.pensjon.simulator.krav.KravService
+import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
+import java.util.*
+
+class SisteBeregningCreatorTest : FunSpec({
+
+    // ===========================================
+    // Tests for sisteBeregningCreator selection based on regelverkType
+    // ===========================================
+
+    test("opprettSisteBeregning should use alderspensjon2011SisteBeregningCreator for N_REG_G_OPPTJ") {
+        val expectedResult = SisteAldersberegning2011()
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat()
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } returns expectedResult
+        }
+        val creator2016 = mockk<Alderspensjon2016SisteBeregningCreator>()
+        val creator2025 = mockk<Alderspensjon2025SisteBeregningCreator>()
+        val kravService = mockk<KravService>()
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            kravService, creator2011, creator2016, creator2025
+        )
+
+        val result = sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = emptyList(),
+            beregningResultat = beregningsresultat
+        )
+
+        result shouldBe expectedResult
+        verify(exactly = 1) { creator2011.createBeregning(any(), any()) }
+    }
+
+    test("opprettSisteBeregning should use alderspensjon2016SisteBeregningCreator for N_REG_G_N_OPPTJ") {
+        val expectedResult = SisteAldersberegning2016()
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_N_OPPTJ)
+        val beregningsresultat = createBeregningsresultat()
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator>()
+        val creator2016 = mockk<Alderspensjon2016SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } returns expectedResult
+        }
+        val creator2025 = mockk<Alderspensjon2025SisteBeregningCreator>()
+        val kravService = mockk<KravService>()
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            kravService, creator2011, creator2016, creator2025
+        )
+
+        val result = sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = emptyList(),
+            beregningResultat = beregningsresultat
+        )
+
+        result shouldBe expectedResult
+        verify(exactly = 1) { creator2016.createBeregning(any(), any()) }
+    }
+
+    test("opprettSisteBeregning should use alderspensjon2025SisteBeregningCreator for N_REG_N_OPPTJ") {
+        // Note: Alderspensjon2025SisteBeregningCreator returns SisteAldersberegning2011, not a 2025-specific type
+        val expectedResult = SisteAldersberegning2011()
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_N_OPPTJ)
+        val beregningsresultat = createBeregningsresultat()
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator>()
+        val creator2016 = mockk<Alderspensjon2016SisteBeregningCreator>()
+        val creator2025 = mockk<Alderspensjon2025SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } returns expectedResult
+        }
+        val kravService = mockk<KravService>()
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            kravService, creator2011, creator2016, creator2025
+        )
+
+        val result = sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = emptyList(),
+            beregningResultat = beregningsresultat
+        )
+
+        result shouldBe expectedResult
+        verify(exactly = 1) { creator2025.createBeregning(any(), any()) }
+    }
+
+    test("opprettSisteBeregning should throw for unexpected regelverkType") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.G_REG)
+        val beregningsresultat = createBeregningsresultat()
+
+        val sisteBeregningCreator = createSisteBeregningCreator()
+
+        shouldThrow<RuntimeException> {
+            sisteBeregningCreator.opprettSisteBeregning(
+                kravhode = kravhode,
+                vedtakListe = emptyList(),
+                beregningResultat = beregningsresultat
+            )
+        }.message shouldBe "Unexpected regelverkType G_REG in SisteBeregningCreator"
+    }
+
+    test("opprettSisteBeregning should throw for null regelverkType") {
+        val kravhode = createKravhodeWithSoker(regelverkType = null)
+        val beregningsresultat = createBeregningsresultat()
+
+        val sisteBeregningCreator = createSisteBeregningCreator()
+
+        shouldThrow<RuntimeException> {
+            sisteBeregningCreator.opprettSisteBeregning(
+                kravhode = kravhode,
+                vedtakListe = emptyList(),
+                beregningResultat = beregningsresultat
+            )
+        }.message shouldBe "Unexpected regelverkType null in SisteBeregningCreator"
+    }
+
+    // ===========================================
+    // Tests for validation
+    // ===========================================
+
+    test("opprettSisteBeregning should throw when beregningsresultat is null") {
+        val kravhode = createKravhodeWithSoker()
+
+        val sisteBeregningCreator = createSisteBeregningCreator()
+
+        shouldThrow<IllegalArgumentException> {
+            sisteBeregningCreator.opprettSisteBeregning(
+                kravhode = kravhode,
+                vedtakListe = emptyList(),
+                beregningResultat = null
+            )
+        }.message shouldBe "beregning and beregningsresultat cannot both be null"
+    }
+
+    // ===========================================
+    // Tests for findForrigeKravhode
+    // ===========================================
+
+    test("opprettSisteBeregning should use periodized kravhode from spec when kravId matches") {
+        // When beregningsresultat.kravId == kravhode.kravId, forrigeKravhode should come from spec.kravhode
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ).apply {
+            kravId = 123L
+        }
+        val beregningsresultat = createBeregningsresultat().apply {
+            kravId = 123L // Same as kravhode.kravId
+        }
+
+        val expectedResult = SisteAldersberegning2011()
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } returns expectedResult
+        }
+        val kravService = mockk<KravService>()
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            kravService,
+            creator2011,
+            mockk(),
+            mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = emptyList(),
+            beregningResultat = beregningsresultat
+        )
+
+        // kravService.fetchKravhode should not be called because kravIds match
+        verify(exactly = 0) { kravService.fetchKravhode(any()) }
+    }
+
+    test("opprettSisteBeregning should fetch kravhode from service when kravId differs") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ).apply {
+            kravId = 123L
+        }
+        val forrigeKravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ).apply {
+            kravId = 456L
+        }
+        val beregningsresultat = createBeregningsresultat().apply {
+            kravId = 456L // Different from kravhode.kravId
+        }
+
+        val expectedResult = SisteAldersberegning2011()
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } returns expectedResult
+        }
+        val kravService = mockk<KravService> {
+            every { fetchKravhode(456L) } returns forrigeKravhode
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            kravService,
+            creator2011,
+            mockk(),
+            mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = emptyList(),
+            beregningResultat = beregningsresultat
+        )
+
+        // kravService.fetchKravhode should be called with beregningsresultat.kravId
+        verify(exactly = 1) { kravService.fetchKravhode(456L) }
+    }
+
+    // ===========================================
+    // Tests for vedtak filtering
+    // ===========================================
+
+    test("opprettSisteBeregning should filter vedtak to only innvilget") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat()
+
+        val innvilgetVedtak = createVedtak(VedtakResultatEnum.INNV)
+        val avslaattVedtak = createVedtak(VedtakResultatEnum.AVSL)
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = listOf(innvilgetVedtak, avslaattVedtak),
+            beregningResultat = beregningsresultat
+        )
+
+        // Only innvilget vedtak should be in the filtered list
+        capturedSpec shouldNotBe null
+        capturedSpec!!.filtrertVilkarsvedtakList.size shouldBe 1
+        capturedSpec!!.filtrertVilkarsvedtakList[0].vilkarsvedtakResultatEnum shouldBe VedtakResultatEnum.INNV
+    }
+
+    test("opprettSisteBeregning should filter vedtak to only vilkarsprovd or ferdig status") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat()
+
+        val vedtakVilkarsprovd = createVedtak(VedtakResultatEnum.INNV, KravlinjeStatus.VILKARSPROVD)
+        val vedtakFerdig = createVedtak(VedtakResultatEnum.INNV, KravlinjeStatus.FERDIG)
+        val vedtakIkkeBehandlet = createVedtak(VedtakResultatEnum.INNV, KravlinjeStatus.TIL_BEHANDLING)
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = listOf(vedtakVilkarsprovd, vedtakFerdig, vedtakIkkeBehandlet),
+            beregningResultat = beregningsresultat
+        )
+
+        // Only vedtak with VILKARSPROVD or FERDIG status should be in the filtered list
+        capturedSpec shouldNotBe null
+        capturedSpec!!.filtrertVilkarsvedtakList.size shouldBe 2
+    }
+
+    test("opprettSisteBeregning should filter vedtak to only Norwegian kravlinje") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat()
+
+        val norskVedtak = createVedtak(VedtakResultatEnum.INNV, KravlinjeStatus.VILKARSPROVD, LandkodeEnum.NOR)
+        val utenlandskVedtak = createVedtak(VedtakResultatEnum.INNV, KravlinjeStatus.VILKARSPROVD, LandkodeEnum.SWE)
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = listOf(norskVedtak, utenlandskVedtak),
+            beregningResultat = beregningsresultat
+        )
+
+        // Only Norwegian vedtak should be in the filtered list
+        capturedSpec shouldNotBe null
+        capturedSpec!!.filtrertVilkarsvedtakList.size shouldBe 1
+        capturedSpec!!.filtrertVilkarsvedtakList[0].kravlinje?.land shouldBe LandkodeEnum.NOR
+    }
+
+    test("opprettSisteBeregning should filter vedtak by virkFom before beregningsresultat virkFom") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat().apply {
+            virkFom = dateAtNoon(2025, Calendar.JUNE, 1)
+        }
+
+        val vedtakBefore = createVedtak(VedtakResultatEnum.INNV).apply {
+            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1) // Before beregningsresultat.virkFom
+        }
+        val vedtakAfter = createVedtak(VedtakResultatEnum.INNV).apply {
+            virkFom = dateAtNoon(2025, Calendar.DECEMBER, 1) // After beregningsresultat.virkFom
+        }
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = listOf(vedtakBefore, vedtakAfter),
+            beregningResultat = beregningsresultat
+        )
+
+        // Only vedtak with virkFom before beregningsresultat.virkFom should pass
+        capturedSpec shouldNotBe null
+        capturedSpec!!.filtrertVilkarsvedtakList.size shouldBe 1
+    }
+
+    test("opprettSisteBeregning should filter vedtak by virkTom after beregningsresultat virkTom") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat().apply {
+            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            virkTom = dateAtNoon(2025, Calendar.JUNE, 1)
+        }
+
+        val vedtakTomNull = createVedtak(VedtakResultatEnum.INNV).apply {
+            virkFom = dateAtNoon(2024, Calendar.JANUARY, 1)
+            virkTom = null // null is considered "after"
+        }
+        val vedtakTomAfter = createVedtak(VedtakResultatEnum.INNV).apply {
+            virkFom = dateAtNoon(2024, Calendar.JANUARY, 1)
+            virkTom = dateAtNoon(2025, Calendar.DECEMBER, 1) // After beregningsresultat.virkTom
+        }
+        val vedtakTomBefore = createVedtak(VedtakResultatEnum.INNV).apply {
+            virkFom = dateAtNoon(2024, Calendar.JANUARY, 1)
+            virkTom = dateAtNoon(2025, Calendar.MARCH, 1) // Before beregningsresultat.virkTom
+        }
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = listOf(vedtakTomNull, vedtakTomAfter, vedtakTomBefore),
+            beregningResultat = beregningsresultat
+        )
+
+        // Only vedtak with virkTom after (or equal to) beregningsresultat.virkTom or null should pass
+        capturedSpec shouldNotBe null
+        capturedSpec!!.filtrertVilkarsvedtakList.size shouldBe 2
+    }
+
+    // ===========================================
+    // Tests for spec values passed to creator
+    // ===========================================
+
+    test("opprettSisteBeregning should set regelverkKodePaNyttKrav from kravhode") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat()
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = emptyList(),
+            beregningResultat = beregningsresultat
+        )
+
+        capturedSpec shouldNotBe null
+        capturedSpec!!.regelverkKodePaNyttKrav shouldBe RegelverkTypeEnum.N_REG_G_OPPTJ
+    }
+
+    test("opprettSisteBeregning should set fomDato and tomDato from beregningsresultat") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val fomDate = dateAtNoon(2025, Calendar.JANUARY, 1)
+        val tomDate = dateAtNoon(2025, Calendar.DECEMBER, 31)
+        val beregningsresultat = createBeregningsresultat().apply {
+            virkFom = fomDate
+            virkTom = tomDate
+        }
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = emptyList(),
+            beregningResultat = beregningsresultat
+        )
+
+        capturedSpec shouldNotBe null
+        capturedSpec!!.fomDato shouldNotBe null
+        capturedSpec!!.tomDato shouldNotBe null
+    }
+
+    test("opprettSisteBeregning should pass beregningsresultat to creator") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat()
+
+        var capturedBeregningsresultat: AbstraktBeregningsResultat? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedBeregningsresultat = arg(1)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = emptyList(),
+            beregningResultat = beregningsresultat
+        )
+
+        capturedBeregningsresultat shouldBe beregningsresultat
+    }
+
+    // ===========================================
+    // Tests for isVirkTomAfterDate edge cases
+    // ===========================================
+
+    test("opprettSisteBeregning should include vedtak when both virkTom and beregningsresultat.virkTom are null") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat().apply {
+            virkTom = null
+        }
+
+        val vedtakWithNullVirkTom = createVedtak(VedtakResultatEnum.INNV).apply {
+            virkTom = null
+        }
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = listOf(vedtakWithNullVirkTom),
+            beregningResultat = beregningsresultat
+        )
+
+        // When both are null, vedtak should be included
+        capturedSpec shouldNotBe null
+        capturedSpec!!.filtrertVilkarsvedtakList.size shouldBe 1
+    }
+
+    test("opprettSisteBeregning should include vedtak when vedtak virkTom is null and beregningsresultat.virkTom is set") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat().apply {
+            virkTom = dateAtNoon(2025, Calendar.JUNE, 1)
+        }
+
+        val vedtakWithNullVirkTom = createVedtak(VedtakResultatEnum.INNV).apply {
+            virkTom = null
+        }
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = listOf(vedtakWithNullVirkTom),
+            beregningResultat = beregningsresultat
+        )
+
+        // When vedtak.virkTom is null, it's considered "after" any date
+        capturedSpec shouldNotBe null
+        capturedSpec!!.filtrertVilkarsvedtakList.size shouldBe 1
+    }
+
+    test("opprettSisteBeregning should exclude vedtak when vedtak virkTom is set and beregningsresultat.virkTom is null") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat().apply {
+            virkTom = null
+        }
+
+        val vedtakWithVirkTom = createVedtak(VedtakResultatEnum.INNV).apply {
+            virkTom = dateAtNoon(2025, Calendar.JUNE, 1)
+        }
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = listOf(vedtakWithVirkTom),
+            beregningResultat = beregningsresultat
+        )
+
+        // When vedtak.virkTom is set but beregningsresultat.virkTom is null, vedtak is excluded
+        capturedSpec shouldNotBe null
+        capturedSpec!!.filtrertVilkarsvedtakList.size shouldBe 0
+    }
+
+    // ===========================================
+    // Tests for complex filtering scenarios
+    // ===========================================
+
+    test("opprettSisteBeregning should filter vedtak by all criteria combined") {
+        val kravhode = createKravhodeWithSoker(RegelverkTypeEnum.N_REG_G_OPPTJ)
+        val beregningsresultat = createBeregningsresultat().apply {
+            virkFom = dateAtNoon(2025, Calendar.JUNE, 1)
+            virkTom = dateAtNoon(2025, Calendar.DECEMBER, 31)
+        }
+
+        // This vedtak passes all filters
+        val validVedtak = VilkarsVedtak().apply {
+            vilkarsvedtakResultatEnum = VedtakResultatEnum.INNV
+            kravlinje = Kravlinje().apply {
+                kravlinjeStatus = KravlinjeStatus.VILKARSPROVD
+                land = LandkodeEnum.NOR
+            }
+            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            virkTom = null
+        }
+
+        // This vedtak fails: not innvilget
+        val failsInnvilget = VilkarsVedtak().apply {
+            vilkarsvedtakResultatEnum = VedtakResultatEnum.AVSL
+            kravlinje = Kravlinje().apply {
+                kravlinjeStatus = KravlinjeStatus.VILKARSPROVD
+                land = LandkodeEnum.NOR
+            }
+            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            virkTom = null
+        }
+
+        // This vedtak fails: wrong status
+        val failsStatus = VilkarsVedtak().apply {
+            vilkarsvedtakResultatEnum = VedtakResultatEnum.INNV
+            kravlinje = Kravlinje().apply {
+                kravlinjeStatus = KravlinjeStatus.TIL_BEHANDLING
+                land = LandkodeEnum.NOR
+            }
+            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            virkTom = null
+        }
+
+        // This vedtak fails: not Norwegian
+        val failsLand = VilkarsVedtak().apply {
+            vilkarsvedtakResultatEnum = VedtakResultatEnum.INNV
+            kravlinje = Kravlinje().apply {
+                kravlinjeStatus = KravlinjeStatus.VILKARSPROVD
+                land = LandkodeEnum.SWE
+            }
+            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            virkTom = null
+        }
+
+        // This vedtak fails: virkFom after beregningsresultat.virkFom
+        val failsVirkFom = VilkarsVedtak().apply {
+            vilkarsvedtakResultatEnum = VedtakResultatEnum.INNV
+            kravlinje = Kravlinje().apply {
+                kravlinjeStatus = KravlinjeStatus.VILKARSPROVD
+                land = LandkodeEnum.NOR
+            }
+            virkFom = dateAtNoon(2025, Calendar.JULY, 1) // After beregningsresultat.virkFom
+            virkTom = null
+        }
+
+        var capturedSpec: SisteBeregningSpec? = null
+
+        val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+            every { createBeregning(any(), any()) } answers {
+                capturedSpec = arg(0)
+                SisteAldersberegning2011()
+            }
+        }
+
+        val sisteBeregningCreator = SisteBeregningCreator(
+            mockk(), creator2011, mockk(), mockk()
+        )
+
+        sisteBeregningCreator.opprettSisteBeregning(
+            kravhode = kravhode,
+            vedtakListe = listOf(validVedtak, failsInnvilget, failsStatus, failsLand, failsVirkFom),
+            beregningResultat = beregningsresultat
+        )
+
+        // Only the valid vedtak should pass all filters
+        capturedSpec shouldNotBe null
+        capturedSpec!!.filtrertVilkarsvedtakList.size shouldBe 1
+        capturedSpec!!.filtrertVilkarsvedtakList.first() shouldBe validVedtak
+    }
+})
+
+// ===========================================
+// Helper functions
+// ===========================================
+
+private fun createSisteBeregningCreator(): SisteBeregningCreator {
+    val kravService = mockk<KravService>()
+    val creator2011 = mockk<Alderspensjon2011SisteBeregningCreator> {
+        every { createBeregning(any(), any()) } returns SisteAldersberegning2011()
+    }
+    val creator2016 = mockk<Alderspensjon2016SisteBeregningCreator> {
+        every { createBeregning(any(), any()) } returns SisteAldersberegning2016()
+    }
+    val creator2025 = mockk<Alderspensjon2025SisteBeregningCreator> {
+        every { createBeregning(any(), any()) } returns SisteAldersberegning2011()
+    }
+
+    return SisteBeregningCreator(kravService, creator2011, creator2016, creator2025)
+}
+
+private fun createKravhodeWithSoker(regelverkType: RegelverkTypeEnum? = RegelverkTypeEnum.N_REG_G_OPPTJ): Kravhode =
+    Kravhode().apply {
+        regelverkTypeEnum = regelverkType
+        persongrunnlagListe = mutableListOf(
+            Persongrunnlag().apply {
+                fodselsdato = dateAtNoon(1960, Calendar.JANUARY, 1)
+                penPerson = PenPerson().apply { penPersonId = 1L }
+                personDetaljListe = mutableListOf(
+                    PersonDetalj().apply {
+                        bruk = true
+                        grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER
+                        virkFom = dateAtNoon(2020, Calendar.JANUARY, 1)
+                    }
+                )
+            }
+        )
+        kravlinjeListe = mutableListOf(
+            Kravlinje().apply { kravlinjeTypeEnum = KravlinjeTypeEnum.AP }
+        )
+    }
+
+private fun createBeregningsresultat(): BeregningsResultatAlderspensjon2011 =
+    BeregningsResultatAlderspensjon2011().apply {
+        virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+        beregningKapittel19 = AldersberegningKapittel19().apply {
+            pensjonUnderUtbetaling = PensjonUnderUtbetaling()
+        }
+    }
+
+private fun createVedtak(
+    resultat: VedtakResultatEnum,
+    status: KravlinjeStatus = KravlinjeStatus.VILKARSPROVD,
+    land: LandkodeEnum = LandkodeEnum.NOR
+): VilkarsVedtak =
+    VilkarsVedtak().apply {
+        vilkarsvedtakResultatEnum = resultat
+        kravlinje = Kravlinje().apply {
+            kravlinjeStatus = status
+            this.land = land
+        }
+        virkFom = dateAtNoon(2024, Calendar.JANUARY, 1)
+        virkTom = null
+    }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Tuple2Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Tuple2Test.kt
@@ -1,0 +1,28 @@
+package no.nav.pensjon.simulator.core.beregn
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class Tuple2Test : FunSpec({
+
+    test("should store first and second values") {
+        val tuple = Tuple2("hello", 42)
+
+        tuple.first shouldBe "hello"
+        tuple.second shouldBe 42
+    }
+
+    test("should work with different types") {
+        val tuple = Tuple2(listOf(1, 2, 3), mapOf("key" to "value"))
+
+        tuple.first shouldBe listOf(1, 2, 3)
+        tuple.second shouldBe mapOf("key" to "value")
+    }
+
+    test("should work with nullable values") {
+        val tuple = Tuple2<String?, Int?>(null, null)
+
+        tuple.first shouldBe null
+        tuple.second shouldBe null
+    }
+})


### PR DESCRIPTION
Dette ble en pakke med 160 KI-laget regresjonstester (Claude). 

**Ulemper:**

1. Det tester eksisterende kode, og antar at koden gjør det riktige. Den tester ikke at funksjon gjør det sier den skal gjøre.
2. En verbøs måte å teste - mange små tester med få asserts
3. Verbøs setup/mocking som kunne kanskje optimeres skrives på en bedre vis
4. Jeg har ikke verifisert at absolutt alle tester er fornuftige. Kun stikkprøver i noen titals tester
5. Vi får ikke vurdere at koden i pakken gjør det det er ment å gjøre. 

**Fordeler:**

1. Tidsbesparelse. Det ville ellers ta mer enn uke for å lage testene manuelt.
2. Ryddige beskrivelser i testene kan fungere som dokumentasjon som i ekte TDD-ånd.
3. Høy Test Coverage

**Hvorfor jeg mener at det er riktig å bruke disse testene:** 
Vår opprinnelig idé var å dekke simuleringskoden med unittester for å skape sikkerhetsnett for videreutvikling av simuleringskode. Det, at vi kunne finne feil eller dødkode, ville vært en hyggelig bonus. Men det ville ta flere uker for å gå gjennom og verifisere koden. Siden det er ingen konkret mistanke om mulige feil, kan det ansees som unødvendig tidsforbruk.
Vi øker Test Coverage med disse testene, og vi er klare til videreutvikling uten å brekke eksisterende funksjonalitet. Vi kan fortsett lage flere unittester manuelt, når vi videreutvikler simuleringskode for å sikre at den nye koden fungerer bra med den gamle