### PR TITLE
TPP-230 Use LocalDate in SimuleringRequest/resultat

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/OffentligAfpConstants.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/OffentligAfpConstants.kt
@@ -1,7 +1,12 @@
 package no.nav.pensjon.simulator.afp.offentlig
 
+import no.nav.pensjon.simulator.alder.Alder
+
 object OffentligAfpConstants {
-    const val AFP_MIN_AGE = 62
+    /**
+     * Minste uttaksalder (antall år) for AFP i offentlig sektor.
+     */
+    val minsteUttaksalderForAfp = Alder(aar = 62, maaneder = 0)
 
     /**
      * Fødselsåret som markerer overgang fra "gamle" til "nye" regler for AFP i offentlig sektor.

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/OffentligAfpConstants.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/OffentligAfpConstants.kt
@@ -1,6 +1,8 @@
 package no.nav.pensjon.simulator.afp.offentlig
 
 object OffentligAfpConstants {
+    const val AFP_MIN_AGE = 62
+
     /**
      * Fødselsåret som markerer overgang fra "gamle" til "nye" regler for AFP i offentlig sektor.
      * "Gamle" regler gjelder før 2025.

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/AfpVilkaarsproever.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/AfpVilkaarsproever.kt
@@ -16,6 +16,6 @@ class AfpVilkaarsproever(private val simulator: SimulatorContext) {
     //   -> SimulerVilkarsprovAfpConsumerCommand.execute
     fun vilkaarsproevTidsbegrensetOffentligAfp(spec: Simulering): Simuleringsresultat =
         simulator.simulerVilkarsprovPre2025OffentligAfp(
-            spec = SimuleringRequest(simulering = spec, fom = spec.uttaksdato)
+            spec = SimuleringRequest(simulering = spec, fom = spec.uttaksdatoLd)
         )
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpFoerstegangBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpFoerstegangBeregner.kt
@@ -11,21 +11,21 @@ import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 import no.nav.pensjon.simulator.core.domain.regler.enum.*
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.*
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
-import no.nav.pensjon.simulator.vedtak.VilkaarsvedtakKravlinje
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simulering
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresultat
 import no.nav.pensjon.simulator.core.domain.regler.to.SimuleringRequest
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
-import no.nav.pensjon.simulator.core.exception.*
+import no.nav.pensjon.simulator.core.exception.FeilISimuleringsgrunnlagetException
+import no.nav.pensjon.simulator.core.exception.KanIkkeBeregnesException
+import no.nav.pensjon.simulator.core.exception.KonsistensenIGrunnlagetErFeilException
+import no.nav.pensjon.simulator.core.exception.RegelmotorValideringException
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.firstDayOfMonthAfterUserTurnsGivenAge
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.ufoere.UfoereService
-import no.nav.pensjon.simulator.core.util.DateNoonExtension.noon
-import no.nav.pensjon.simulator.core.util.NorwegianCalendar
 import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
-import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.g.GrunnbeloepService
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
+import no.nav.pensjon.simulator.vedtak.VilkaarsvedtakKravlinje
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.util.*
@@ -129,7 +129,7 @@ class Pre2025OffentligAfpFoerstegangBeregner(
     //   -> SimulerVilkarsprovAfpConsumerCommand.execute
     private fun simulerVilkarsprovAfp(spec: Simulering): Simuleringsresultat =
         try {
-            context.simulerVilkarsprovPre2025OffentligAfp(SimuleringRequest(fjernTrygdeavtale(spec), spec.uttaksdato))
+            context.simulerVilkarsprovPre2025OffentligAfp(SimuleringRequest(fjernTrygdeavtale(spec), spec.uttaksdatoLd))
         } catch (e: KanIkkeBeregnesException) {
             throw FeilISimuleringsgrunnlagetException(e)
         } catch (e: RegelmotorValideringException) {
@@ -172,7 +172,7 @@ class Pre2025OffentligAfpFoerstegangBeregner(
         persongrunnlag.penPerson?.pid?.let {
             ufoereService.ufoerehistorikk(
                 pid = it,
-                uttakDato = spec.uttaksdato!!.toNorwegianLocalDate()
+                uttakDato = spec.uttaksdatoLd!!
             )
         }
 
@@ -236,16 +236,14 @@ class Pre2025OffentligAfpFoerstegangBeregner(
 
     // PEN: SimulerPensjonsberegningCommand.createVilkarsvedtakList
     private fun createVedtakListe(spec: Simulering) {
-        val innvilgetResultat = VedtakResultatEnum.INNV
-        val virkningFom: Date? = spec.uttaksdato?.let { virkningFom(uttakDato = it).noon() }// TODO LocalDate
-
-        val grunnbeloep = virkningFom?.let { grunnbeloepService.grunnbeloep(dato = it.toNorwegianLocalDate()) }
-            ?: throw RuntimeException("Failed to obtain grunnbeløp - virkningFom null")
+        val virkningFom: LocalDate = spec.uttaksdatoLd!!.withDayOfMonth(1)
+        val grunnbeloep = grunnbeloepService.grunnbeloep(virkningFom)
+        val virkningFomDato: Date = virkningFom.toNorwegianDateAtNoon()
 
         for (persongrunnlag in spec.persongrunnlagListe) {
             val vedtak = VilkarsVedtak().apply {
-                vilkarsvedtakResultatEnum = innvilgetResultat
-                virkFom = virkningFom
+                vilkarsvedtakResultatEnum = VedtakResultatEnum.INNV
+                virkFom = virkningFomDato
                 virkTom = null
                 gjelderPerson = persongrunnlag.penPerson
                 penPerson = persongrunnlag.penPerson // ref. PEN: VilkarsVedtakToReglerMapper.mapVilkarsVedtak
@@ -291,7 +289,7 @@ class Pre2025OffentligAfpFoerstegangBeregner(
         context.simulerPre2025OffentligAfp(
             SimuleringRequest(
                 simulering = fjernTrygdeavtale(spec),
-                fom = spec.uttaksdato,
+                fom = spec.uttaksdatoLd,
                 ektefelleMottarPensjon = epsMottarPensjon,
                 beregnForsorgingstillegg = beregnForsoergingstillegg,
                 beregnInstitusjonsopphold = beregnInstitusjonsopphold
@@ -302,10 +300,10 @@ class Pre2025OffentligAfpFoerstegangBeregner(
         .apply {
             simuleringTypeEnum = spec.simuleringTypeEnum
             afpOrdningEnum = spec.afpOrdningEnum
-            uttaksdato = spec.uttaksdato
+            uttaksdatoLd = spec.uttaksdatoLd
             persongrunnlagListe = spec.persongrunnlagListe
-                .map { Persongrunnlag(it)
-                    .apply {
+                .map {
+                    Persongrunnlag(it).apply {
                         it.trygdeavtaledetaljer = null
                         it.trygdeavtale = null
                     }
@@ -507,7 +505,7 @@ class Pre2025OffentligAfpFoerstegangBeregner(
         private fun afpSpec(spec: SimuleringSpec, persongrunnlagListe: MutableList<Persongrunnlag>) =
             Simulering().apply {
                 simuleringTypeEnum = SimuleringTypeEnum.AFP
-                uttaksdato = spec.foersteUttakDato?.toNorwegianDateAtNoon()
+                uttaksdatoLd = spec.foersteUttakDato
                 afpOrdningEnum = spec.pre2025OffentligAfp?.afpOrdning
                 this.persongrunnlagListe = persongrunnlagListe
             }
@@ -592,12 +590,6 @@ class Pre2025OffentligAfpFoerstegangBeregner(
                 it.inntektTypeEnum == InntekttypeEnum.FPI
             }
         }
-
-        // PEN: Extracted from SimulerPensjonsberegningCommand.createVilkarsvedtakList
-        private fun virkningFom(uttakDato: Date): Date =
-            NorwegianCalendar.forDate(uttakDato).apply {
-                this[Calendar.DAY_OF_MONTH] = 1
-            }.time
 
         // PEN: Extracted from SimulerPensjonsberegningCommand.updateVilkarsvedtak
         private fun gjelderEps(rolle: String?, personDetalj: PersonDetalj) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpSpecValidator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpSpecValidator.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.afp.offentlig.pre2025
 
-import no.nav.pensjon.simulator.afp.offentlig.OffentligAfpConstants.AFP_MIN_AGE
+import no.nav.pensjon.simulator.afp.offentlig.OffentligAfpConstants.minsteUttaksalderForAfp
 import no.nav.pensjon.simulator.alder.Alder
 import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
@@ -44,8 +44,10 @@ object Pre2025OffentligAfpSpecValidator {
         }
 
         if (SimuleringTypeEnum.AFP == simuleringType) {
-            if (uttaksalderAar < AFP_MIN_AGE || uttaksalderAar == AFP_MIN_AGE && uttaksmaaned <= foedselsmaaned) {
-                throw PersonForUngException("AFP;$AFP_MIN_AGE;0")
+            val minstealderAar = minsteUttaksalderForAfp.aar
+
+            if (uttaksalderAar < minstealderAar || uttaksalderAar == minstealderAar && uttaksmaaned <= foedselsmaaned) {
+                throw PersonForUngException("AFP;$minstealderAar;0")
             }
         }
     }

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpSpecValidator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpSpecValidator.kt
@@ -1,14 +1,15 @@
 package no.nav.pensjon.simulator.afp.offentlig.pre2025
 
+import no.nav.pensjon.simulator.afp.offentlig.OffentligAfpConstants.AFP_MIN_AGE
 import no.nav.pensjon.simulator.alder.Alder
 import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simulering
 import no.nav.pensjon.simulator.core.exception.PersonForUngException
-import no.nav.pensjon.simulator.core.util.NorwegianCalendar
+import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.validity.BadSpecException
-import java.util.*
+import java.time.LocalDate
 
 /**
  * Validerer spesifikasjonen for simulering av førstegangsuttak av offentlig AFP
@@ -16,37 +17,34 @@ import java.util.*
  */
 object Pre2025OffentligAfpSpecValidator {
 
-    private const val AFP_MIN_AGE: Int = 62
-
     // PEN: SimulerPensjonsberegningCommand.validateInput
     fun validateInput(spec: Simulering, normalder: Alder) {
-        val simuleringType = spec.simuleringTypeEnum ?: throw BadSpecException("Pre2025-AFP-spec mangler simuleringType")
-        val uttaksdato: Date = spec.uttaksdato ?: throw BadSpecException("Pre2025-AFP-spec mangler uttaksdato")
+        val simuleringType = spec.simuleringTypeEnum ?: throw BadSpecException("Spec for tidsbegrenset AFP mangler simuleringType")
+        val uttaksdato: LocalDate = spec.uttaksdatoLd ?: throw BadSpecException("Spec for tidsbegrenset AFP mangler uttaksdato")
 
         if (SimuleringTypeEnum.AFP == simuleringType && spec.afpOrdningEnum == null) {
-            throw BadSpecException("Pre2025-AFP-spec mangler AFP-ordning")
+            throw BadSpecException("Spec for tidsbegrenset AFP mangler AFP-ordning")
         }
 
         // PEN: SimulerPensjonsberegningCommand.findPersongrunnlagWithGivenRole
         val soekerGrunnlag: Persongrunnlag =
             spec.persongrunnlagListe.firstOrNull { hasRolle(persongrunnlag = it, rolle = GrunnlagsrolleEnum.SOKER) }
-                ?: throw BadSpecException("Pre2025-AFP-spec mangler persongrunnlag for søker")
+                ?: throw BadSpecException("Spec for tidsbegrenset AFP mangler persongrunnlag for søker")
 
-        val soekerFoedselsdato: Calendar = NorwegianCalendar.forNoon(soekerGrunnlag.fodselsdato!!)
-        val uttakDato: Calendar = NorwegianCalendar.forNoon(uttaksdato)
-        val foedselMaaned = soekerFoedselsdato[Calendar.MONTH]
-        val uttakMaaned = uttakDato[Calendar.MONTH]
-        val uttakAlderAar = uttakDato[Calendar.YEAR] - soekerFoedselsdato[Calendar.YEAR]
+        val foedselsdato = soekerGrunnlag.fodselsdato!!.toNorwegianLocalDate()
+        val foedselsmaaned: Int = foedselsdato.monthValue
+        val uttaksmaaned = uttaksdato.monthValue
+        val uttaksalderAar = uttaksdato.year - foedselsdato.year
 
         if (SimuleringTypeEnum.ALDER == simuleringType) {
             //TODO should 'uttakMaaned <= foedselMaaned' be 'uttakMaaned <= foedselMaaned + normalder.maaneder'?
-            if (uttakAlderAar < normalder.aar || uttakAlderAar == normalder.aar && uttakMaaned <= foedselMaaned) {
+            if (uttaksalderAar < normalder.aar || uttaksalderAar == normalder.aar && uttaksmaaned <= foedselsmaaned) {
                 throw PersonForUngException("Alderspensjon;${normalder.aar};${normalder.maaneder}")
             }
         }
 
         if (SimuleringTypeEnum.AFP == simuleringType) {
-            if (uttakAlderAar < AFP_MIN_AGE || uttakAlderAar == AFP_MIN_AGE && uttakMaaned <= foedselMaaned) {
+            if (uttaksalderAar < AFP_MIN_AGE || uttaksalderAar == AFP_MIN_AGE && uttaksmaaned <= foedselsmaaned) {
                 throw PersonForUngException("AFP;$AFP_MIN_AGE;0")
             }
         }

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/api/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultMapperV0.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/api/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultMapperV0.kt
@@ -8,7 +8,6 @@ import no.nav.pensjon.simulator.core.domain.regler.beregning.Tilleggspensjon
 import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableException
 import no.nav.pensjon.simulator.core.result.*
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
-import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import java.time.LocalDate
 
 /**
@@ -22,7 +21,7 @@ object AfpEtterfulgtAvAlderspensjonResultMapperV0 {
             simuleringSuksess = true,
             aarsakListeIkkeSuksess = emptyList(),
             folketrygdberegnetAfp = folketrygdberegnetAfp(
-                fom = source.pre2025OffentligAfp!!.virk!!.toNorwegianLocalDate(),
+                fom = source.pre2025OffentligAfp!!.virkLd!!,
                 afp = validAfpBeregning(source),
                 spec
             ),
@@ -113,8 +112,7 @@ object AfpEtterfulgtAvAlderspensjonResultMapperV0 {
     ): List<AlderspensjonFraFolketrygdenV0> =
         pensjon.pensjonPeriodeListe
             .filter { it.simulertBeregningInformasjonListe.isNotEmpty() }
-            .map { simuleringsperiodeListe(it, pensjon, uttakDato) }
-            .flatten()
+            .flatMap { simuleringsperiodeListe(it, pensjon, uttakDato) }
             .map { alderspensjonFraFolketrygden(it, pensjon, grunnbeloep) }
 
     private fun simuleringsperiodeListe(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/result/NavSimuleringResultMapperV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/result/NavSimuleringResultMapperV2.kt
@@ -8,7 +8,6 @@ import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresulta
 import no.nav.pensjon.simulator.core.result.*
 import no.nav.pensjon.simulator.core.util.toNorwegianDate
 import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
-import no.nav.pensjon.simulator.core.util.toNorwegianNoon
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -64,7 +63,7 @@ object NavSimuleringResultMapperV2 {
 
         return SimuleringResultatV2(
             status = source.statusEnum,
-            virk = source.virk?.toNorwegianNoon(),
+            virk = source.virkLd?.toNorwegianDate(),
             beregning = source.beregning?.let(::beregning),
             delberegninger = beregningerPerId,
             merknader = source.merknadListe.map(::merknad)

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/result/NavSimuleringResultMapperV2.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/acl/v2/result/NavSimuleringResultMapperV2.kt
@@ -7,6 +7,7 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresultat
 import no.nav.pensjon.simulator.core.result.*
 import no.nav.pensjon.simulator.core.util.toNorwegianDate
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import java.util.concurrent.atomic.AtomicLong
 
@@ -63,7 +64,7 @@ object NavSimuleringResultMapperV2 {
 
         return SimuleringResultatV2(
             status = source.statusEnum,
-            virk = source.virkLd?.toNorwegianDate(),
+            virk = source.virkLd?.toNorwegianDateAtNoon(),
             beregning = source.beregning?.let(::beregning),
             delberegninger = beregningerPerId,
             merknader = source.merknadListe.map(::merknad)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/GeneralPensjonSimuleringService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/GeneralPensjonSimuleringService.kt
@@ -19,7 +19,7 @@ class GeneralPensjonSimuleringService(private val simulator: SimulatorContext) {
     ): Simuleringsresultat {
         val spec = SimuleringRequest(
             simulering = coreSpec,
-            fom = coreSpec.uttaksdato,
+            fom = coreSpec.uttaksdatoLd,
             ektefelleMottarPensjon = extraSpec.epsMottarPensjon,
             beregnForsorgingstillegg = extraSpec.beregnForsoergingstillegg,
             beregnInstitusjonsopphold = extraSpec.beregnInstitusjonsopphold

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/simulering/Simulering.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/simulering/Simulering.kt
@@ -4,9 +4,9 @@ import no.nav.pensjon.simulator.core.domain.regler.enum.AFPtypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
-import java.util.*
+import java.time.LocalDate
 
-// 2025-03-09
+// 2026-04-07
 class Simulering {
 
     /**
@@ -22,11 +22,12 @@ class Simulering {
     /**
      * Dato for når bruker ønsker å simulere uttak av pensjon fra.
      */
-    var uttaksdato: Date? = null
+    var uttaksdatoLd: LocalDate? = null
 
     /**
      * Liste av tilknyttede personer.
      */
     var persongrunnlagListe: List<Persongrunnlag> = mutableListOf()
+
     var vilkarsvedtakliste: MutableList<VilkarsVedtak> = mutableListOf()
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/simulering/Simuleringsresultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/simulering/Simuleringsresultat.kt
@@ -3,11 +3,27 @@ package no.nav.pensjon.simulator.core.domain.regler.simulering
 import no.nav.pensjon.simulator.core.domain.regler.Merknad
 import no.nav.pensjon.simulator.core.domain.regler.beregning.Beregning
 import no.nav.pensjon.simulator.core.domain.regler.enum.VedtakResultatEnum
-import java.util.*
+import java.time.LocalDate
 
-class Simuleringsresultat(
-    var statusEnum: VedtakResultatEnum? = null,
-    var beregning: Beregning? = null,
-    var virk: Date? = null,
+// 2026-04-07
+class Simuleringsresultat {
+    /**
+     * Status på vedtaket
+     */
+    var statusEnum: VedtakResultatEnum? = null
+
+    /**
+     * Beregningen
+     */
+    var beregning: Beregning? = null
+
+    /**
+     * Virkningstidspunkt
+     */
+    var virkLd: LocalDate? = null
+
+    /**
+     * Liste av merknader
+     */
     var merknadListe: MutableList<Merknad> = mutableListOf()
-)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/SimuleringRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/SimuleringRequest.kt
@@ -1,33 +1,31 @@
 package no.nav.pensjon.simulator.core.domain.regler.to
 
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simulering
-import no.nav.pensjon.simulator.core.util.DateNoonExtension.noon
-import java.util.*
+import java.time.LocalDate
 
 class SimuleringRequest() : ServiceRequest() {
-
     var simulering: Simulering? = null
-    var fom: Date? = null
+    var fomLd: LocalDate? = null
     var ektefelleMottarPensjon = false
     var beregnForsorgingstillegg = false
     var beregnInstitusjonsopphold = false
 
     constructor(
         simulering: Simulering?,
-        fom: Date?,
+        fom: LocalDate?,
         ektefelleMottarPensjon: Boolean,
         beregnForsorgingstillegg: Boolean,
         beregnInstitusjonsopphold: Boolean
     ) : this() {
         this.simulering = simulering
-        this.fom = fom?.noon()
+        this.fomLd = fom
         this.ektefelleMottarPensjon = ektefelleMottarPensjon
         this.beregnForsorgingstillegg = beregnForsorgingstillegg
         this.beregnInstitusjonsopphold = beregnInstitusjonsopphold
     }
 
-    constructor(simulering: Simulering?, fom: Date?) : this() {
+    constructor(simulering: Simulering?, fom: LocalDate?) : this() {
         this.simulering = simulering
-        this.fom = fom
+        this.fomLd = fom
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/SimuleringResponse.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/SimuleringResponse.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.simulator.core.domain.regler.to
 
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresultat
 
+// 2026-04-07
 class SimuleringResponse : ServiceResponse() {
 
     var simuleringsResultat: Simuleringsresultat? = null

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringService.kt
@@ -10,9 +10,11 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.*
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simulering
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresultat
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
-import no.nav.pensjon.simulator.core.exception.*
+import no.nav.pensjon.simulator.core.exception.FeilISimuleringsgrunnlagetException
+import no.nav.pensjon.simulator.core.exception.KanIkkeBeregnesException
+import no.nav.pensjon.simulator.core.exception.KonsistensenIGrunnlagetErFeilException
+import no.nav.pensjon.simulator.core.exception.RegelmotorValideringException
 import no.nav.pensjon.simulator.core.spec.ExtraSimuleringSpec
-import no.nav.pensjon.simulator.core.util.isBefore
 import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.fpp.FppSimuleringSpecValidator.validate
@@ -113,13 +115,13 @@ class FppSimuleringService(
 
         relevantUfoerehistorikk(
             person = grunnlag.penPerson,
-            virkningFom = spec.uttaksdato
+            virkningFom = spec.uttaksdatoLd
         )?.let {
             grunnlag.uforeHistorikk = it
         }
     }
 
-    private fun relevantUfoerehistorikk(person: PenPerson?, virkningFom: Date?): Uforehistorikk? {
+    private fun relevantUfoerehistorikk(person: PenPerson?, virkningFom: LocalDate?): Uforehistorikk? {
         val historikk: Uforehistorikk = person?.pid?.let(personService::person)?.uforehistorikk ?: return null
 
         historikk.uforeperiodeListe = historikk.uforeperiodeListe
@@ -130,7 +132,7 @@ class FppSimuleringService(
     }
 
     private fun createVilkaarsvedtakListe(spec: Simulering) {
-        val virkningFom: LocalDate = spec.uttaksdato!!.toNorwegianLocalDate().withDayOfYear(1)
+        val virkningFom: LocalDate = spec.uttaksdatoLd!!.withDayOfYear(1)
         val legacyVirkningFom: Date = virkningFom.toNorwegianDateAtNoon()
         val grunnbeloep: Int = grunnbeloepService.grunnbeloep(dato = virkningFom)
 
@@ -168,7 +170,7 @@ class FppSimuleringService(
 
     private fun simulerBarnepensjon(coreSpec: Simulering, extraSpec: ExtraSimuleringSpec): Simuleringsresultat {
         var antallBarn = 1
-        val uttaksaar: Int = coreSpec.uttaksdato!!.toNorwegianLocalDate().year
+        val uttaksaar: Int = coreSpec.uttaksdatoLd!!.year
         var soekersPersongrunnlag: Persongrunnlag? = null
 
         for (persongrunnlag in coreSpec.persongrunnlagListe) {
@@ -361,8 +363,8 @@ class FppSimuleringService(
                 penPerson = person
             }
 
-        private fun isRelevant(periode: Uforeperiode, virkningFom: Date?): Boolean =
+        private fun isRelevant(periode: Uforeperiode, virkningFom: LocalDate?): Boolean =
             periode.isRealUforeperiode() &&
-                    periode.virk?.isBefore(virkningFom) == true
+                    periode.virk?.toNorwegianLocalDate()?.isBefore(virkningFom) == true
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringService.kt
@@ -115,13 +115,13 @@ class FppSimuleringService(
 
         relevantUfoerehistorikk(
             person = grunnlag.penPerson,
-            virkningFom = spec.uttaksdatoLd
+            virkningFom = spec.uttaksdatoLd!!
         )?.let {
             grunnlag.uforeHistorikk = it
         }
     }
 
-    private fun relevantUfoerehistorikk(person: PenPerson?, virkningFom: LocalDate?): Uforehistorikk? {
+    private fun relevantUfoerehistorikk(person: PenPerson?, virkningFom: LocalDate): Uforehistorikk? {
         val historikk: Uforehistorikk = person?.pid?.let(personService::person)?.uforehistorikk ?: return null
 
         historikk.uforeperiodeListe = historikk.uforeperiodeListe
@@ -363,7 +363,7 @@ class FppSimuleringService(
                 penPerson = person
             }
 
-        private fun isRelevant(periode: Uforeperiode, virkningFom: LocalDate?): Boolean =
+        private fun isRelevant(periode: Uforeperiode, virkningFom: LocalDate): Boolean =
             periode.isRealUforeperiode() &&
                     periode.virk?.toNorwegianLocalDate()?.isBefore(virkningFom) == true
     }

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecCreator.kt
@@ -38,7 +38,7 @@ class FppSimuleringSpecCreator(
     ) =
         Simulering().apply {
             simuleringTypeEnum = simuleringType
-            this.uttaksdato = uttaksdato.toNorwegianDateAtNoon()
+            this.uttaksdatoLd = uttaksdato
 
             if (simuleringType == AFP) {
                 afpOrdningEnum = personopplysninger.valgtAfpOrdning

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecValidator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecValidator.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.fpp
 
-import no.nav.pensjon.simulator.afp.offentlig.OffentligAfpConstants.AFP_MIN_AGE
+import no.nav.pensjon.simulator.afp.offentlig.OffentligAfpConstants.minsteUttaksalderForAfp
 import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum.AFP
@@ -49,8 +49,8 @@ object FppSimuleringSpecValidator {
 
         if (simuleringType == AFP) {
             //TODO normert aldersgrense
-            if (forUng(soekersFoedselsdato, uttaksdato, minimumAlderAar = AFP_MIN_AGE))
-                throw PersonForUngException("AFP $AFP_MIN_AGE")
+            if (forUng(soekersFoedselsdato, uttaksdato, minimumAlderAar = minsteUttaksalderForAfp.aar))
+                throw PersonForUngException("AFP $minsteUttaksalderForAfp")
         }
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecValidator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecValidator.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.simulator.fpp
 
+import no.nav.pensjon.simulator.afp.offentlig.OffentligAfpConstants.AFP_MIN_AGE
 import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum.AFP
@@ -13,14 +14,13 @@ import no.nav.pensjon.simulator.fpp.FppSimuleringUtil.persongrunnlagForRolle
 import java.time.LocalDate
 
 object FppSimuleringSpecValidator {
-    private const val AFP_MIN_AGE = 62
     private const val AP_MIN_AGE = 67 //TODO normert aldersgrense
 
     fun validate(spec: Simulering) {
         val simuleringType: SimuleringTypeEnum = spec.simuleringTypeEnum
             ?: throw ImplementationUnrecoverableException("simulering.simuleringType")
 
-        if (spec.uttaksdato == null)
+        if (spec.uttaksdatoLd == null)
             throw ImplementationUnrecoverableException("simulering.uttaksdato")
 
         if (AFP == simuleringType && spec.afpOrdningEnum == null)
@@ -39,7 +39,7 @@ object FppSimuleringSpecValidator {
         val soekersFoedselsdato: LocalDate = soeker.fodselsdato?.toNorwegianLocalDate()
             ?: throw ImplementationUnrecoverableException("simulering.persongrunnlagListe.soeker.fodselsdato")
 
-        val uttaksdato: LocalDate = spec.uttaksdato!!.toNorwegianLocalDate()
+        val uttaksdato: LocalDate = spec.uttaksdatoLd!!
 
         if (simuleringType == ALDER) {
             //TODO normert aldersgrense

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecValidator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecValidator.kt
@@ -13,6 +13,7 @@ import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.fpp.FppSimuleringUtil.persongrunnlagForRolle
 import java.time.LocalDate
 
+//TODO align with Pre2025OffentligAfpSpecValidator
 object FppSimuleringSpecValidator {
     private const val AP_MIN_AGE = 67 //TODO normert aldersgrense
 
@@ -50,7 +51,7 @@ object FppSimuleringSpecValidator {
         if (simuleringType == AFP) {
             //TODO normert aldersgrense
             if (forUng(soekersFoedselsdato, uttaksdato, minimumAlderAar = minsteUttaksalderForAfp.aar))
-                throw PersonForUngException("AFP $minsteUttaksalderForAfp")
+                throw PersonForUngException("AFP ${minsteUttaksalderForAfp.aar}")
         }
     }
 

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp/folketrygdberegnet/api/direct/acl/v0/result/TpoFolketrygdberegnetAfpResultMapperV0Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp/folketrygdberegnet/api/direct/acl/v0/result/TpoFolketrygdberegnetAfpResultMapperV0Test.kt
@@ -20,7 +20,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
 
     test("toResultV0 returns null when beregning is null") {
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = null)
+            pre2025OffentligAfp = Simuleringsresultat()
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)
@@ -57,7 +57,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
             st = Sertillegg().apply { netto = 2000 }
         }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!
@@ -81,7 +81,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
         val virkFomDate = dateAtNoon(2029, Calendar.JUNE, 15)
         val beregning = Beregning().apply { virkFom = virkFomDate }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!
@@ -97,7 +97,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
     test("toResultV0 sets virkFom to null when beregning virkFom is null") {
         val beregning = Beregning().apply { virkFom = null }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!
@@ -108,7 +108,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
     test("toResultV0 handles null tilleggspensjon") {
         val beregning = Beregning().apply { tp = null }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!
@@ -130,7 +130,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
             }
         }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!
@@ -154,7 +154,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
             }
         }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!
@@ -179,7 +179,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
             }
         }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!
@@ -191,7 +191,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
     test("toResultV0 handles null grunnpensjon") {
         val beregning = Beregning().apply { gp = null }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!
@@ -202,7 +202,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
     test("toResultV0 handles null afpTillegg") {
         val beregning = Beregning().apply { afpTillegg = null }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!
@@ -213,7 +213,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
     test("toResultV0 handles null sertillegg") {
         val beregning = Beregning().apply { st = null }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!
@@ -224,7 +224,7 @@ class TpoFolketrygdberegnetAfpResultMapperV0Test : FunSpec({
     test("toResultV0 uses default zero values for netto, tt_anv, and g on empty beregning") {
         val beregning = Beregning()
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = TpoFolketrygdberegnetAfpResultMapperV0.toResultV0(output)!!

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp/folketrygdberegnet/api/viapen/acl/v1/result/FolketrygdberegnetAfpResultMapperV1Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp/folketrygdberegnet/api/viapen/acl/v1/result/FolketrygdberegnetAfpResultMapperV1Test.kt
@@ -11,21 +11,12 @@ import java.util.*
 class FolketrygdberegnetAfpResultMapperV1Test : FunSpec({
 
     test("toResultV1 returns null when pre2025OffentligAfp is null") {
-        val output = SimulatorOutput()
-
-        val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)
-
-        result shouldBe null
+        FolketrygdberegnetAfpResultMapperV1.toResultV1(SimulatorOutput()) shouldBe null
     }
 
     test("toResultV1 returns null when beregning is null") {
-        val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = null)
-        }
-
-        val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)
-
-        result shouldBe null
+        val output = SimulatorOutput().apply { pre2025OffentligAfp = Simuleringsresultat() }
+        FolketrygdberegnetAfpResultMapperV1.toResultV1(output) shouldBe null
     }
 
     test("toResultV1 maps all fields from fully populated beregning") {
@@ -56,7 +47,7 @@ class FolketrygdberegnetAfpResultMapperV1Test : FunSpec({
             st = Sertillegg().apply { netto = 2000 }
         }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)!!
@@ -79,7 +70,7 @@ class FolketrygdberegnetAfpResultMapperV1Test : FunSpec({
     test("toResultV1 converts virkFom to Norwegian noon") {
         val beregning = Beregning().apply { virkFom = dateAtNoon(2029, Calendar.JUNE, 15) }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)!!
@@ -95,7 +86,7 @@ class FolketrygdberegnetAfpResultMapperV1Test : FunSpec({
     test("toResultV1 sets virkFom to null when beregning virkFom is null") {
         val beregning = Beregning().apply { virkFom = null }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)!!
@@ -106,7 +97,7 @@ class FolketrygdberegnetAfpResultMapperV1Test : FunSpec({
     test("toResultV1 handles null tilleggspensjon") {
         val beregning = Beregning().apply { tp = null }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)!!
@@ -128,7 +119,7 @@ class FolketrygdberegnetAfpResultMapperV1Test : FunSpec({
             }
         }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)!!
@@ -150,7 +141,7 @@ class FolketrygdberegnetAfpResultMapperV1Test : FunSpec({
             }
         }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)!!
@@ -173,7 +164,7 @@ class FolketrygdberegnetAfpResultMapperV1Test : FunSpec({
             }
         }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)!!
@@ -189,7 +180,7 @@ class FolketrygdberegnetAfpResultMapperV1Test : FunSpec({
             st = null
         }
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)!!
@@ -202,7 +193,7 @@ class FolketrygdberegnetAfpResultMapperV1Test : FunSpec({
     test("toResultV1 uses default zero values for netto, tt_anv, and g on empty beregning") {
         val beregning = Beregning()
         val output = SimulatorOutput().apply {
-            pre2025OffentligAfp = Simuleringsresultat(beregning = beregning)
+            pre2025OffentligAfp = Simuleringsresultat().apply { this.beregning = beregning }
         }
 
         val result = FolketrygdberegnetAfpResultMapperV1.toResultV1(output)!!

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpSpecValidatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpSpecValidatorTest.kt
@@ -13,11 +13,12 @@ import no.nav.pensjon.simulator.core.domain.regler.simulering.Simulering
 import no.nav.pensjon.simulator.core.exception.PersonForUngException
 import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
 import no.nav.pensjon.simulator.validity.BadSpecException
+import java.time.LocalDate
 
 class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
 
     val normalder = Alder(aar = 67, maaneder = 0)
-    val dato = dateAtNoon(2025, 1, 1)
+    val dato = LocalDate.of(2025, 2, 1)
     val soeker = mutableListOf(PersonDetalj().apply { grunnlagsrolleEnum = GrunnlagsrolleEnum.SOKER })
 
     test("Manglende simuleringType skal forhindres med BadSpecException") {
@@ -26,7 +27,7 @@ class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
                 spec = Simulering().apply { simuleringTypeEnum = null },
                 normalder
             )
-        }.message shouldBe "Pre2025-AFP-spec mangler simuleringType"
+        }.message shouldBe "Spec for tidsbegrenset AFP mangler simuleringType"
     }
 
     test("Manglende uttaksdato skal forhindres med BadSpecException") {
@@ -34,11 +35,11 @@ class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
             Pre2025OffentligAfpSpecValidator.validateInput(
                 spec = Simulering().apply {
                     simuleringTypeEnum = SimuleringTypeEnum.ALDER
-                    uttaksdato = null
+                    uttaksdatoLd = null
                 },
                 normalder
             )
-        }.message shouldBe "Pre2025-AFP-spec mangler uttaksdato"
+        }.message shouldBe "Spec for tidsbegrenset AFP mangler uttaksdato"
     }
 
     test("AFP-simulering med manglende AFP-ordning skal forhindres med BadSpecException") {
@@ -46,12 +47,12 @@ class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
             Pre2025OffentligAfpSpecValidator.validateInput(
                 spec = Simulering().apply {
                     simuleringTypeEnum = SimuleringTypeEnum.AFP
-                    uttaksdato = dato
+                    uttaksdatoLd = dato
                     afpOrdningEnum = null
                 },
                 normalder
             )
-        }.message shouldBe "Pre2025-AFP-spec mangler AFP-ordning"
+        }.message shouldBe "Spec for tidsbegrenset AFP mangler AFP-ordning"
     }
 
     test("Manglende persongrunnlag skal forhindres med BadSpecException") {
@@ -59,12 +60,12 @@ class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
             Pre2025OffentligAfpSpecValidator.validateInput(
                 spec = Simulering().apply {
                     simuleringTypeEnum = SimuleringTypeEnum.ALDER
-                    uttaksdato = dato
+                    uttaksdatoLd = dato
                     persongrunnlagListe = mutableListOf()
                 },
                 normalder
             )
-        }.message shouldBe "Pre2025-AFP-spec mangler persongrunnlag for søker"
+        }.message shouldBe "Spec for tidsbegrenset AFP mangler persongrunnlag for søker"
     }
 
     test("Manglende persondetalj skal forhindres med BadSpecException") {
@@ -72,12 +73,12 @@ class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
             Pre2025OffentligAfpSpecValidator.validateInput(
                 spec = Simulering().apply {
                     simuleringTypeEnum = SimuleringTypeEnum.ALDER
-                    uttaksdato = dato
+                    uttaksdatoLd = dato
                     persongrunnlagListe = mutableListOf(Persongrunnlag().apply { personDetaljListe = mutableListOf() })
                 },
                 normalder
             )
-        }.message shouldBe "Pre2025-AFP-spec mangler persongrunnlag for søker"
+        }.message shouldBe "Spec for tidsbegrenset AFP mangler persongrunnlag for søker"
     }
 
     test("Manglende søker-persondetalj skal forhindres med BadSpecException") {
@@ -85,7 +86,7 @@ class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
             Pre2025OffentligAfpSpecValidator.validateInput(
                 spec = Simulering().apply {
                     simuleringTypeEnum = SimuleringTypeEnum.ALDER
-                    uttaksdato = dato
+                    uttaksdatoLd = dato
                     persongrunnlagListe = mutableListOf(Persongrunnlag().apply {
                         personDetaljListe =
                             mutableListOf(PersonDetalj().apply { grunnlagsrolleEnum = GrunnlagsrolleEnum.BARN })
@@ -93,7 +94,7 @@ class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
                 },
                 normalder
             )
-        }.message shouldBe "Pre2025-AFP-spec mangler persongrunnlag for søker"
+        }.message shouldBe "Spec for tidsbegrenset AFP mangler persongrunnlag for søker"
     }
 
     test("Alderspensjonsimulering med søker yngre enn normalder skal forhindres med PersonForUngException") {
@@ -101,7 +102,7 @@ class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
             Pre2025OffentligAfpSpecValidator.validateInput(
                 spec = Simulering().apply {
                     simuleringTypeEnum = SimuleringTypeEnum.ALDER
-                    uttaksdato = dateAtNoon(2025, 6, 1)
+                    uttaksdatoLd = LocalDate.of(2025, 7, 1)
                     persongrunnlagListe = mutableListOf(Persongrunnlag().apply {
                         fodselsdato = dateAtNoon(1958, 6, 15) // blir 67 år 2 måneder 2025-08-15 => for ung
                         personDetaljListe = soeker
@@ -118,7 +119,7 @@ class Pre2025OffentligAfpSpecValidatorTest : FunSpec({
                 spec = Simulering().apply {
                     simuleringTypeEnum = SimuleringTypeEnum.AFP
                     afpOrdningEnum = AFPtypeEnum.AFPSTAT
-                    uttaksdato = dateAtNoon(2025, 6, 1)
+                    uttaksdatoLd = LocalDate.of(2025, 7, 1)
                     persongrunnlagListe = mutableListOf(Persongrunnlag().apply {
                         fodselsdato = dateAtNoon(1963, 6, 15) // blir 62 år 2025-06-15 => for ung
                         personDetaljListe = soeker

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/api/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultMapperV0Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/api/acl/v0/result/AfpEtterfulgtAvAlderspensjonResultMapperV0Test.kt
@@ -14,8 +14,6 @@ import no.nav.pensjon.simulator.core.krav.UttakGradKode
 import no.nav.pensjon.simulator.core.result.*
 import no.nav.pensjon.simulator.core.spec.Pre2025OffentligAfpSpec
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
-import no.nav.pensjon.simulator.core.util.toNorwegianDate
-import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.person.Pid
 import java.time.LocalDate
 import kotlin.reflect.full.companionObject
@@ -143,7 +141,7 @@ private fun folketrygdberegnetAfp(
     val poengrekke = sluttpoengtall.poengrekke!!
 
     return FolketrygdberegnetAfpV0(
-        fraOgMedDato = tidsbegrensetOffentligAfp.virk!!.toNorwegianLocalDate(),
+        fraOgMedDato = tidsbegrensetOffentligAfp.virkLd!!,
         beregnetTidligereInntekt = poengrekke.tpi,
         sisteLignetInntektBrukt = false,
         sisteLignetInntektAar = null,
@@ -244,7 +242,7 @@ private fun pensjonsperiode(foersteUtbetalingFom: LocalDate) =
 
 private fun tidsbegrensetOffentligAfp(fom: LocalDate) =
     Simuleringsresultat().apply {
-        virk = fom.toNorwegianDate()
+        virkLd = fom
         beregning = Beregning().apply {
             g = 33
             gpAfpPensjonsregulert = Grunnpensjon().apply { brukt = true }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/person/PersongrunnlagServiceTest.kt
@@ -4,7 +4,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -12,7 +11,6 @@ import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagResult
 import no.nav.pensjon.simulator.beholdning.BeholdningerMedGrunnlagService
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
-import no.nav.pensjon.simulator.core.domain.regler.enum.GrunnlagsrolleEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.*
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
@@ -203,8 +201,10 @@ class PersongrunnlagServiceTest : FunSpec({
             hentBeholdninger = true
         )
 
-        persongrunnlag.beholdninger shouldHaveSize 1
-        (persongrunnlag.beholdninger[0] as Pensjonsbeholdning).totalbelop shouldBe 500000.0
+        with(persongrunnlag) {
+            beholdninger shouldHaveSize 1
+            beholdninger[0].totalbelop shouldBe 500000.0
+        }
     }
 
     test("addBeholdningerMedGrunnlagToPersongrunnlag should not add beholdninger when hentBeholdninger=false") {

--- a/src/test/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecCreatorTest.kt
@@ -12,7 +12,6 @@ import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.domain.regler.enum.*
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum.*
 import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableException
-import no.nav.pensjon.simulator.fpp.InvalidArgumentException
 import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.fpp.api.acl.v1.RelasjonTypeCodeV1
 import no.nav.pensjon.simulator.g.GrunnbeloepService
@@ -24,41 +23,6 @@ import no.nav.pensjon.simulator.tech.time.Time
 import java.time.LocalDate
 
 class FppSimuleringSpecCreatorTest : ShouldSpec({
-
-    val soekerPid = Pid("12345678901")
-    val epsPid = Pid("98765432101")
-    val foedselsdato = LocalDate.of(1960, 1, 15)
-    val uttaksdato = LocalDate.of(2027, 3, 1)
-    val grunnbeloep = 124028
-
-    fun arrangePersonService(
-        soekerPerson: Person = Person(
-            foedselsdato = foedselsdato,
-            sivilstand = Sivilstandstype.UGIFT,
-            statsborgerskap = LandkodeEnum.NOR
-        ),
-        epsFoedselsdato: LocalDate = LocalDate.of(1961, 5, 10),
-        epsPerson: Person = Person(
-            foedselsdato = epsFoedselsdato,
-            sivilstand = null,
-            statsborgerskap = LandkodeEnum.SWE
-        ),
-        borSammen: Boolean = false
-    ): GeneralPersonService =
-        mockk<GeneralPersonService>().apply {
-            every { person(soekerPid) } returns soekerPerson
-            every { person(epsPid) } returns epsPerson
-            every { foedselsdato(any()) } returns epsFoedselsdato
-            every { statsborgerskap(any()) } returns LandkodeEnum.NOR
-            every { borSammen(any()) } returns borSammen
-        }
-
-    fun arrangeGrunnbeloepService(): GrunnbeloepService =
-        mockk<GrunnbeloepService>().apply {
-            every { naavaerendeGrunnbeloep() } returns grunnbeloep
-        }
-
-    fun arrangeTime(today: LocalDate = LocalDate.of(2027, 1, 15)): Time = Time { today }
 
     fun creator(
         personService: GeneralPersonService = arrangePersonService(),
@@ -178,9 +142,11 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                 barneopplysninger = null
             )
 
-            result.simuleringTypeEnum shouldBe ALDER
-            result.uttaksdato shouldBe uttaksdato.toNorwegianDateAtNoon()
-            result.afpOrdningEnum.shouldBeNull()
+            with(result) {
+                simuleringTypeEnum shouldBe ALDER
+                uttaksdatoLd shouldBe uttaksdato
+                afpOrdningEnum.shouldBeNull()
+            }
         }
 
         should("opprette persongrunnlag for søker med korrekte verdier") {
@@ -196,16 +162,19 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
             )
 
             val soeker = result.persongrunnlagListe.first()
-            soeker.penPerson?.penPersonId shouldBe 1L
-            soeker.penPerson?.pid shouldBe soekerPid
-            soeker.fodselsdato shouldBe foedselsdato.toNorwegianDateAtNoon()
-            soeker.dodsdato.shouldBeNull()
-            soeker.antallArUtland shouldBe 5
-            soeker.flyktning shouldBe true
-            soeker.over60ArKanIkkeForsorgesSelv shouldBe false
-            soeker.dodAvYrkesskade shouldBe false
-            soeker.medlemIFolketrygdenSiste3Ar shouldBe true
-            soeker.statsborgerskapEnum shouldBe LandkodeEnum.NOR
+
+            with(soeker) {
+                penPerson?.penPersonId shouldBe 1L
+                penPerson?.pid shouldBe soekerPid
+                fodselsdato shouldBe foedselsdato.toNorwegianDateAtNoon()
+                dodsdato.shouldBeNull()
+                antallArUtland shouldBe 5
+                flyktning shouldBe true
+                over60ArKanIkkeForsorgesSelv shouldBe false
+                dodAvYrkesskade shouldBe false
+                medlemIFolketrygdenSiste3Ar shouldBe true
+                statsborgerskapEnum shouldBe LandkodeEnum.NOR
+            }
         }
 
         should("opprette persondetalj for søker med rolle SOKER og sivilstand fra personservice") {
@@ -226,10 +195,13 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
             )
 
             val personDetalj = result.persongrunnlagListe.first().personDetaljListe.first()
-            personDetalj.grunnlagsrolleEnum shouldBe GrunnlagsrolleEnum.SOKER
-            personDetalj.bruk shouldBe true
-            personDetalj.sivilstandTypeEnum shouldBe SivilstandEnum.UGIF
-            personDetalj.penRolleFom shouldBe foedselsdato.toNorwegianDateAtNoon()
+
+            with(personDetalj) {
+                grunnlagsrolleEnum shouldBe GrunnlagsrolleEnum.SOKER
+                bruk shouldBe true
+                sivilstandTypeEnum shouldBe SivilstandEnum.UGIF
+                penRolleFom shouldBe foedselsdato.toNorwegianDateAtNoon()
+            }
         }
 
         should("bruke mappet sivilstand fra personservice for diverse sivilstandstyper") {
@@ -267,13 +239,16 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
             )
 
             val grunnlag = result.persongrunnlagListe.first().opptjeningsgrunnlagListe
+
             grunnlag shouldHaveSize 1
-            grunnlag[0].opptjeningTypeEnum shouldBe OpptjeningtypeEnum.PPI
-            grunnlag[0].pi shouldBe 600000
-            grunnlag[0].pp shouldBe 5.0
-            grunnlag[0].ar shouldBe 2020
-            grunnlag[0].bruk shouldBe true
-            grunnlag[0].grunnlagKildeEnum shouldBe GrunnlagkildeEnum.SIMULERING
+            with(grunnlag[0]) {
+                opptjeningTypeEnum shouldBe OpptjeningtypeEnum.PPI
+                pi shouldBe 600000
+                pp shouldBe 5.0
+                ar shouldBe 2020
+                bruk shouldBe true
+                grunnlagKildeEnum shouldBe GrunnlagkildeEnum.SIMULERING
+            }
         }
 
         should("inkludere opptjeningsgrunnlag med OSFE når omsorgspoeng > 0") {
@@ -518,7 +493,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                 barneopplysninger = null
             )
 
-            result.persongrunnlagListe[1].inntektsgrunnlagListe.first().belop shouldBe grunnbeloep * 2 + 1
+            result.persongrunnlagListe[1].inntektsgrunnlagListe.first().belop shouldBe GRUNNBELOEP * 2 + 1
         }
 
         should("beregne EPS-beløp som G+1 når erEpsInntektOver1G er true") {
@@ -536,7 +511,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                 barneopplysninger = null
             )
 
-            result.persongrunnlagListe[1].inntektsgrunnlagListe.first().belop shouldBe grunnbeloep + 1
+            result.persongrunnlagListe[1].inntektsgrunnlagListe.first().belop shouldBe GRUNNBELOEP + 1
         }
 
         should("beregne EPS-beløp som 0 for SAMB uten tidligereGiftEllerBarnMedSamboer") {
@@ -1009,7 +984,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                 barneopplysninger = null
             )
 
-            result.persongrunnlagListe[1].inntektsgrunnlagListe.first().belop shouldBe grunnbeloep + 1
+            result.persongrunnlagListe[1].inntektsgrunnlagListe.first().belop shouldBe GRUNNBELOEP + 1
         }
 
         should("beregne EPS FPI-beløp som 0 når avdødInntektMinst1G er false") {
@@ -1074,13 +1049,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
     context("BARN simulering") {
         should("ikke inkludere EPS-persongrunnlag") {
             val morPid = Pid("22222222222")
-            val morPerson = Person(
-                foedselsdato = LocalDate.of(1970, 3, 10),
-                sivilstand = null,
-                statsborgerskap = LandkodeEnum.NOR
-            )
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
+            val personService = arrangeMor(morPid)
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
@@ -1114,13 +1083,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("sette antallArUtland til 0 for søker") {
             val morPid = Pid("22222222222")
-            val morPerson = Person(
-                foedselsdato = LocalDate.of(1970, 3, 10),
-                sivilstand = null,
-                statsborgerskap = LandkodeEnum.NOR
-            )
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
+            val personService = arrangeMor(morPid)
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
@@ -1145,13 +1108,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("bruke 2*G som søker-beløp når erUnderUtdanning er true") {
             val morPid = Pid("22222222222")
-            val morPerson = Person(
-                foedselsdato = LocalDate.of(1970, 3, 10),
-                sivilstand = null,
-                statsborgerskap = LandkodeEnum.NOR
-            )
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
+            val personService = arrangeMor(morPid)
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
@@ -1171,18 +1128,12 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                 barneopplysninger = null
             )
 
-            result.persongrunnlagListe.first().inntektsgrunnlagListe.first().belop shouldBe grunnbeloep * 2
+            result.persongrunnlagListe.first().inntektsgrunnlagListe.first().belop shouldBe GRUNNBELOEP * 2
         }
 
         should("bruke 0 som søker-beløp når erUnderUtdanning er false") {
             val morPid = Pid("22222222222")
-            val morPerson = Person(
-                foedselsdato = LocalDate.of(1970, 3, 10),
-                sivilstand = null,
-                statsborgerskap = LandkodeEnum.NOR
-            )
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
+            val personService = arrangeMor(morPid)
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
@@ -1207,13 +1158,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("sette tom opptjeningsgrunnlag for søker ved BARN") {
             val morPid = Pid("22222222222")
-            val morPerson = Person(
-                foedselsdato = LocalDate.of(1970, 3, 10),
-                sivilstand = null,
-                statsborgerskap = LandkodeEnum.NOR
-            )
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
+            val personService = arrangeMor(morPid)
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
@@ -1238,13 +1183,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
         should("opprette forelder-persongrunnlag med MOR-rolle") {
             val morPid = Pid("22222222222")
             val morFoedselsdato = LocalDate.of(1970, 3, 10)
-            val morPerson = Person(
-                foedselsdato = morFoedselsdato,
-                sivilstand = null,
-                statsborgerskap = LandkodeEnum.NOR
-            )
             val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
+            every { personService.person(morPid) } returns norskPerson(morFoedselsdato)
 
             val doedsdato = LocalDate.of(2026, 6, 15)
             val avdoed = avdoedData(
@@ -1288,13 +1228,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
         should("opprette forelder-persongrunnlag med FAR-rolle") {
             val farPid = Pid("33333333333")
             val farFoedselsdato = LocalDate.of(1968, 8, 20)
-            val farPerson = Person(
-                foedselsdato = farFoedselsdato,
-                sivilstand = null,
-                statsborgerskap = LandkodeEnum.SWE
-            )
             val personService = arrangePersonService()
-            every { personService.person(farPid) } returns farPerson
+            every { personService.person(farPid) } returns svenskPerson(farFoedselsdato)
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
@@ -1319,11 +1254,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
         should("opprette to forelder-persongrunnlag når begge foreldre er døde") {
             val morPid = Pid("22222222222")
             val farPid = Pid("33333333333")
-            val morPerson = Person(foedselsdato = LocalDate.of(1970, 3, 10), sivilstand = null, statsborgerskap = LandkodeEnum.NOR)
-            val farPerson = Person(foedselsdato = LocalDate.of(1968, 8, 20), sivilstand = null, statsborgerskap = LandkodeEnum.SWE)
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
-            every { personService.person(farPid) } returns farPerson
+            val personService = arrangeMor(morPid)
+            every { personService.person(farPid) } returns svenskPerson(LocalDate.of(1968, 8, 20))
 
             val avdoedMor = avdoedData(
                 relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
@@ -1363,9 +1295,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("ikke inkludere opptjeningsgrunnlag for forelder når kun én forelder er død") {
             val morPid = Pid("22222222222")
-            val morPerson = Person(foedselsdato = LocalDate.of(1970, 3, 10), sivilstand = null, statsborgerskap = LandkodeEnum.NOR)
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
+            val personService = arrangeMor(morPid)
 
             val avdoed = avdoedData(
                 relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
@@ -1388,9 +1318,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("sette yrkesskadegrunnlag for forelder når avdød døde av yrkesskade") {
             val morPid = Pid("22222222222")
-            val morPerson = Person(foedselsdato = LocalDate.of(1970, 3, 10), sivilstand = null, statsborgerskap = LandkodeEnum.NOR)
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
+            val personService = arrangeMor(morPid)
 
             val doedsdato = LocalDate.of(2026, 6, 15)
             val avdoed = avdoedData(
@@ -1419,11 +1347,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
             val morPid = Pid("22222222222")
             val soeskenPid = Pid("44444444444")
             val soeskenFoedselsdato = LocalDate.of(2010, 5, 20)
-            val morPerson = Person(foedselsdato = LocalDate.of(1970, 3, 10), sivilstand = null, statsborgerskap = LandkodeEnum.NOR)
-            val soeskenPerson = Person(foedselsdato = soeskenFoedselsdato, sivilstand = null, statsborgerskap = LandkodeEnum.NOR)
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
-            every { personService.person(soeskenPid) } returns soeskenPerson
+            val personService = arrangeMor(morPid)
+            every { personService.person(soeskenPid) } returns norskPerson(soeskenFoedselsdato)
 
             val avdoed = avdoedData(
                 relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
@@ -1471,11 +1396,10 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
         should("sette N_SOSKEN som borMedType for søsken ikke oppdratt sammen") {
             val morPid = Pid("22222222222")
             val soeskenPid = Pid("44444444444")
-            val morPerson = Person(foedselsdato = LocalDate.of(1970, 3, 10), sivilstand = null, statsborgerskap = LandkodeEnum.NOR)
-            val soeskenPerson = Person(foedselsdato = LocalDate.of(2012, 7, 1), sivilstand = null, statsborgerskap = LandkodeEnum.NOR)
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
-            every { personService.person(soeskenPid) } returns soeskenPerson
+            val personService = arrangePersonService().apply {
+                every { person(morPid) } returns mor()
+                every { person(soeskenPid) } returns norskPerson(LocalDate.of(2012, 7, 1))
+            }
 
             val avdoed = avdoedData(
                 relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
@@ -1505,9 +1429,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("ikke inkludere barn-persongrunnlag for BARN-simulering") {
             val morPid = Pid("22222222222")
-            val morPerson = Person(foedselsdato = LocalDate.of(1970, 3, 10), sivilstand = null, statsborgerskap = LandkodeEnum.NOR)
-            val personService = arrangePersonService()
-            every { personService.person(morPid) } returns morPerson
+            val personService = arrangeMor(morPid)
 
             val avdoed = avdoedData(
                 relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
@@ -1728,7 +1650,11 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
     context("sivilstand-mapping fra personservice") {
         should("mappe UOPPGITT til NULL") {
             val personService = arrangePersonService(
-                soekerPerson = Person(foedselsdato = foedselsdato, sivilstand = Sivilstandstype.UOPPGITT, statsborgerskap = LandkodeEnum.NOR)
+                soekerPerson = Person(
+                    foedselsdato = foedselsdato,
+                    sivilstand = Sivilstandstype.UOPPGITT,
+                    statsborgerskap = LandkodeEnum.NOR
+                )
             )
 
             val result = creator(personService = personService).createSpec(
@@ -1745,7 +1671,11 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("mappe SEPARERT til SEPR") {
             val personService = arrangePersonService(
-                soekerPerson = Person(foedselsdato = foedselsdato, sivilstand = Sivilstandstype.SEPARERT, statsborgerskap = LandkodeEnum.NOR)
+                soekerPerson = Person(
+                    foedselsdato = foedselsdato,
+                    sivilstand = Sivilstandstype.SEPARERT,
+                    statsborgerskap = LandkodeEnum.NOR
+                )
             )
 
             val result = creator(personService = personService).createSpec(
@@ -1762,7 +1692,11 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("mappe REGISTRERT_PARTNER til REPA") {
             val personService = arrangePersonService(
-                soekerPerson = Person(foedselsdato = foedselsdato, sivilstand = Sivilstandstype.REGISTRERT_PARTNER, statsborgerskap = LandkodeEnum.NOR)
+                soekerPerson = Person(
+                    foedselsdato = foedselsdato,
+                    sivilstand = Sivilstandstype.REGISTRERT_PARTNER,
+                    statsborgerskap = LandkodeEnum.NOR
+                )
             )
 
             val result = creator(personService = personService).createSpec(
@@ -1779,7 +1713,11 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("mappe SKILT til SKIL") {
             val personService = arrangePersonService(
-                soekerPerson = Person(foedselsdato = foedselsdato, sivilstand = Sivilstandstype.SKILT, statsborgerskap = LandkodeEnum.NOR)
+                soekerPerson = Person(
+                    foedselsdato = foedselsdato,
+                    sivilstand = Sivilstandstype.SKILT,
+                    statsborgerskap = LandkodeEnum.NOR
+                )
             )
 
             val result = creator(personService = personService).createSpec(
@@ -1796,7 +1734,11 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("mappe SEPARERT_PARTNER til SEPA") {
             val personService = arrangePersonService(
-                soekerPerson = Person(foedselsdato = foedselsdato, sivilstand = Sivilstandstype.SEPARERT_PARTNER, statsborgerskap = LandkodeEnum.NOR)
+                soekerPerson = Person(
+                    foedselsdato = foedselsdato,
+                    sivilstand = Sivilstandstype.SEPARERT_PARTNER,
+                    statsborgerskap = LandkodeEnum.NOR
+                )
             )
 
             val result = creator(personService = personService).createSpec(
@@ -1813,7 +1755,11 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("mappe SKILT_PARTNER til SKPA") {
             val personService = arrangePersonService(
-                soekerPerson = Person(foedselsdato = foedselsdato, sivilstand = Sivilstandstype.SKILT_PARTNER, statsborgerskap = LandkodeEnum.NOR)
+                soekerPerson = Person(
+                    foedselsdato = foedselsdato,
+                    sivilstand = Sivilstandstype.SKILT_PARTNER,
+                    statsborgerskap = LandkodeEnum.NOR
+                )
             )
 
             val result = creator(personService = personService).createSpec(
@@ -1830,7 +1776,11 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("mappe GJENLEVENDE_PARTNER til GJPA") {
             val personService = arrangePersonService(
-                soekerPerson = Person(foedselsdato = foedselsdato, sivilstand = Sivilstandstype.GJENLEVENDE_PARTNER, statsborgerskap = LandkodeEnum.NOR)
+                soekerPerson = Person(
+                    foedselsdato = foedselsdato,
+                    sivilstand = Sivilstandstype.GJENLEVENDE_PARTNER,
+                    statsborgerskap = LandkodeEnum.NOR
+                )
             )
 
             val result = creator(personService = personService).createSpec(
@@ -1847,7 +1797,11 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
         should("mappe GIFT til null (ubehandlet i mapSivilstand)") {
             val personService = arrangePersonService(
-                soekerPerson = Person(foedselsdato = foedselsdato, sivilstand = Sivilstandstype.GIFT, statsborgerskap = LandkodeEnum.NOR)
+                soekerPerson = Person(
+                    foedselsdato = foedselsdato,
+                    sivilstand = Sivilstandstype.GIFT,
+                    statsborgerskap = LandkodeEnum.NOR
+                )
             )
 
             val result = creator(personService = personService).createSpec(
@@ -2015,3 +1969,48 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
         }
     }
 })
+
+private const val GRUNNBELOEP = 124028
+private val soekerPid = Pid("12345678901")
+private val epsPid = Pid("98765432101")
+private val foedselsdato = LocalDate.of(1960, 1, 15)
+private val uttaksdato = LocalDate.of(2027, 3, 1)
+
+private fun arrangeGrunnbeloepService(): GrunnbeloepService =
+    mockk<GrunnbeloepService>().apply {
+        every { naavaerendeGrunnbeloep() } returns GRUNNBELOEP
+    }
+
+private fun arrangeTime(today: LocalDate = LocalDate.of(2027, 1, 15)): Time =
+    Time { today }
+
+private fun arrangePersonService(
+    soekerPerson: Person = Person(
+        foedselsdato = foedselsdato,
+        sivilstand = Sivilstandstype.UGIFT,
+        statsborgerskap = LandkodeEnum.NOR
+    ),
+    epsFoedselsdato: LocalDate = LocalDate.of(1961, 5, 10),
+    borSammen: Boolean = false
+): GeneralPersonService =
+    mockk<GeneralPersonService>().apply {
+        every { person(soekerPid) } returns soekerPerson
+        every { person(epsPid) } returns svenskPerson(epsFoedselsdato)
+        every { foedselsdato(any()) } returns epsFoedselsdato
+        every { statsborgerskap(any()) } returns LandkodeEnum.NOR
+        every { borSammen(any()) } returns borSammen
+    }
+
+private fun arrangeMor(pid: Pid): GeneralPersonService =
+    arrangePersonService().apply {
+        every { person(pid) } returns mor()
+    }
+
+private fun mor() =
+    norskPerson(foedselsdato = LocalDate.of(1970, 3, 10))
+
+private fun norskPerson(foedselsdato: LocalDate?) =
+    Person(foedselsdato, sivilstand = null, statsborgerskap = LandkodeEnum.NOR)
+
+private fun svenskPerson(foedselsdato: LocalDate?) =
+    Person(foedselsdato, sivilstand = null, statsborgerskap = LandkodeEnum.SWE)

--- a/src/test/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecValidatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecValidatorTest.kt
@@ -13,7 +13,6 @@ import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableExcept
 import no.nav.pensjon.simulator.core.exception.PersonForUngException
 import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import java.time.LocalDate
-import java.util.Date
 
 class FppSimuleringSpecValidatorTest : ShouldSpec({
 
@@ -27,7 +26,7 @@ class FppSimuleringSpecValidatorTest : ShouldSpec({
         shouldThrow<ImplementationUnrecoverableException> {
             FppSimuleringSpecValidator.validate(spec = Simulering().apply {
                 simuleringTypeEnum = SimuleringTypeEnum.GJENLEVENDE
-                uttaksdato = null
+                uttaksdatoLd = null
             })
         }.message shouldBe "simulering.uttaksdato"
     }
@@ -36,7 +35,7 @@ class FppSimuleringSpecValidatorTest : ShouldSpec({
         shouldThrow<ImplementationUnrecoverableException> {
             FppSimuleringSpecValidator.validate(spec = Simulering().apply {
                 simuleringTypeEnum = SimuleringTypeEnum.AFP
-                uttaksdato = uttaksdato()
+                uttaksdatoLd = uttaksdato()
                 afpOrdningEnum = null
             })
         }.message shouldBe "simulering.afpordning"
@@ -46,7 +45,7 @@ class FppSimuleringSpecValidatorTest : ShouldSpec({
         shouldThrow<ImplementationUnrecoverableException> {
             FppSimuleringSpecValidator.validate(spec = Simulering().apply {
                 simuleringTypeEnum = SimuleringTypeEnum.ALDER_M_GJEN
-                uttaksdato = uttaksdato()
+                uttaksdatoLd = uttaksdato()
                 persongrunnlagListe = emptyList()
             })
         }.message shouldBe "simulering.persongrunnlagListe"
@@ -56,7 +55,7 @@ class FppSimuleringSpecValidatorTest : ShouldSpec({
         shouldThrow<ImplementationUnrecoverableException> {
             FppSimuleringSpecValidator.validate(spec = Simulering().apply {
                 simuleringTypeEnum = SimuleringTypeEnum.ALDER_M_GJEN
-                uttaksdato = uttaksdato()
+                uttaksdatoLd = uttaksdato()
                 persongrunnlagListe = listOf(Persongrunnlag().apply { personDetaljListe = mutableListOf() })
             })
         }.message shouldBe "simulering.persongrunnlagListe.persondetaljliste"
@@ -66,7 +65,7 @@ class FppSimuleringSpecValidatorTest : ShouldSpec({
         shouldThrow<ImplementationUnrecoverableException> {
             FppSimuleringSpecValidator.validate(spec = Simulering().apply {
                 simuleringTypeEnum = SimuleringTypeEnum.ALDER
-                uttaksdato = uttaksdato()
+                uttaksdatoLd = uttaksdato()
                 persongrunnlagListe = soekergrunnlag(foedselsaar = null)
             })
         }.message shouldBe "simulering.persongrunnlagListe.soeker.fodselsdato"
@@ -77,7 +76,7 @@ class FppSimuleringSpecValidatorTest : ShouldSpec({
             FppSimuleringSpecValidator.validate(spec = Simulering().apply {
                 simuleringTypeEnum = SimuleringTypeEnum.AFP
                 afpOrdningEnum = AFPtypeEnum.AFPSTAT
-                uttaksdato = uttaksdato(aar = 2025)
+                uttaksdatoLd = uttaksdato(aar = 2025)
                 persongrunnlagListe = soekergrunnlag(foedselsaar = 1964) // 61 år i 2025
             })
         }.message shouldBe "AFP 62"
@@ -87,7 +86,7 @@ class FppSimuleringSpecValidatorTest : ShouldSpec({
         shouldThrow<PersonForUngException> {
             FppSimuleringSpecValidator.validate(spec = Simulering().apply {
                 simuleringTypeEnum = SimuleringTypeEnum.ALDER
-                uttaksdato = uttaksdato(aar = 2020)
+                uttaksdatoLd = uttaksdato(aar = 2020)
                 persongrunnlagListe = soekergrunnlag(foedselsaar = 1954) // 66 år i 2020
 
             })
@@ -95,8 +94,8 @@ class FppSimuleringSpecValidatorTest : ShouldSpec({
     }
 })
 
-private fun uttaksdato(aar: Int = 2026): Date =
-    LocalDate.of(aar, 1, 1).toNorwegianDateAtNoon()
+private fun uttaksdato(aar: Int = 2026) =
+    LocalDate.of(aar, 1, 1)
 
 private fun soekergrunnlag(foedselsaar: Int?): List<Persongrunnlag> =
     listOf(


### PR DESCRIPTION
Bakgrunn: pensjon-regler-api støtter nå datoer i form av `LocalDate` (feltene har suffix "Ld" for å skille dem fra de gamle `Date`-feltene).

Denne PR bytter ut `Date` med `LocalDate` i `SimuleringRequest` og `Simuleringsresultat`.

Pluss noe refaktorering.