### PR TITLE
TPP-230 Use LocalDate in AbstraktBeregningsResultat

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorCore.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorCore.kt
@@ -26,7 +26,6 @@ import no.nav.pensjon.simulator.core.result.SimulatorOutput
 import no.nav.pensjon.simulator.core.result.SimuleringResultPreparer
 import no.nav.pensjon.simulator.core.spec.InnvilgetLivsvarigOffentligAfpSpec
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
-import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDatoCombo
 import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDatoRepopulator
 import no.nav.pensjon.simulator.core.ytelse.LoependeYtelser
@@ -160,7 +159,7 @@ class SimulatorCore(
                 soekerVirkningFom = ytelser.soekerVirkningFom,
                 avdoedVirkningFom = ytelser.avdoed?.foersteVirkningsdato,
                 forrigeAlderspensjonBeregningResultatVirkningFom =
-                    ytelser.forrigeAlderspensjonBeregningResultat?.virkFom?.toNorwegianLocalDate(),
+                    ytelser.forrigeAlderspensjonBeregningResultat?.virkFomLd,
                 sakId = kravhode.sakId
             )
         )

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2011SisteBeregningCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2011SisteBeregningCreator.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.simulator.core.beregn
 
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 import no.nav.pensjon.simulator.core.domain.reglerextend.beregning2011.copy
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.krav.KravService
 import org.springframework.stereotype.Component
 
@@ -30,7 +31,7 @@ class Alderspensjon2011SisteBeregningCreator(kravService: KravService) : SisteBe
         source: BeregningsResultatAlderspensjon2011,
         sink: SisteAldersberegning2011
     ) {
-        source.virkFom?.let { sink.virkDato = it }
+        source.virkFomLd?.let { sink.virkDato = it.toNorwegianDateAtNoon() }
         source.benyttetSivilstandEnum?.let { sink.benyttetSivilstandEnum = it }
         source.pensjonUnderUtbetaling?.let { sink.pensjonUnderUtbetaling = utenIrrelevanteYtelseskomponenter(it) }
         source.beregningKapittel19?.tt_anv?.let { sink.tt_anv = it }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2016SisteBeregningCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2016SisteBeregningCreator.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.simulator.core.beregn
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 import no.nav.pensjon.simulator.core.domain.regler.enum.BorMedTypeEnum
 import no.nav.pensjon.simulator.core.domain.reglerextend.beregning2011.copy
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.krav.KravService
 import org.springframework.stereotype.Component
 
@@ -55,7 +56,7 @@ class Alderspensjon2016SisteBeregningCreator(kravService: KravService) : SisteBe
             sink.resultatTypeEnum = beregningKapittel19?.resultatTypeEnum ?: it.resultatTypeEnum
         }
 
-        sink.virkDato = source.virkFom
+        sink.virkDato = source.virkFomLd?.toNorwegianDateAtNoon()
 
         resultat2011?.pensjonUnderUtbetalingUtenGJR?.let {
             sink.pensjonUnderUtbetaling2011UtenGJR = utenIrrelevanteYtelseskomponenter(it)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2025SisteBeregningCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2025SisteBeregningCreator.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.simulator.core.beregn
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsResultatAlderspensjon2025
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.SisteAldersberegning2011
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.krav.KravService
 import org.springframework.stereotype.Component
 
@@ -28,7 +29,7 @@ class Alderspensjon2025SisteBeregningCreator(kravService: KravService) : SisteBe
         source: BeregningsResultatAlderspensjon2025,
         sink: SisteAldersberegning2011
     ) {
-        source.virkFom?.let { sink.virkDato = it }
+        source.virkFomLd?.let { sink.virkDato = it.toNorwegianDateAtNoon() }
         source.benyttetSivilstandEnum?.let { sink.benyttetSivilstandEnum = it }
         source.pensjonUnderUtbetaling?.let { sink.pensjonUnderUtbetaling = utenIrrelevanteYtelseskomponenter(it) }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonBeregner.kt
@@ -204,8 +204,8 @@ class AlderspensjonBeregner(private val context: SimulatorContext) {
                 kravhode = spec.kravhode
                 vilkarsvedtakListe = spec.vilkarsvedtakListe
                 infoPavirkendeYtelse = spec.infoPavirkendeYtelse
-                virkFom = spec.virkFom?.toNorwegianDateAtNoon()
-                virkTom = null // set to null in legacy SimuleringEtter2011Context.beregnAlderspensjon2011ForsteUttak
+                virkFomLd = spec.virkFom
+                virkTomLd = null // set to null in legacy SimuleringEtter2011Context.beregnAlderspensjon2011ForsteUttak
                 ektefellenMottarPensjon = spec.epsMottarPensjon
                 afpPrivatLivsvarig = spec.privatAfp
             }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregner.kt
@@ -258,7 +258,7 @@ class AlderspensjonVilkaarsproeverOgBeregner(
                         beregningResultat.beregningsResultat2025!!.beregningKapittel20!!.beholdningerForForsteuttak!!
                     pensjonBeholdningPeriodeListe.add(
                         beholdningPeriode(
-                            virkningFom = beregningResultat.virkFom!!.toNorwegianLocalDate(),
+                            virkningFom = beregningResultat.virkFomLd!!,
                             beholdninger,
                             foedselsdato
                         )
@@ -267,7 +267,7 @@ class AlderspensjonVilkaarsproeverOgBeregner(
                     val beholdninger = beregningResultat.beregningKapittel20!!.beholdningerForForsteuttak!!
                     pensjonBeholdningPeriodeListe.add(
                         beholdningPeriode(
-                            virkningFom = beregningResultat.virkFom!!.toNorwegianLocalDate(),
+                            virkningFom = beregningResultat.virkFomLd!!,
                             beholdninger,
                             foedselsdato
                         )
@@ -512,7 +512,7 @@ class AlderspensjonVilkaarsproeverOgBeregner(
         }
 
         private fun findValidForDate(list: MutableList<BeregningsResultatAfpPrivat>, date: LocalDate) =
-            list.firstOrNull { isDateInPeriod(date, it.virkFom, it.virkTom) }
+            list.firstOrNull { isDateInPeriod(date, it.virkFomLd?.toNorwegianDateAtNoon(), it.virkTom) }
 
         private fun periodiserGrunnlag(kravhode: Kravhode): Kravhode {
             kravhode.persongrunnlagListe.forEach { periodiserDetaljer(it.personDetaljListe) }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreator.kt
@@ -7,6 +7,7 @@ import no.nav.pensjon.simulator.core.domain.regler.enum.RegelverkTypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.VedtakResultatEnum
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
+import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableException
 import no.nav.pensjon.simulator.core.krav.KravlinjeStatus
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isAfterByDay
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.isBeforeByDay
@@ -70,7 +71,7 @@ class SisteBeregningCreator(
         return kravId?.let {
             periodiserGrunnlag(
                 kravhode = kravService.fetchKravhode(it),
-                fom = beregningsresultat.virkFom?.toNorwegianLocalDate(),
+                fom = beregningsresultat.virkFomLd,
                 tom = beregningsresultat.virkTom?.toNorwegianLocalDate()
             )
         }
@@ -126,7 +127,7 @@ class SisteBeregningCreator(
                     beregningsresultat = beregningResultat,
                     vilkarsvedtakListe = vedtakListe,
                     regelverk1967VirkToEarly = etterRegulering,
-                    fomDato = if (etterRegulering) null else beregning.virkFom?.toNorwegianLocalDate(),
+                    fomDato = if (etterRegulering) null else beregning.virkFomLd,
                     tomDato = if (etterRegulering) null else beregning.virkTom?.toNorwegianLocalDate(),
                     filtrertVilkarsvedtakList = emptyList(),
                     forrigeKravhode = null,
@@ -135,9 +136,8 @@ class SisteBeregningCreator(
             }
 
             val filtrertVedtakListe: List<VilkarsVedtak> =
-                beregningResultat?.virkFom?.let { filtrerVedtak(it, beregningResultat.virkTom, vedtakListe) }
-                //?: throw ImplementationUnrecoverableException("Missing beregningsresultat.virkFom")
-                    ?: throw RuntimeException("Missing beregningsresultat.virkFom")
+                beregningResultat?.virkFomLd?.let { filtrerVedtak(it, beregningResultat.virkTom, vedtakListe) }
+                    ?: throw ImplementationUnrecoverableException("Missing beregningsresultat.virkFom")
 
             return SisteBeregningSpec(
                 isRegelverk1967 = false,
@@ -145,7 +145,7 @@ class SisteBeregningCreator(
                 beregning = beregning,
                 beregningsresultat = beregningResultat,
                 vilkarsvedtakListe = vedtakListe,
-                fomDato = beregningResultat.virkFom?.toNorwegianLocalDate(),
+                fomDato = beregningResultat.virkFomLd!!,
                 tomDato = beregningResultat.virkTom?.toNorwegianLocalDate(),
                 filtrertVilkarsvedtakList = filtrertVedtakListe,
                 forrigeKravhode = null,
@@ -155,7 +155,7 @@ class SisteBeregningCreator(
 
         // SimpleBeregningService.filtrerVilkarsvedtak
         // -> FiltrerVilkarsvedtakCommand.execute
-        private fun filtrerVedtak(fom: Date, tom: Date?, vedtakListe: List<VilkarsVedtak>): List<VilkarsVedtak> =
+        private fun filtrerVedtak(fom: LocalDate, tom: Date?, vedtakListe: List<VilkarsVedtak>): List<VilkarsVedtak> =
             vedtakListe.filter {
                 isInnvilget(it.vilkarsvedtakResultatEnum)
                         && isVilkarsprovdOrFerdig(it.kravlinje)
@@ -177,7 +177,7 @@ class SisteBeregningCreator(
             LandkodeEnum.NOR == kravlinje?.land
 
         // FiltrerVilkarsvedtakCommand.isVirkFomBeforeFomDate
-        private fun isVirkFomBeforeDate(virkFom: Date?, date: Date): Boolean =
+        private fun isVirkFomBeforeDate(virkFom: Date?, date: LocalDate): Boolean =
             isBeforeByDay(virkFom, date, true)
 
         // FiltrerVilkarsvedtakCommand.isVirkTomAfterTomDate

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreatorBase.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreatorBase.kt
@@ -9,7 +9,6 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
-import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.krav.KravService
 
 // AbstraktOpprettSisteAldersberegning, OpprettSisteAldersberegningCommon, OpprettSisteBeregningCommand
@@ -114,7 +113,7 @@ abstract class SisteBeregningCreatorBase(private val kravService: KravService) {
         val periodisertKravhode: Kravhode? =
             kravhode?.let {
                 periodiserGrunnlag(
-                    virkningFom = beregningResultat.virkFom?.toNorwegianLocalDate(),
+                    virkningFom = beregningResultat.virkFomLd,
                     virkningTom = null,
                     originalKravhode = it,
                     periodiserFomTomDatoUtenUnntak = true,

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/AbstraktBeregningsResultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/AbstraktBeregningsResultat.kt
@@ -6,9 +6,10 @@ import no.nav.pensjon.simulator.core.domain.regler.Merknad
 import no.nav.pensjon.simulator.core.domain.regler.enum.Beregningsarsak
 import no.nav.pensjon.simulator.core.domain.regler.enum.BorMedTypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SivilstandEnum
+import java.time.LocalDate
 import java.util.*
 
-// 2025-03-10
+// 2026-04-10
 @JsonSubTypes(
     JsonSubTypes.Type(value = BeregningsresultatUforetrygd::class),
     JsonSubTypes.Type(value = BeregningsResultatAlderspensjon2016::class),
@@ -18,7 +19,7 @@ import java.util.*
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 abstract class AbstraktBeregningsResultat {
-    var virkFom: Date? = null
+    var virkFomLd: LocalDate? = null
     var pensjonUnderUtbetaling: PensjonUnderUtbetaling? = null
     var uttaksgrad = 0
 
@@ -33,10 +34,12 @@ abstract class AbstraktBeregningsResultat {
     var gjennomsnittligUttaksgradSisteAr = 0.0
 
     //--- Extra:
-
     // from PEN no.nav.domain.pensjon.kjerne.beregning2011.BeregningHoveddel
+    // Dette er felter som ikke returneres av pensjon-regler, men som returneres av pensjon-pen:
     var kravId: Long? = null
+    @Deprecated("Use virkTomLd instead")
     var virkTom: Date? = null
+    var virkTomLd: LocalDate? = null
     var beregningsinformasjon: SpecialBeregningInformasjon? = null
     var epsMottarPensjon: Boolean = false // deprecated; use beregningInformasjon
     var epsPaavirkerBeregning: Boolean = false // deprecated
@@ -50,7 +53,7 @@ abstract class AbstraktBeregningsResultat {
     protected constructor() : super()
 
     override fun toString(): String =
-        "virk: $virkFom-$virkTom, pensjonUnderUtbetaling: [$pensjonUnderUtbetaling]"
+        "virk: $virkFomLd-$virkTom, pensjonUnderUtbetaling: [$pensjonUnderUtbetaling]"
 
     // end extra
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/LonnsvekstInformasjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/LonnsvekstInformasjon.kt
@@ -1,10 +1,10 @@
 package no.nav.pensjon.simulator.core.domain.regler.beregning2011
 
-import java.util.Date
+import java.time.LocalDate
 
-// 2025-03-23
+// 2026-04-10
 class LonnsvekstInformasjon {
     var lonnsvekst = 0.0
-    var reguleringsDato: Date? = null
+    var reguleringsDatoLd: LocalDate? = null
     var uttaksgradVedRegulering = 0
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2011ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2011ForsteUttakRequest.kt
@@ -4,15 +4,16 @@ import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AfpPrivatLivsva
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.InfoPavirkendeYtelse
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
+import java.time.LocalDate
 import java.util.*
 
-// 2025-06-13
+// 2026-04-10
 class BeregnAlderspensjon2011ForsteUttakRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()
     var infoPavirkendeYtelse: InfoPavirkendeYtelse? = null
-    var virkFom: Date? = null
-    var virkTom: Date? = null
+    var virkFomLd: LocalDate? = null
+    var virkTomLd: LocalDate? = null
     var ektefellenMottarPensjon = false
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2011ForsteUttakResponse.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2011ForsteUttakResponse.kt
@@ -2,8 +2,8 @@ package no.nav.pensjon.simulator.core.domain.regler.to
 
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsResultatAlderspensjon2011
 
+// 2026-04-10
 class BeregnAlderspensjon2011ForsteUttakResponse : ServiceResponse() {
-
     var beregningsResultat: BeregningsResultatAlderspensjon2011? = null
     var beregningsresultatTilRevurdering: BeregningsResultatAlderspensjon2011? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/reglerextend/beregning2011/Beregning2011Extension.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/reglerextend/beregning2011/Beregning2011Extension.kt
@@ -390,7 +390,7 @@ fun LonnsvekstDetaljer.copy() =
 fun LonnsvekstInformasjon.copy() =
     LonnsvekstInformasjon().also {
         it.lonnsvekst = this.lonnsvekst
-        it.reguleringsDato = this.reguleringsDato?.copy()
+        it.reguleringsDatoLd = this.reguleringsDatoLd
         it.uttaksgradVedRegulering = this.uttaksgradVedRegulering
     }
 
@@ -615,7 +615,7 @@ private fun copyBeregningsgrunnlag(source: AbstraktBeregningsgrunnlag, target: A
 }
 
 private fun copyBeregningsResultat(source: AbstraktBeregningsResultat, target: AbstraktBeregningsResultat) {
-    target.virkFom = source.virkFom?.copy()
+    target.virkFomLd = source.virkFomLd
     target.virkTom = source.virkTom?.copy()
     target.merknadListe = source.merknadListe.map { o -> o.copy() }.toMutableList()
     target.pensjonUnderUtbetaling = source.pensjonUnderUtbetaling?.let(::PensjonUnderUtbetaling)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/legacy/util/DateUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/legacy/util/DateUtil.kt
@@ -193,6 +193,12 @@ object DateUtil {
     fun isDateInPeriod(dato: LocalDate?, fom: Date?, tom: Date?): Boolean =
         isDateInPeriod(dato?.toNorwegianDateAtNoon(), fom, tom)
 
+    fun isDateInPeriod(dato: Date?, fom: LocalDate?, tom: Date?): Boolean =
+        isDateInPeriod(dato, fom?.toNorwegianDateAtNoon(), tom)
+
+    fun isDateInPeriod(dato: LocalDate?, fom: LocalDate?, tom: Date?): Boolean =
+        isDateInPeriod(dato?.toNorwegianDateAtNoon(), fom?.toNorwegianDateAtNoon(), tom)
+
     /**
      * Returns true if the dates are the same day.
      * Hours, minutes, seconds and milliseconds are not regarded.

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutputMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutputMapper.kt
@@ -380,7 +380,7 @@ object SimulatorOutputMapper {
 
     // From PeriodisertInformasjonUtils
     private fun isValidForDate(element: AbstraktBeregningsResultat, date: LocalDate) =
-        isDateInPeriod(date, element.virkFom, element.virkTom)
+        isDateInPeriod(date, element.virkFomLd, element.virkTom)
 
     // From ArligInformasjonListeUtils
     private fun containsValidForstegangstjenestePeriodeForAr(list: List<ForstegangstjenestePeriode>, year: Int) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimuleringResultPreparer.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/result/SimuleringResultPreparer.kt
@@ -17,7 +17,6 @@ import no.nav.pensjon.simulator.core.legacy.util.DateUtil.calculateAgeInYears
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.firstDayOfMonthAfterUserTurnsGivenAge
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getFirstDateInYear
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getLastDayOfMonth
-import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getRelativeDateByDays
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getRelativeDateByYear
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.getYear
 import no.nav.pensjon.simulator.core.legacy.util.DateUtil.intersects
@@ -142,7 +141,7 @@ class SimuleringResultPreparer(
                     maanedsutbetalinger = listOf(
                         Maanedsutbetaling(
                             beloep = maanedsbeloepVedPeriodeStart,
-                            fom = it.virkFom!!.toNorwegianLocalDate()
+                            fom = it.virkFomLd!!
                         )
                     )
                 )
@@ -402,8 +401,8 @@ class SimuleringResultPreparer(
         val alderToday: Int = calculateAgeInYears(foedselsdato, time.today())
 
         return copy(beregningResultat).apply {
-            virkFom = firstDayOfMonthAfterUserTurnsGivenAge(foedselsdato, alderToday)
-            virkTom = dayBefore(earliestVirkningFom(resultatListe))
+            virkFomLd = firstDayOfMonthAfterUserTurnsGivenAge(foedselsdato, alderToday).toNorwegianLocalDate()
+            virkTom = earliestVirkningFom(resultatListe)?.minusDays(1)?.toNorwegianDateAtNoon()
             removeEktefelleAndBarnetilleggFromTotalbeloep(this)
         }
     }
@@ -418,8 +417,8 @@ class SimuleringResultPreparer(
 
         // Make a copy in order to preserve the original beregningResultat:
         return beregningResultat.copy().apply {
-            virkFom = firstDayOfMonthAfterUserTurnsGivenAge(foedselsdato, alderToday)
-            virkTom = if (resultatListe.isEmpty()) null else dayBefore(earliestVirkningFom(resultatListe))
+            virkFomLd = firstDayOfMonthAfterUserTurnsGivenAge(foedselsdato, alderToday).toNorwegianLocalDate()
+            virkTom = if (resultatListe.isEmpty()) null else earliestVirkningFom(resultatListe)?.minusDays(1)?.toNorwegianDateAtNoon()
         }
     }
 
@@ -503,7 +502,7 @@ class SimuleringResultPreparer(
             var beloep = 0
             val maanedsutbetalinger = mutableListOf<Maanedsutbetaling>()
             for (resultat in resultatListe) {
-                val fom: Date = resultat.virkFom!!.toNorwegianNoon()
+                val fom: Date = resultat.virkFomLd!!.toNorwegianDateAtNoon()
                 val tom: Date = resultat.virkTom?.toNorwegianNoon() ?: ETERNITY
 
                 if (intersects(periodeStart, periodeSlutt, fom, tom, true)) {
@@ -512,7 +511,7 @@ class SimuleringResultPreparer(
                     maanedsutbetalinger.add(
                         Maanedsutbetaling(
                             resultat.pensjonUnderUtbetaling?.totalbelopNetto ?: 0,
-                            resultat.virkFom!!.toNorwegianLocalDate()
+                            resultat.virkFomLd!!
                         )
                     )
                 }
@@ -521,8 +520,8 @@ class SimuleringResultPreparer(
             return BeloepPeriode(beloep, periodeStart, periodeSlutt, maanedsutbetalinger)
         }
 
-        private fun earliestVirkningFom(resultater: List<AbstraktBeregningsResultat>): Date? =
-            PeriodeUtil.findEarliest(resultater)?.virkFom
+        private fun earliestVirkningFom(resultater: List<AbstraktBeregningsResultat>): LocalDate? =
+            PeriodeUtil.findEarliest(resultater)?.virkFomLd
 
         // OpprettOutputHelper.getBelop
         private fun getBeloep(
@@ -660,7 +659,7 @@ class SimuleringResultPreparer(
             forrigeResultat: AbstraktBeregningsResultat?,
             beregningResultat: AbstraktBeregningsResultat
         ): Pensjonsbeholdning? {
-            val dagenFoerBeregningsresultatVirkFom = getRelativeDateByDays(beregningResultat.virkFom!!, -1)
+            val dagenFoerBeregningsresultatVirkFom = beregningResultat.virkFomLd!!.minusDays(1).toNorwegianDateAtNoon()
             val forrigeResultatMedBeholdning =
                 findForrigeBeregningsresultatMedBeholdning(
                     forrigeResultat,
@@ -674,8 +673,6 @@ class SimuleringResultPreparer(
                 forrigeResultatMedBeholdning
             )
         }
-
-        private fun dayBefore(earliestVirkningFom: Date?): Date = getRelativeDateByDays(earliestVirkningFom!!, -1)
 
         private fun findForrigeBeregningsresultatMedBeholdning(
             forrigeResultat: AbstraktBeregningsResultat?,
@@ -771,9 +768,11 @@ class SimuleringResultPreparer(
             var earliestDate: Date? = ETERNITY
 
             for (element in list) {
-                if (intersectsWithPossiblyOpenEndings(startDate, endDate, element.virkFom, element.virkTom, true)) {
-                    if (isBeforeByDay(element.virkFom, earliestDate, false)) {
-                        earliestDate = element.virkFom
+                val virkFom = element.virkFomLd?.toNorwegianDateAtNoon()
+
+                if (intersectsWithPossiblyOpenEndings(startDate, endDate, virkFom, element.virkTom, true)) {
+                    if (isBeforeByDay(virkFom, earliestDate, false)) {
+                        earliestDate = virkFom
                         result = element
                     }
                 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/util/PeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/util/PeriodeUtil.kt
@@ -58,14 +58,6 @@ object PeriodeUtil {
     fun findValidForDate(list: List<AbstraktBeregningsResultat>, date: LocalDate): AbstraktBeregningsResultat? =
         list.firstOrNull { isValidForDate(it, date.toNorwegianDateAtNoon()) }
 
-    // PeriodisertInformasjonListeUtils.findValidForDate
-    fun findValidForDate(list: List<Pensjonsbeholdning>, date: Date): Pensjonsbeholdning? =
-        list.firstOrNull { isValidForDate(it, date) }
-
-    // PeriodisertInformasjonListeUtils.findAllValidForDate
-    fun findAllValidForDate(list: List<VilkarsVedtak>, date: Date): List<VilkarsVedtak> =
-        list.filter { isValidForDate(it, date) }
-
     // PeriodisertInformasjonListeUtils.findEarliest
     fun findEarliest(list: List<AbstraktBeregningsResultat>): AbstraktBeregningsResultat? =
         when {
@@ -119,7 +111,7 @@ object PeriodeUtil {
 
     // PeriodisertInformasjonUtils.isValidForDate
     private fun isValidForDate(tidsbegrenset: AbstraktBeregningsResultat, date: Date): Boolean =
-        isDateInPeriod(date, tidsbegrenset.virkFom, tidsbegrenset.virkTom)
+        isDateInPeriod(date, tidsbegrenset.virkFomLd, tidsbegrenset.virkTom)
 
     // PeriodisertInformasjonUtils.isValidForDate
     private fun isValidForDate(tidsbegrenset: Pensjonsbeholdning, date: Date): Boolean =
@@ -135,9 +127,10 @@ object PeriodeUtil {
         var earliestFom = ETERNITY
 
         list.forEach {
-            if (isBeforeByDay(it.virkFom, earliestFom, false)) {
+            val virkFom = it.virkFomLd!!.toNorwegianDateAtNoon()
+            if (isBeforeByDay(virkFom, earliestFom, false)) {
                 result = it
-                earliestFom = it.virkFom!!
+                earliestFom = virkFom
             }
         }
 
@@ -165,9 +158,10 @@ object PeriodeUtil {
         var latestFom: Date? = null
 
         list.forEach {
-            if (isAfterByDay(it.virkFom, latestFom, false)) {
+            val virkFom = it.virkFomLd?.toNorwegianDateAtNoon()
+            if (isAfterByDay(virkFom, latestFom, false)) {
                 result = it
-                latestFom = it.virkFom
+                latestFom = virkFom
             }
         }
 
@@ -180,9 +174,10 @@ object PeriodeUtil {
         var latestFom: Date? = null
 
         list.forEach {
-            if (isAfterByDay(it.fom, latestFom, false)) {
+            val fom = it.fom.toNorwegianDateAtNoon()
+            if (isAfterByDay(fom, latestFom, false)) {
                 result = it
-                latestFom = it.fom.toNorwegianDateAtNoon()
+                latestFom = fom
             }
         }
 

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2011SisteBeregningCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2011SisteBeregningCreatorTest.kt
@@ -13,9 +13,10 @@ import no.nav.pensjon.simulator.core.domain.regler.enum.*
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
-import no.nav.pensjon.simulator.core.domain.regler.krav.Kravlinje
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
+import java.time.LocalDate
 import java.util.*
 
 class Alderspensjon2011SisteBeregningCreatorTest : FunSpec({
@@ -87,9 +88,9 @@ class Alderspensjon2011SisteBeregningCreatorTest : FunSpec({
     // ===========================================
 
     test("createBeregning should set virkDato from beregningsresultat virkFom") {
-        val virkFom = dateAtNoon(2024, Calendar.MARCH, 1)
+        val virkFom = LocalDate.of(2024, 3, 1)
         val beregning = createBeregning(virkFom = virkFom)
-        beregning.virkDato shouldBe virkFom
+        beregning.virkDato shouldBe virkFom.toNorwegianDateAtNoon()
     }
 
     test("createBeregning should not set virkDato when virkFom is null") {
@@ -335,7 +336,7 @@ class Alderspensjon2011SisteBeregningCreatorTest : FunSpec({
 
         val beregning = createBeregning(
             regelverkType = RegelverkTypeEnum.N_REG_G_OPPTJ,
-            virkFom = dateAtNoon(2024, Calendar.JANUARY, 1),
+            virkFom = LocalDate.of(2024, 1, 1),
             benyttetSivilstand = BorMedTypeEnum.J_EKTEF,
             kap19TtAnv = 35,
             kap19ResultatType = ResultattypeEnum.AP2011,
@@ -374,7 +375,7 @@ class Alderspensjon2011SisteBeregningCreatorTest : FunSpec({
 
 private fun createBeregning(
     regelverkType: RegelverkTypeEnum? = null,
-    virkFom: Date? = null,
+    virkFom: LocalDate? = null,
     benyttetSivilstand: BorMedTypeEnum? = null,
     kap19TtAnv: Int? = null,
     kap19ResultatType: ResultattypeEnum? = null,
@@ -387,7 +388,7 @@ private fun createBeregning(
     ytelseskomponentListe: MutableList<Ytelseskomponent> = mutableListOf()
 ): SisteAldersberegning2011 {
     val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-        this.virkFom = virkFom
+        this.virkFomLd = virkFom
         this.benyttetSivilstandEnum = benyttetSivilstand
         this.pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
             ytelseskomponenter = ytelseskomponentListe

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2016SisteBeregningCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2016SisteBeregningCreatorTest.kt
@@ -15,8 +15,8 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.trygdetid.Brok
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
-import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
-import java.util.*
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
+import java.time.LocalDate
 
 class Alderspensjon2016SisteBeregningCreatorTest : FunSpec({
 
@@ -97,15 +97,15 @@ class Alderspensjon2016SisteBeregningCreatorTest : FunSpec({
     // --- Tests for virkDato ---
 
     test("createBeregning should set virkDato from beregningsresultat") {
-        val virkFom = dateAtNoon(2025, Calendar.MARCH, 1)
+        val virkFom = LocalDate.of(2025, 3, 1)
         val beregning = createBeregning(virkFom = virkFom)
-        beregning.virkDato shouldBe virkFom
+        beregning.virkDato shouldBe virkFom.toNorwegianDateAtNoon()
     }
 
     // --- Tests for kapittel 19 data ---
 
     test("createBeregning should copy tt_anv from beregningKapittel19") {
-        val beregning = createBeregning(tt_anv_kapittel19 = 40)
+        val beregning = createBeregning(kapittel19Trygdetid = 40)
         beregning.tt_anv shouldBe 40
     }
 
@@ -156,7 +156,7 @@ class Alderspensjon2016SisteBeregningCreatorTest : FunSpec({
     }
 
     test("createBeregning should set tt_anv_kap_20 from beregningKapittel20") {
-        val beregning = createBeregning(tt_anv_kapittel20 = 35)
+        val beregning = createBeregning(kapittel20Trygdetid = 35)
         beregning.tt_anv_kap_20 shouldBe 35
     }
 
@@ -345,9 +345,9 @@ private fun createBeregning(
     ytelseskomponentListe2011: MutableList<Ytelseskomponent> = mutableListOf(),
     ytelseskomponentListe2025: MutableList<Ytelseskomponent> = mutableListOf(),
     regelverkType: RegelverkTypeEnum = RegelverkTypeEnum.N_REG_G_N_OPPTJ,
-    virkFom: Date? = null,
-    tt_anv_kapittel19: Int? = null,
-    tt_anv_kapittel20: Int? = null,
+    virkFom: LocalDate? = null,
+    kapittel19Trygdetid: Int? = null,
+    kapittel20Trygdetid: Int? = null,
     restpensjon: Basispensjon? = null,
     basispensjon: Basispensjon? = null,
     restpensjonUtenGJR: Basispensjon? = null,
@@ -371,7 +371,7 @@ private fun createBeregning(
     includeKapittel19: Boolean = true
 ): SisteAldersberegning2016 {
     val beregningsResultat2011 = if (includeKapittel19 || ytelseskomponentListe2011.isNotEmpty() ||
-        pensjonUnderUtbetalingUtenGJR != null || tt_anv_kapittel19 != null ||
+        pensjonUnderUtbetalingUtenGJR != null || kapittel19Trygdetid != null ||
         restpensjon != null || basispensjon != null || restpensjonUtenGJR != null ||
         basispensjonUtenGJR != null || resultatTypeKapittel19 != null ||
         benyttetSivilstand2011 != null || epsMottarPensjon19 != null || gjenlevenderettAnvendt19 != null
@@ -386,7 +386,7 @@ private fun createBeregning(
             benyttetSivilstandEnum = benyttetSivilstand2011
 
             beregningKapittel19 = AldersberegningKapittel19().apply {
-                tt_anv = tt_anv_kapittel19 ?: 0
+                tt_anv = kapittel19Trygdetid ?: 0
                 this.restpensjon = restpensjon
                 this.basispensjon = basispensjon
                 this.restpensjonUtenGJR = restpensjonUtenGJR
@@ -412,7 +412,7 @@ private fun createBeregning(
         beregningKapittel20 = AldersberegningKapittel20().apply {
             beregningsMetodeEnum = beregningsMetode
             this.prorataBrok = prorataBrok
-            tt_anv = tt_anv_kapittel20 ?: 0
+            tt_anv = kapittel20Trygdetid ?: 0
             this.beholdninger = beholdninger
             resultatTypeEnum = resultatTypeKapittel20
 
@@ -433,7 +433,7 @@ private fun createBeregning(
 
     val spec = SisteBeregningSpec(
         beregningsresultat = BeregningsResultatAlderspensjon2016().apply {
-            this.virkFom = virkFom
+            this.virkFomLd = virkFom
             this.beregningsResultat2011 = beregningsResultat2011
             this.beregningsResultat2025 = beregningsResultat2025
             this.pensjonUnderUtbetaling = topLevelPensjonUnderUtbetaling

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2025SisteBeregningCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/Alderspensjon2025SisteBeregningCreatorTest.kt
@@ -16,8 +16,8 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.trygdetid.Brok
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
-import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
-import java.util.*
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
+import java.time.LocalDate
 
 class Alderspensjon2025SisteBeregningCreatorTest : FunSpec({
 
@@ -63,8 +63,8 @@ class Alderspensjon2025SisteBeregningCreatorTest : FunSpec({
     // --- Tests for virkDato ---
 
     test("createBeregning should set virkDato from beregningsresultat") {
-        val virkFom = dateAtNoon(2025, Calendar.MARCH, 1)
-        createBeregning(virkFom = virkFom).virkDato shouldBe virkFom
+        val virkFom = LocalDate.of(2025, 3, 1)
+        createBeregning(virkFom = virkFom).virkDato shouldBe virkFom.toNorwegianDateAtNoon()
     }
 
     test("createBeregning should handle null virkFom") {
@@ -290,7 +290,7 @@ class Alderspensjon2025SisteBeregningCreatorTest : FunSpec({
     // --- Integration-style tests ---
 
     test("createBeregning should correctly populate all fields from full spec") {
-        val virkFom = dateAtNoon(2025, Calendar.JUNE, 1)
+        val virkFom = LocalDate.of(2025, 6, 1)
         val beholdninger = Beholdninger()
 
         val beregning = createBeregning(
@@ -312,7 +312,7 @@ class Alderspensjon2025SisteBeregningCreatorTest : FunSpec({
 
         with(beregning) {
             regelverkTypeEnum shouldBe RegelverkTypeEnum.N_REG_N_OPPTJ
-            virkDato shouldBe virkFom
+            virkDato shouldBe virkFom.toNorwegianDateAtNoon()
             benyttetSivilstandEnum shouldBe BorMedTypeEnum.J_EKTEF
             beregningsMetodeEnum shouldBe BeregningsmetodeEnum.FOLKETRYGD
             prorataBrok_kap_20?.teller shouldBe 35
@@ -336,7 +336,7 @@ private fun persondetalj(grunnlagsrolle: GrunnlagsrolleEnum) =
 private fun createBeregning(
     ytelseskomponentListe: MutableList<Ytelseskomponent> = mutableListOf(),
     regelverkType: RegelverkTypeEnum? = RegelverkTypeEnum.N_REG_N_OPPTJ,
-    virkFom: Date? = null,
+    virkFom: LocalDate? = null,
     benyttetSivilstand: BorMedTypeEnum? = null,
     beregningsmetode: BeregningsmetodeEnum? = null,
     prorataBroek: Brok? = null,
@@ -351,7 +351,7 @@ private fun createBeregning(
 ): SisteAldersberegning2011 {
     val spec = SisteBeregningSpec(
         beregningsresultat = BeregningsResultatAlderspensjon2025().apply {
-            this.virkFom = virkFom
+            this.virkFomLd = virkFom
             this.benyttetSivilstandEnum = benyttetSivilstand
 
             if (ytelseskomponentListe.isNotEmpty()) {

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonBeregnerTest.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.simulator.core.beregn
 
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
@@ -20,87 +20,38 @@ import no.nav.pensjon.simulator.validity.BadSpecException
 import no.nav.pensjon.simulator.vedtak.VilkaarsvedtakKravlinje
 import java.time.LocalDate
 
-class AlderspensjonBeregnerTest : FunSpec({
+class AlderspensjonBeregnerTest : ShouldSpec({
 
-    // ===========================================
-    // Tests for first uttak with different regelverkTypes
-    // ===========================================
+    context("førstegangsuttak med forskjellige regelverkstyper") {
+        should("call beregnAlderspensjon2011FoersteUttak for N_REG_G_OPPTJ") {
+            val expectedResult = BeregningsResultatAlderspensjon2011()
+            val context = arrangeAlderspensjon2011FoersteUttak(resultat = expectedResult)
 
-    test("beregnAlderspensjon should call beregnAlderspensjon2011FoersteUttak for N_REG_G_OPPTJ") {
-        val expectedResult = BeregningsResultatAlderspensjon2011()
-        val context = mockk<SimulatorContext> {
-            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } returns expectedResult
+            val result = AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = null,
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = 123L,
+                isFoersteUttak = true,
+                ignoreAvslag = false
+            )
+
+            result shouldBe expectedResult
+            verify(exactly = 1) { context.beregnAlderspensjon2011FoersteUttak(any(), eq(123L)) }
         }
 
-        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = null,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = 123L,
-            isFoersteUttak = true,
-            ignoreAvslag = false
-        )
+        should("call beregnAlderspensjon2016FoersteUttak for N_REG_G_N_OPPTJ") {
+            val expectedResult = BeregningsResultatAlderspensjon2016()
+            val context = mockk<SimulatorContext> {
+                every { beregnAlderspensjon2016FoersteUttak(any(), any()) } returns expectedResult
+            }
 
-        result shouldBe expectedResult
-        verify(exactly = 1) { context.beregnAlderspensjon2011FoersteUttak(any(), eq(123L)) }
-    }
-
-    test("beregnAlderspensjon should call beregnAlderspensjon2016FoersteUttak for N_REG_G_N_OPPTJ") {
-        val expectedResult = BeregningsResultatAlderspensjon2016()
-        val context = mockk<SimulatorContext> {
-            every { beregnAlderspensjon2016FoersteUttak(any(), any()) } returns expectedResult
-        }
-
-        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = null,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = true,
-            ignoreAvslag = false
-        )
-
-        result shouldBe expectedResult
-        verify(exactly = 1) { context.beregnAlderspensjon2016FoersteUttak(any(), isNull()) }
-    }
-
-    test("beregnAlderspensjon should call beregnAlderspensjon2025FoersteUttak for N_REG_N_OPPTJ") {
-        val expectedResult = BeregningsResultatAlderspensjon2025()
-        val context = mockk<SimulatorContext> {
-            every { beregnAlderspensjon2025FoersteUttak(any(), any()) } returns expectedResult
-        }
-
-        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = null,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = true,
-            ignoreAvslag = false
-        )
-
-        result shouldBe expectedResult
-        verify(exactly = 1) { context.beregnAlderspensjon2025FoersteUttak(any(), isNull()) }
-    }
-
-    test("beregnAlderspensjon should throw for G_REG regelverkType on first uttak") {
-        val context = mockk<SimulatorContext>()
-
-        shouldThrow<RuntimeException> {
             AlderspensjonBeregner(context).beregnAlderspensjon(
-                kravhode = kravhode(RegelverkTypeEnum.G_REG),
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
                 vedtakListe = mutableListOf(),
                 virkningDato = LocalDate.of(2025, 1, 1),
                 sisteAldersberegning2011 = null,
@@ -110,16 +61,19 @@ class AlderspensjonBeregnerTest : FunSpec({
                 sakId = null,
                 isFoersteUttak = true,
                 ignoreAvslag = false
-            )
-        }.message shouldBe "Unexpected regelverkType: G_REG"
-    }
+            ) shouldBe expectedResult
 
-    test("beregnAlderspensjon should throw for null regelverkType on first uttak") {
-        val context = mockk<SimulatorContext>()
+            verify(exactly = 1) { context.beregnAlderspensjon2016FoersteUttak(any(), isNull()) }
+        }
 
-        shouldThrow<RuntimeException> {
+        should("call beregnAlderspensjon2025FoersteUttak for N_REG_N_OPPTJ") {
+            val expectedResult = BeregningsResultatAlderspensjon2025()
+            val context = mockk<SimulatorContext> {
+                every { beregnAlderspensjon2025FoersteUttak(any(), any()) } returns expectedResult
+            }
+
             AlderspensjonBeregner(context).beregnAlderspensjon(
-                kravhode = Kravhode(), // no regelverkType
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
                 vedtakListe = mutableListOf(),
                 virkningDato = LocalDate.of(2025, 1, 1),
                 sisteAldersberegning2011 = null,
@@ -129,89 +83,99 @@ class AlderspensjonBeregnerTest : FunSpec({
                 sakId = null,
                 isFoersteUttak = true,
                 ignoreAvslag = false
-            )
-        }.message shouldBe "Undefined regelverkTypeEnum"
-    }
+            ) shouldBe expectedResult
 
-    // ===========================================
-    // Tests for revurdering with different regelverkTypes
-    // ===========================================
-
-    test("beregnAlderspensjon should call revurderAlderspensjon2011 for N_REG_G_OPPTJ revurdering") {
-        val expectedResult = BeregningsResultatAlderspensjon2011()
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2011(any(), any()) } returns expectedResult
+            verify(exactly = 1) { context.beregnAlderspensjon2025FoersteUttak(any(), isNull()) }
         }
 
-        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = SisteAldersberegning2011(),
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = 456L,
-            isFoersteUttak = false,
-            ignoreAvslag = false
-        )
-
-        result shouldBe expectedResult
-        verify(exactly = 1) { context.revurderAlderspensjon2011(any(), eq(456L)) }
-    }
-
-    test("beregnAlderspensjon should call revurderAlderspensjon2016 for N_REG_G_N_OPPTJ revurdering") {
-        val expectedResult = BeregningsResultatAlderspensjon2016()
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2016(any(), any()) } returns expectedResult
+        should("throw for G_REG regelverkType on first uttak") {
+            shouldThrow<RuntimeException> {
+                AlderspensjonBeregner(context = mockk()).beregnAlderspensjon(
+                    kravhode = kravhode(RegelverkTypeEnum.G_REG),
+                    vedtakListe = mutableListOf(),
+                    virkningDato = LocalDate.of(2025, 1, 1),
+                    sisteAldersberegning2011 = null,
+                    privatAfp = null,
+                    livsvarigOffentligAfpGrunnlag = null,
+                    simuleringSpec = simuleringSpec(),
+                    sakId = null,
+                    isFoersteUttak = true,
+                    ignoreAvslag = false
+                )
+            }.message shouldBe "Unexpected regelverkType: G_REG"
         }
 
-        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = SisteAldersberegning2016(),
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = false,
-            ignoreAvslag = false
-        )
-
-        result shouldBe expectedResult
-        verify(exactly = 1) { context.revurderAlderspensjon2016(any(), isNull()) }
-    }
-
-    test("beregnAlderspensjon should call revurderAlderspensjon2025 for N_REG_N_OPPTJ revurdering") {
-        val expectedResult = BeregningsResultatAlderspensjon2025()
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2025(any(), any()) } returns expectedResult
+        should("throw for null regelverkType on first uttak") {
+            shouldThrow<RuntimeException> {
+                AlderspensjonBeregner(context = mockk()).beregnAlderspensjon(
+                    kravhode = Kravhode(), // no regelverkType
+                    vedtakListe = mutableListOf(),
+                    virkningDato = LocalDate.of(2025, 1, 1),
+                    sisteAldersberegning2011 = null,
+                    privatAfp = null,
+                    livsvarigOffentligAfpGrunnlag = null,
+                    simuleringSpec = simuleringSpec(),
+                    sakId = null,
+                    isFoersteUttak = true,
+                    ignoreAvslag = false
+                )
+            }.message shouldBe "Undefined regelverkTypeEnum"
         }
-
-        val result = AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = SisteAldersberegning2011(),
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = false,
-            ignoreAvslag = false
-        )
-
-        result shouldBe expectedResult
-        verify(exactly = 1) { context.revurderAlderspensjon2025(any(), isNull()) }
     }
 
-    test("beregnAlderspensjon should throw for G_REG regelverkType on revurdering") {
-        val context = mockk<SimulatorContext>()
+    context("revurdering with different regelverkTypes") {
+        should("call revurderAlderspensjon2011 for N_REG_G_OPPTJ revurdering") {
+            val expectedResult = BeregningsResultatAlderspensjon2011()
+            val context = mockk<SimulatorContext> {
+                every { revurderAlderspensjon2011(any(), any()) } returns expectedResult
+            }
 
-        shouldThrow<RuntimeException> {
             AlderspensjonBeregner(context).beregnAlderspensjon(
-                kravhode = kravhode(RegelverkTypeEnum.G_REG),
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = SisteAldersberegning2011(),
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = 456L,
+                isFoersteUttak = false,
+                ignoreAvslag = false
+            ) shouldBe expectedResult
+
+            verify(exactly = 1) { context.revurderAlderspensjon2011(any(), eq(456L)) }
+        }
+
+        should("call revurderAlderspensjon2016 for N_REG_G_N_OPPTJ revurdering") {
+            val expectedResult = BeregningsResultatAlderspensjon2016()
+            val context = mockk<SimulatorContext> {
+                every { revurderAlderspensjon2016(any(), any()) } returns expectedResult
+            }
+
+             AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = SisteAldersberegning2016(),
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = false,
+                ignoreAvslag = false
+            ) shouldBe expectedResult
+
+            verify(exactly = 1) { context.revurderAlderspensjon2016(any(), isNull()) }
+        }
+
+        should("call revurderAlderspensjon2025 for N_REG_N_OPPTJ revurdering") {
+            val expectedResult = BeregningsResultatAlderspensjon2025()
+            val context = mockk<SimulatorContext> {
+                every { revurderAlderspensjon2025(any(), any()) } returns expectedResult
+            }
+
+             AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
                 vedtakListe = mutableListOf(),
                 virkningDato = LocalDate.of(2025, 1, 1),
                 sisteAldersberegning2011 = SisteAldersberegning2011(),
@@ -221,150 +185,404 @@ class AlderspensjonBeregnerTest : FunSpec({
                 sakId = null,
                 isFoersteUttak = false,
                 ignoreAvslag = false
+            ) shouldBe expectedResult
+
+            verify(exactly = 1) { context.revurderAlderspensjon2025(any(), isNull()) }
+        }
+
+        should("throw for G_REG regelverkType on revurdering") {
+            shouldThrow<RuntimeException> {
+                AlderspensjonBeregner(context = mockk()).beregnAlderspensjon(
+                    kravhode = kravhode(RegelverkTypeEnum.G_REG),
+                    vedtakListe = mutableListOf(),
+                    virkningDato = LocalDate.of(2025, 1, 1),
+                    sisteAldersberegning2011 = SisteAldersberegning2011(),
+                    privatAfp = null,
+                    livsvarigOffentligAfpGrunnlag = null,
+                    simuleringSpec = simuleringSpec(),
+                    sakId = null,
+                    isFoersteUttak = false,
+                    ignoreAvslag = false
+                )
+            }.message shouldBe "Unexpected regelverkType: G_REG"
+        }
+    }
+
+    context("ignoreAvslag functionality") {
+        should("innvilge vedtak when ignoreAvslag is true and vedtak is not innvilget") {
+            val vedtak = VilkarsVedtak().apply {
+                anbefaltResultatEnum = VedtakResultatEnum.AVSL
+                vilkarsvedtakResultatEnum = VedtakResultatEnum.AVSL
+                begrunnelseEnum = BegrunnelseTypeEnum.ANNULERING
+                merknadListe = mutableListOf(Merknad())
+            }
+            val vedtakListe = mutableListOf(vedtak)
+            val context = arrangeAlderspensjon2011FoersteUttak()
+
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+                vedtakListe = vedtakListe,
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = null,
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = true,
+                ignoreAvslag = true
             )
-        }.message shouldBe "Unexpected regelverkType: G_REG"
+
+            with(vedtakListe[0]) {
+                anbefaltResultatEnum shouldBe VedtakResultatEnum.INNV
+                vilkarsvedtakResultatEnum shouldBe VedtakResultatEnum.INNV
+                begrunnelseEnum shouldBe null
+                merknadListe shouldBe mutableListOf()
+            }
+        }
+
+        should("not modify vedtak when ignoreAvslag is true and vedtak is already innvilget") {
+            val vedtak = VilkarsVedtak().apply {
+                anbefaltResultatEnum = VedtakResultatEnum.INNV
+                vilkarsvedtakResultatEnum = VedtakResultatEnum.INNV
+            }
+            val vedtakListe = mutableListOf(vedtak)
+            val context = arrangeAlderspensjon2011FoersteUttak()
+
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+                vedtakListe = vedtakListe,
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = null,
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = true,
+                ignoreAvslag = true
+            )
+
+            with(vedtakListe[0]) {
+                anbefaltResultatEnum shouldBe VedtakResultatEnum.INNV
+                vilkarsvedtakResultatEnum shouldBe VedtakResultatEnum.INNV
+            }
+        }
+
+        should("not modify vedtak when ignoreAvslag is false") {
+            val vedtak = VilkarsVedtak().apply {
+                anbefaltResultatEnum = VedtakResultatEnum.AVSL
+                vilkarsvedtakResultatEnum = VedtakResultatEnum.AVSL
+            }
+            val vedtakListe = mutableListOf(vedtak)
+            val context = arrangeAlderspensjon2011FoersteUttak()
+
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+                vedtakListe = vedtakListe,
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = null,
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = true,
+                ignoreAvslag = false
+            )
+
+            with(vedtakListe[0]) {
+                anbefaltResultatEnum shouldBe VedtakResultatEnum.AVSL
+                vilkarsvedtakResultatEnum shouldBe VedtakResultatEnum.AVSL
+            }
+        }
     }
 
-    // ===========================================
-    // Tests for ignoreAvslag functionality
-    // ===========================================
+    context("exception handling of gjenlevenderett") {
+        should("throw BadSpecException when gjenlevenderett not supported") {
+            val context = mockk<SimulatorContext> {
+                every { revurderAlderspensjon2016(any(), any()) } throws RegelmotorValideringException(
+                    message = "Original error",
+                    merknadListe = listOf(
+                        merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakKravlinjeMangler"),
+                        merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakRelatertPersonFinnesIkke"),
+                    )
+                )
+            }
 
-    test("beregnAlderspensjon should innvilge vedtak when ignoreAvslag is true and vedtak is not innvilget") {
-        val vedtak = VilkarsVedtak().apply {
-            anbefaltResultatEnum = VedtakResultatEnum.AVSL
-            vilkarsvedtakResultatEnum = VedtakResultatEnum.AVSL
-            begrunnelseEnum = BegrunnelseTypeEnum.ANNULERING
-            merknadListe = mutableListOf(Merknad())
-        }
-        val vedtakListe = mutableListOf(vedtak)
-
-        val context = mockk<SimulatorContext> {
-            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } returns BeregningsResultatAlderspensjon2011()
-        }
-
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
-            vedtakListe = vedtakListe,
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = null,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = true,
-            ignoreAvslag = true
-        )
-
-        with(vedtakListe[0]) {
-            anbefaltResultatEnum shouldBe VedtakResultatEnum.INNV
-            vilkarsvedtakResultatEnum shouldBe VedtakResultatEnum.INNV
-            begrunnelseEnum shouldBe null
-            merknadListe shouldBe mutableListOf()
-        }
-    }
-
-    test("beregnAlderspensjon should not modify vedtak when ignoreAvslag is true and vedtak is already innvilget") {
-        val vedtak = VilkarsVedtak().apply {
-            anbefaltResultatEnum = VedtakResultatEnum.INNV
-            vilkarsvedtakResultatEnum = VedtakResultatEnum.INNV
-        }
-        val vedtakListe = mutableListOf(vedtak)
-
-        val context = mockk<SimulatorContext> {
-            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } returns BeregningsResultatAlderspensjon2011()
+            shouldThrow<BadSpecException> {
+                AlderspensjonBeregner(context).beregnAlderspensjon(
+                    kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+                    vedtakListe = mutableListOf(gjenlevenderettVedtak()),
+                    virkningDato = LocalDate.of(2025, 3, 1),
+                    sisteAldersberegning2011 = SisteAldersberegning2016(),
+                    privatAfp = null,
+                    livsvarigOffentligAfpGrunnlag = null,
+                    simuleringSpec = simuleringSpec(type = SimuleringTypeEnum.ALDER_M_AFP_PRIVAT),
+                    sakId = null,
+                    isFoersteUttak = false,
+                    ignoreAvslag = false
+                )
+            }.message shouldBe "Pensjonen involverer gjenlevenderett, noe som ikke støttes for simuleringstype ALDER_M_AFP_PRIVAT"
         }
 
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
-            vedtakListe = vedtakListe,
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = null,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = true,
-            ignoreAvslag = true
-        )
+        should("rethrow original exception when merknader do not indicate gjenlevende") {
+            val originalException = RegelmotorValideringException(
+                message = "Original error",
+                merknadListe = listOf(merknad("SOME_OTHER_ERROR"))
+            )
+            val context = arrangeErrorInRevurderingAlderspensjon2016(originalException)
 
-        vedtakListe[0].anbefaltResultatEnum shouldBe VedtakResultatEnum.INNV
-        vedtakListe[0].vilkarsvedtakResultatEnum shouldBe VedtakResultatEnum.INNV
-    }
-
-    test("beregnAlderspensjon should not modify vedtak when ignoreAvslag is false") {
-        val vedtak = VilkarsVedtak().apply {
-            anbefaltResultatEnum = VedtakResultatEnum.AVSL
-            vilkarsvedtakResultatEnum = VedtakResultatEnum.AVSL
-        }
-        val vedtakListe = mutableListOf(vedtak)
-
-        val context = mockk<SimulatorContext> {
-            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } returns BeregningsResultatAlderspensjon2011()
+            shouldThrow<RegelmotorValideringException> {
+                AlderspensjonBeregner(context).beregnAlderspensjon(
+                    kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+                    vedtakListe = mutableListOf(gjenlevenderettVedtak()),
+                    virkningDato = LocalDate.of(2025, 3, 1),
+                    sisteAldersberegning2011 = SisteAldersberegning2016(),
+                    privatAfp = null,
+                    livsvarigOffentligAfpGrunnlag = null,
+                    simuleringSpec = simuleringSpec(),
+                    sakId = null,
+                    isFoersteUttak = false,
+                    ignoreAvslag = false
+                )
+            } shouldBe originalException
         }
 
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
-            vedtakListe = vedtakListe,
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = null,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = true,
-            ignoreAvslag = false
-        )
-
-        vedtakListe[0].anbefaltResultatEnum shouldBe VedtakResultatEnum.AVSL
-        vedtakListe[0].vilkarsvedtakResultatEnum shouldBe VedtakResultatEnum.AVSL
-    }
-
-    // ===========================================
-    // Tests for exception handling with gjenlevenderett
-    // ===========================================
-
-    test("beregnAlderspensjon should throw BadSpecException when gjenlevenderett not supported") {
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2016(any(), any()) } throws RegelmotorValideringException(
+        should("rethrow original exception when no GJR vedtak") {
+            val originalException = RegelmotorValideringException(
                 message = "Original error",
                 merknadListe = listOf(
                     merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakKravlinjeMangler"),
                     merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakRelatertPersonFinnesIkke"),
                 )
             )
+            val context = arrangeErrorInRevurderingAlderspensjon2016(originalException)
+
+            val alderspensjonsvedtak = VilkarsVedtak().apply {
+                kravlinje = VilkaarsvedtakKravlinje(type = KravlinjeTypeEnum.AP, person = null)
+                kravlinjeTypeEnum = KravlinjeTypeEnum.AP
+            }
+
+            shouldThrow<RegelmotorValideringException> {
+                AlderspensjonBeregner(context).beregnAlderspensjon(
+                    kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+                    vedtakListe = mutableListOf(alderspensjonsvedtak), // no GJR vedtak
+                    virkningDato = LocalDate.of(2025, 3, 1),
+                    sisteAldersberegning2011 = SisteAldersberegning2016(),
+                    privatAfp = null,
+                    livsvarigOffentligAfpGrunnlag = null,
+                    simuleringSpec = simuleringSpec(),
+                    sakId = null,
+                    isFoersteUttak = false,
+                    ignoreAvslag = false
+                )
+            } shouldBe originalException
         }
 
-        shouldThrow<BadSpecException> {
+        should("rethrow original exception when only one gjenlevende merknad present") {
+            val originalException = RegelmotorValideringException(
+                message = "Original error",
+                merknadListe = listOf(
+                    merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakKravlinjeMangler"),
+                    // missing VilkarsVedtakRelatertPersonFinnesIkke
+                )
+            )
+            val context = arrangeErrorInRevurderingAlderspensjon2016(originalException)
+
+            shouldThrow<RegelmotorValideringException> {
+                AlderspensjonBeregner(context).beregnAlderspensjon(
+                    kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
+                    vedtakListe = mutableListOf(gjenlevenderettVedtak()),
+                    virkningDato = LocalDate.of(2025, 3, 1),
+                    sisteAldersberegning2011 = SisteAldersberegning2016(),
+                    privatAfp = null,
+                    livsvarigOffentligAfpGrunnlag = null,
+                    simuleringSpec = simuleringSpec(),
+                    sakId = null,
+                    isFoersteUttak = false,
+                    ignoreAvslag = false
+                )
+            } shouldBe originalException
+        }
+    }
+
+    context("EPS mottar pensjon") {
+        should("not create InfoPavirkendeYtelse when EPS does not have pensjon") {
+            var capturedRequest: BeregnAlderspensjon2011ForsteUttakRequest? = null
+            val context = mockk<SimulatorContext> {
+                every { beregnAlderspensjon2011FoersteUttak(any(), any()) } answers {
+                    capturedRequest = firstArg()
+                    BeregningsResultatAlderspensjon2011()
+                }
+            }
+
             AlderspensjonBeregner(context).beregnAlderspensjon(
-                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
-                vedtakListe = mutableListOf(gjenlevenderettVedtak()),
-                virkningDato = LocalDate.of(2025, 3, 1),
-                sisteAldersberegning2011 = SisteAldersberegning2016(),
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = null,
                 privatAfp = null,
                 livsvarigOffentligAfpGrunnlag = null,
-                simuleringSpec = simuleringSpec(type = SimuleringTypeEnum.ALDER_M_AFP_PRIVAT),
+                simuleringSpec = simuleringSpec(epsHarPensjon = false),
+                sakId = null,
+                isFoersteUttak = true,
+                ignoreAvslag = false
+            )
+
+            capturedRequest shouldNotBe null
+            capturedRequest!!.infoPavirkendeYtelse shouldBe null
+        }
+    }
+
+    context("privat AFP") {
+        should("pass privatAfp to request for first uttak") {
+            var capturedRequest: BeregnAlderspensjon2011ForsteUttakRequest? = null
+            val privatAfp = AfpPrivatLivsvarig()
+
+            val context = mockk<SimulatorContext> {
+                every { beregnAlderspensjon2011FoersteUttak(any(), any()) } answers {
+                    capturedRequest = firstArg()
+                    BeregningsResultatAlderspensjon2011()
+                }
+            }
+
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = null,
+                privatAfp = privatAfp,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = true,
+                ignoreAvslag = false
+            )
+
+            capturedRequest!!.afpPrivatLivsvarig shouldBe privatAfp
+        }
+
+        should("pass privatAfp to request for revurdering") {
+            var capturedRequest: RevurderingAlderspensjon2011Request? = null
+            val privatAfp = AfpPrivatLivsvarig()
+
+            val context = mockk<SimulatorContext> {
+                every { revurderAlderspensjon2011(any(), any()) } answers {
+                    capturedRequest = firstArg()
+                    BeregningsResultatAlderspensjon2011()
+                }
+            }
+
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = SisteAldersberegning2011(),
+                privatAfp = privatAfp,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
                 sakId = null,
                 isFoersteUttak = false,
                 ignoreAvslag = false
             )
-        }.message shouldBe "Pensjonen involverer gjenlevenderett, noe som ikke støttes for simuleringstype ALDER_M_AFP_PRIVAT"
+
+            capturedRequest!!.afpPrivatLivsvarig shouldBe privatAfp
+        }
     }
 
-    test("beregnAlderspensjon should rethrow original exception when merknader do not indicate gjenlevende") {
-        val originalException = RegelmotorValideringException(
-            message = "Original error",
-            merknadListe = listOf(merknad("SOME_OTHER_ERROR"))
-        )
+    context("livsvarig offentlig AFP") {
+        should("pass livsvarigOffentligAfpGrunnlag to 2025 request") {
+            var capturedRequest: BeregnAlderspensjon2025ForsteUttakRequest? = null
+            val offentligAfp = AfpOffentligLivsvarigGrunnlag(sistRegulertG = 100000, bruttoPerAr = 50000.0)
 
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2016(any(), any()) } throws originalException
+            val context = mockk<SimulatorContext> {
+                every { beregnAlderspensjon2025FoersteUttak(any(), any()) } answers {
+                    capturedRequest = firstArg()
+                    BeregningsResultatAlderspensjon2025()
+                }
+            }
+
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = null,
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = offentligAfp,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = true,
+                ignoreAvslag = false
+            )
+
+            capturedRequest!!.afpOffentligLivsvarigGrunnlag shouldBe offentligAfp
         }
 
-        shouldThrow<RegelmotorValideringException> {
+        should("pass livsvarigOffentligAfpGrunnlag to 2025 revurdering request") {
+            var capturedRequest: RevurderingAlderspensjon2025Request? = null
+            val offentligAfp = AfpOffentligLivsvarigGrunnlag(sistRegulertG = 100000, bruttoPerAr = 50000.0)
+
+            val context = mockk<SimulatorContext> {
+                every { revurderAlderspensjon2025(any(), any()) } answers {
+                    capturedRequest = firstArg()
+                    BeregningsResultatAlderspensjon2025()
+                }
+            }
+
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = SisteAldersberegning2011(),
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = offentligAfp,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = false,
+                ignoreAvslag = false
+            )
+
+            capturedRequest!!.afpOffentligLivsvarigGrunnlag shouldBe offentligAfp
+        }
+    }
+
+    context("request 'virkning fra og med'-dato") {
+        should("set virkFom in request for first uttak") {
+            var capturedRequest: BeregnAlderspensjon2011ForsteUttakRequest? = null
+            val context = mockk<SimulatorContext> {
+                every { beregnAlderspensjon2011FoersteUttak(any(), any()) } answers {
+                    capturedRequest = firstArg()
+                    BeregningsResultatAlderspensjon2011()
+                }
+            }
+
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 6, 15),
+                sisteAldersberegning2011 = null,
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = true,
+                ignoreAvslag = false
+            )
+
+            capturedRequest!!.virkFomLd shouldNotBe null
+        }
+
+        should("set virkFom in request for revurdering") {
+            var capturedRequest: RevurderingAlderspensjon2016Request? = null
+            val context = mockk<SimulatorContext> {
+                every { revurderAlderspensjon2016(any(), any()) } answers {
+                    capturedRequest = firstArg()
+                    BeregningsResultatAlderspensjon2016()
+                }
+            }
+
             AlderspensjonBeregner(context).beregnAlderspensjon(
                 kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
-                vedtakListe = mutableListOf(gjenlevenderettVedtak()),
-                virkningDato = LocalDate.of(2025, 3, 1),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 6, 15),
                 sisteAldersberegning2011 = SisteAldersberegning2016(),
                 privatAfp = null,
                 livsvarigOffentligAfpGrunnlag = null,
@@ -373,33 +591,28 @@ class AlderspensjonBeregnerTest : FunSpec({
                 isFoersteUttak = false,
                 ignoreAvslag = false
             )
-        } shouldBe originalException
+
+            capturedRequest!!.virkFom shouldNotBe null
+        }
     }
 
-    test("beregnAlderspensjon should rethrow original exception when no GJR vedtak") {
-        val originalException = RegelmotorValideringException(
-            message = "Original error",
-            merknadListe = listOf(
-                merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakKravlinjeMangler"),
-                merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakRelatertPersonFinnesIkke"),
-            )
-        )
+    context("forrige alderspensjonsberegning i revurdering") {
+        should("pass forrigeAldersBeregning to 2011 revurdering request") {
+            var capturedRequest: RevurderingAlderspensjon2011Request? = null
+            val sisteBeregning = SisteAldersberegning2011().apply { tt_anv = 40 }
 
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2016(any(), any()) } throws originalException
-        }
+            val context = mockk<SimulatorContext> {
+                every { revurderAlderspensjon2011(any(), any()) } answers {
+                    capturedRequest = firstArg()
+                    BeregningsResultatAlderspensjon2011()
+                }
+            }
 
-        val alderspensjonsvedtak = VilkarsVedtak().apply {
-            kravlinje = VilkaarsvedtakKravlinje(type = KravlinjeTypeEnum.AP, person = null)
-            kravlinjeTypeEnum = KravlinjeTypeEnum.AP
-        }
-
-        shouldThrow<RegelmotorValideringException> {
             AlderspensjonBeregner(context).beregnAlderspensjon(
-                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
-                vedtakListe = mutableListOf(alderspensjonsvedtak), // no GJR vedtak
-                virkningDato = LocalDate.of(2025, 3, 1),
-                sisteAldersberegning2011 = SisteAldersberegning2016(),
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = sisteBeregning,
                 privatAfp = null,
                 livsvarigOffentligAfpGrunnlag = null,
                 simuleringSpec = simuleringSpec(),
@@ -407,28 +620,26 @@ class AlderspensjonBeregnerTest : FunSpec({
                 isFoersteUttak = false,
                 ignoreAvslag = false
             )
-        } shouldBe originalException
-    }
 
-    test("beregnAlderspensjon should rethrow original exception when only one gjenlevende merknad present") {
-        val originalException = RegelmotorValideringException(
-            message = "Original error",
-            merknadListe = listOf(
-                merknad("VILKARSVEDTAK_KontrollerVilkarsVedtakLogiskSammenhengRS.VilkarsVedtakKravlinjeMangler"),
-                // missing VilkarsVedtakRelatertPersonFinnesIkke
-            )
-        )
-
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2016(any(), any()) } throws originalException
+            capturedRequest!!.forrigeAldersBeregning shouldBe sisteBeregning
         }
 
-        shouldThrow<RegelmotorValideringException> {
+        should("pass forrigeAldersBeregning to 2016 revurdering request") {
+            var capturedRequest: RevurderingAlderspensjon2016Request? = null
+            val sisteBeregning = SisteAldersberegning2016()
+
+            val context = mockk<SimulatorContext> {
+                every { revurderAlderspensjon2016(any(), any()) } answers {
+                    capturedRequest = firstArg()
+                    BeregningsResultatAlderspensjon2016()
+                }
+            }
+
             AlderspensjonBeregner(context).beregnAlderspensjon(
                 kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
-                vedtakListe = mutableListOf(gjenlevenderettVedtak()),
-                virkningDato = LocalDate.of(2025, 3, 1),
-                sisteAldersberegning2011 = SisteAldersberegning2016(),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = sisteBeregning,
                 privatAfp = null,
                 livsvarigOffentligAfpGrunnlag = null,
                 simuleringSpec = simuleringSpec(),
@@ -436,294 +647,50 @@ class AlderspensjonBeregnerTest : FunSpec({
                 isFoersteUttak = false,
                 ignoreAvslag = false
             )
-        } shouldBe originalException
-    }
 
-    // ===========================================
-    // Tests for EPS mottar pensjon functionality
-    // ===========================================
-
-    test("beregnAlderspensjon should not create InfoPavirkendeYtelse when EPS does not have pensjon") {
-        var capturedRequest: BeregnAlderspensjon2011ForsteUttakRequest? = null
-        val context = mockk<SimulatorContext> {
-            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } answers {
-                capturedRequest = firstArg()
-                BeregningsResultatAlderspensjon2011()
-            }
+            capturedRequest!!.forrigeAldersBeregning shouldBe sisteBeregning
         }
 
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = null,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(epsHarPensjon = false),
-            sakId = null,
-            isFoersteUttak = true,
-            ignoreAvslag = false
-        )
+        should("pass sisteAldersBeregning2011 to 2025 revurdering request") {
+            var capturedRequest: RevurderingAlderspensjon2025Request? = null
+            val sisteBeregning = SisteAldersberegning2011()
 
-        capturedRequest shouldNotBe null
-        capturedRequest!!.infoPavirkendeYtelse shouldBe null
-    }
-
-    // ===========================================
-    // Tests for privat AFP
-    // ===========================================
-
-    test("beregnAlderspensjon should pass privatAfp to request for first uttak") {
-        var capturedRequest: BeregnAlderspensjon2011ForsteUttakRequest? = null
-        val privatAfp = AfpPrivatLivsvarig()
-
-        val context = mockk<SimulatorContext> {
-            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } answers {
-                capturedRequest = firstArg()
-                BeregningsResultatAlderspensjon2011()
+            val context = mockk<SimulatorContext> {
+                every { revurderAlderspensjon2025(any(), any()) } answers {
+                    capturedRequest = firstArg()
+                    BeregningsResultatAlderspensjon2025()
+                }
             }
+
+            AlderspensjonBeregner(context).beregnAlderspensjon(
+                kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
+                vedtakListe = mutableListOf(),
+                virkningDato = LocalDate.of(2025, 1, 1),
+                sisteAldersberegning2011 = sisteBeregning,
+                privatAfp = null,
+                livsvarigOffentligAfpGrunnlag = null,
+                simuleringSpec = simuleringSpec(),
+                sakId = null,
+                isFoersteUttak = false,
+                ignoreAvslag = false
+            )
+
+            capturedRequest!!.sisteAldersBeregning2011 shouldBe sisteBeregning
         }
-
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = null,
-            privatAfp = privatAfp,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = true,
-            ignoreAvslag = false
-        )
-
-        capturedRequest!!.afpPrivatLivsvarig shouldBe privatAfp
-    }
-
-    test("beregnAlderspensjon should pass privatAfp to request for revurdering") {
-        var capturedRequest: RevurderingAlderspensjon2011Request? = null
-        val privatAfp = AfpPrivatLivsvarig()
-
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2011(any(), any()) } answers {
-                capturedRequest = firstArg()
-                BeregningsResultatAlderspensjon2011()
-            }
-        }
-
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = SisteAldersberegning2011(),
-            privatAfp = privatAfp,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = false,
-            ignoreAvslag = false
-        )
-
-        capturedRequest!!.afpPrivatLivsvarig shouldBe privatAfp
-    }
-
-    // ===========================================
-    // Tests for livsvarig offentlig AFP
-    // ===========================================
-
-    test("beregnAlderspensjon should pass livsvarigOffentligAfpGrunnlag to 2025 request") {
-        var capturedRequest: BeregnAlderspensjon2025ForsteUttakRequest? = null
-        val offentligAfp = AfpOffentligLivsvarigGrunnlag(sistRegulertG = 100000, bruttoPerAr = 50000.0)
-
-        val context = mockk<SimulatorContext> {
-            every { beregnAlderspensjon2025FoersteUttak(any(), any()) } answers {
-                capturedRequest = firstArg()
-                BeregningsResultatAlderspensjon2025()
-            }
-        }
-
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = null,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = offentligAfp,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = true,
-            ignoreAvslag = false
-        )
-
-        capturedRequest!!.afpOffentligLivsvarigGrunnlag shouldBe offentligAfp
-    }
-
-    test("beregnAlderspensjon should pass livsvarigOffentligAfpGrunnlag to 2025 revurdering request") {
-        var capturedRequest: RevurderingAlderspensjon2025Request? = null
-        val offentligAfp = AfpOffentligLivsvarigGrunnlag(sistRegulertG = 100000, bruttoPerAr = 50000.0)
-
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2025(any(), any()) } answers {
-                capturedRequest = firstArg()
-                BeregningsResultatAlderspensjon2025()
-            }
-        }
-
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = SisteAldersberegning2011(),
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = offentligAfp,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = false,
-            ignoreAvslag = false
-        )
-
-        capturedRequest!!.afpOffentligLivsvarigGrunnlag shouldBe offentligAfp
-    }
-
-    // ===========================================
-    // Tests for request virkFom
-    // ===========================================
-
-    test("beregnAlderspensjon should set virkFom in request for first uttak") {
-        var capturedRequest: BeregnAlderspensjon2011ForsteUttakRequest? = null
-        val context = mockk<SimulatorContext> {
-            every { beregnAlderspensjon2011FoersteUttak(any(), any()) } answers {
-                capturedRequest = firstArg()
-                BeregningsResultatAlderspensjon2011()
-            }
-        }
-
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 6, 15),
-            sisteAldersberegning2011 = null,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = true,
-            ignoreAvslag = false
-        )
-
-        capturedRequest!!.virkFom shouldNotBe null
-    }
-
-    test("beregnAlderspensjon should set virkFom in request for revurdering") {
-        var capturedRequest: RevurderingAlderspensjon2016Request? = null
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2016(any(), any()) } answers {
-                capturedRequest = firstArg()
-                BeregningsResultatAlderspensjon2016()
-            }
-        }
-
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 6, 15),
-            sisteAldersberegning2011 = SisteAldersberegning2016(),
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = false,
-            ignoreAvslag = false
-        )
-
-        capturedRequest!!.virkFom shouldNotBe null
-    }
-
-    // ===========================================
-    // Tests for forrige aldersberegning in revurdering
-    // ===========================================
-
-    test("beregnAlderspensjon should pass forrigeAldersBeregning to 2011 revurdering request") {
-        var capturedRequest: RevurderingAlderspensjon2011Request? = null
-        val sisteBeregning = SisteAldersberegning2011().apply { tt_anv = 40 }
-
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2011(any(), any()) } answers {
-                capturedRequest = firstArg()
-                BeregningsResultatAlderspensjon2011()
-            }
-        }
-
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = sisteBeregning,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = false,
-            ignoreAvslag = false
-        )
-
-        capturedRequest!!.forrigeAldersBeregning shouldBe sisteBeregning
-    }
-
-    test("beregnAlderspensjon should pass forrigeAldersBeregning to 2016 revurdering request") {
-        var capturedRequest: RevurderingAlderspensjon2016Request? = null
-        val sisteBeregning = SisteAldersberegning2016()
-
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2016(any(), any()) } answers {
-                capturedRequest = firstArg()
-                BeregningsResultatAlderspensjon2016()
-            }
-        }
-
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_G_N_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = sisteBeregning,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = false,
-            ignoreAvslag = false
-        )
-
-        capturedRequest!!.forrigeAldersBeregning shouldBe sisteBeregning
-    }
-
-    test("beregnAlderspensjon should pass sisteAldersBeregning2011 to 2025 revurdering request") {
-        var capturedRequest: RevurderingAlderspensjon2025Request? = null
-        val sisteBeregning = SisteAldersberegning2011()
-
-        val context = mockk<SimulatorContext> {
-            every { revurderAlderspensjon2025(any(), any()) } answers {
-                capturedRequest = firstArg()
-                BeregningsResultatAlderspensjon2025()
-            }
-        }
-
-        AlderspensjonBeregner(context).beregnAlderspensjon(
-            kravhode = kravhode(RegelverkTypeEnum.N_REG_N_OPPTJ),
-            vedtakListe = mutableListOf(),
-            virkningDato = LocalDate.of(2025, 1, 1),
-            sisteAldersberegning2011 = sisteBeregning,
-            privatAfp = null,
-            livsvarigOffentligAfpGrunnlag = null,
-            simuleringSpec = simuleringSpec(),
-            sakId = null,
-            isFoersteUttak = false,
-            ignoreAvslag = false
-        )
-
-        capturedRequest!!.sisteAldersBeregning2011 shouldBe sisteBeregning
     }
 })
+
+private fun arrangeAlderspensjon2011FoersteUttak(
+    resultat: BeregningsResultatAlderspensjon2011 = BeregningsResultatAlderspensjon2011()
+): SimulatorContext =
+    mockk<SimulatorContext> {
+        every { beregnAlderspensjon2011FoersteUttak(any(), any()) } returns resultat
+    }
+
+private fun arrangeErrorInRevurderingAlderspensjon2016(exception: RegelmotorValideringException): SimulatorContext =
+    mockk<SimulatorContext> {
+        every { revurderAlderspensjon2016(any(), any()) } throws exception
+    }
 
 private fun kravhode(regelverkType: RegelverkTypeEnum) =
     Kravhode().apply {

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonVilkaarsproeverOgBeregnerTest.kt
@@ -5,16 +5,17 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.mockk.*
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import no.nav.pensjon.simulator.afp.offentlig.fra2025.grunnlag.LivsvarigOffentligAfpGrunnlagService
 import no.nav.pensjon.simulator.alder.Alder
 import no.nav.pensjon.simulator.core.SimulatorContext
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
-import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Beholdning
+import no.nav.pensjon.simulator.core.domain.regler.enum.*
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Beholdninger
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Pensjonsbeholdning
-import no.nav.pensjon.simulator.core.domain.regler.enum.*
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
@@ -685,7 +686,7 @@ class AlderspensjonVilkaarsproeverOgBeregnerTest : FunSpec({
         }
 
         val beregningsresultat2025 = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            virkFomLd = LocalDate.of(2025, 1, 1)
             beregningKapittel20 = AldersberegningKapittel20().apply {
                 beholdningerForForsteuttak = beholdninger
             }
@@ -752,7 +753,7 @@ class AlderspensjonVilkaarsproeverOgBeregnerTest : FunSpec({
         }
 
         val beregningsresultat2016 = BeregningsResultatAlderspensjon2016().apply {
-            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            virkFomLd = LocalDate.of(2025, 1, 1)
             beregningsResultat2025 = BeregningsResultatAlderspensjon2025().apply {
                 beregningKapittel20 = AldersberegningKapittel20().apply {
                     beholdningerForForsteuttak = beholdninger
@@ -844,7 +845,7 @@ class AlderspensjonVilkaarsproeverOgBeregnerTest : FunSpec({
     }
 
     test("vilkaarsproevOgBeregnAlder should not add pensjonsbeholdning perioder when regelverkType is not new opptjening") {
-        // Using N_REG_G_OPPTJ which is NOT in the list of allowed types (N_REG_N_OPPTJ, N_REG_G_N_OPPTJ)
+        // Using N_REG_G_OPPTJ, which is NOT in the list of allowed types (N_REG_N_OPPTJ, N_REG_G_N_OPPTJ)
         val kravhode = createKravhodeWithSoker() // Uses N_REG_G_OPPTJ
         val vedtakListe = mutableListOf<VilkarsVedtak>()
 

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/beregn/SisteBeregningCreatorTest.kt
@@ -17,9 +17,11 @@ import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravlinje
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import no.nav.pensjon.simulator.core.krav.KravlinjeStatus
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.krav.KravService
 import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
 import no.nav.pensjon.simulator.vedtak.VilkaarsvedtakKravlinje
+import java.time.LocalDate
 import java.util.*
 
 class SisteBeregningCreatorTest : FunSpec({
@@ -330,7 +332,7 @@ class SisteBeregningCreatorTest : FunSpec({
     test("opprettSisteBeregning should filter vedtak by virkFom before beregningsresultat virkFom") {
         val kravhode = createKravhodeWithSoeker(RegelverkTypeEnum.N_REG_G_OPPTJ)
         val beregningsresultat = createBeregningsresultat().apply {
-            virkFom = dateAtNoon(2025, Calendar.JUNE, 1)
+            virkFomLd = LocalDate.of(2025, 6, 1)
         }
 
         val vedtakBefore = createVedtak(VedtakResultatEnum.INNV).apply {
@@ -367,7 +369,7 @@ class SisteBeregningCreatorTest : FunSpec({
     test("opprettSisteBeregning should filter vedtak by virkTom after beregningsresultat virkTom") {
         val kravhode = createKravhodeWithSoeker(RegelverkTypeEnum.N_REG_G_OPPTJ)
         val beregningsresultat = createBeregningsresultat().apply {
-            virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+            virkFomLd = LocalDate.of(2025, 1, 1)
             virkTom = dateAtNoon(2025, Calendar.JUNE, 1)
         }
 
@@ -441,10 +443,10 @@ class SisteBeregningCreatorTest : FunSpec({
 
     test("opprettSisteBeregning should set fomDato and tomDato from beregningsresultat") {
         val kravhode = createKravhodeWithSoeker(RegelverkTypeEnum.N_REG_G_OPPTJ)
-        val fomDate = dateAtNoon(2025, Calendar.JANUARY, 1)
-        val tomDate = dateAtNoon(2025, Calendar.DECEMBER, 31)
+        val fomDate = LocalDate.of(2025, 1, 1)
+        val tomDate = LocalDate.of(2025, 12, 31).toNorwegianDateAtNoon()
         val beregningsresultat = createBeregningsresultat().apply {
-            virkFom = fomDate
+            virkFomLd = fomDate
             virkTom = tomDate
         }
 
@@ -611,8 +613,8 @@ class SisteBeregningCreatorTest : FunSpec({
     test("opprettSisteBeregning should filter vedtak by all criteria combined") {
         val kravhode = createKravhodeWithSoeker(RegelverkTypeEnum.N_REG_G_OPPTJ)
         val beregningsresultat = createBeregningsresultat().apply {
-            virkFom = dateAtNoon(2025, Calendar.JUNE, 1)
-            virkTom = dateAtNoon(2025, Calendar.DECEMBER, 31)
+            virkFomLd = LocalDate.of(2025, 6, 1)
+            virkTom = LocalDate.of(2025, 12, 31).toNorwegianDateAtNoon()
         }
 
         // This vedtak passes all filters
@@ -727,7 +729,7 @@ private fun kravlinje(status: KravlinjeStatus, land: LandkodeEnum = LandkodeEnum
 
 private fun createBeregningsresultat() =
     BeregningsResultatAlderspensjon2011().apply {
-        virkFom = dateAtNoon(2025, Calendar.JANUARY, 1)
+        virkFomLd = LocalDate.of(2025, 1, 1)
         beregningKapittel19 = AldersberegningKapittel19().apply {
             pensjonUnderUtbetaling = PensjonUnderUtbetaling()
         }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutputMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutputMapperTest.kt
@@ -1034,7 +1034,7 @@ class SimulatorOutputMapperTest : FunSpec({
     test("mapToSimulertOpptjening should get pensjonBeholdning from beregningsresultat when not in persongrunnlag") {
         val persongrunnlag = Persongrunnlag()
         val beregningsResultat = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = LocalDate.of(2024, 1, 1).toNorwegianDateAtNoon()
+            virkFomLd = LocalDate.of(2024, 1, 1)
             uttaksgrad = 100
             beregningKapittel20 = AldersberegningKapittel20().apply {
                 beholdninger = Beholdninger().apply {

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimuleringResultPreparerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimuleringResultPreparerTest.kt
@@ -17,15 +17,12 @@ import no.nav.pensjon.simulator.core.domain.regler.beregning.BarnetilleggSerkull
 import no.nav.pensjon.simulator.core.domain.regler.beregning.Ektefelletillegg
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 import no.nav.pensjon.simulator.core.domain.regler.enum.*
-import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Beholdninger
-import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Pensjonsbeholdning
-import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonDetalj
-import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Persongrunnlag
-import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.*
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresultat
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
 import no.nav.pensjon.simulator.tech.time.Time
 import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
@@ -171,7 +168,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2025, 1, 1)
 
         val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2027, 7, 1)
+            virkFomLd = LocalDate.of(2027, 8, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000
@@ -206,7 +203,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns today
 
         val forrigeResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 4, 1)
+            virkFomLd = LocalDate.of(2025, 5, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 18000
@@ -214,7 +211,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 7, 1)
+            virkFomLd = LocalDate.of(2025, 8, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 19000
@@ -251,7 +248,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2025, 1, 1)
 
         val afpResultat = BeregningsResultatAfpPrivat().apply {
-            virkFom = dateAtNoon(2030, 2, 1)
+            virkFomLd = LocalDate.of(2030, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 5000
@@ -340,7 +337,7 @@ class SimuleringResultPreparerTest : FunSpec({
 
         val uttaksgrad = Uttaksgrad().apply {
             uttaksgrad = 50
-            fomDato = dateAtNoon(2030, 2, 1)
+            fomDato = LocalDate.of(2030, 3, 1).toNorwegianDateAtNoon()
         }
 
         val spec = resultPreparerSpec(
@@ -403,7 +400,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2024, 1, 1)
 
         val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2030, 2, 1)
+            virkFomLd = LocalDate.of(2030, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 22000
@@ -462,7 +459,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2025, 1, 1)
 
         val beregningsresultat2016 = BeregningsResultatAlderspensjon2016().apply {
-            virkFom = dateAtNoon(2027, 7, 1)
+            virkFomLd = LocalDate.of(2027, 8, 1)
             virkTom = null
             andelKapittel19 = 5 // 50%
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
@@ -500,18 +497,18 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2025, 1, 1)
 
         val gradertResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2028, 2, 1)
-            virkTom = dateAtNoon(2030, 1, 31)
+            virkFomLd = LocalDate.of(2028, 3, 1)
+            virkTom = LocalDate.of(2030, 2, 28).toNorwegianDateAtNoon()
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
-                totalbelopNetto = 10000 // 50% uttak
+                totalbelopNetto = 10000 // 50 % uttak
             }
         }
 
         val heltResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2030, 2, 1)
+            virkFomLd = LocalDate.of(2030, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
-                totalbelopNetto = 20000 // 100% uttak
+                totalbelopNetto = 20000 // 100 % uttak
             }
         }
 
@@ -544,7 +541,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2025, 1, 1)
 
         val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2030, 2, 1)
+            virkFomLd = LocalDate.of(2030, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000
@@ -578,7 +575,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2025, 6, 1) // User already receiving AFP
 
         val forrigeAfpResultat = BeregningsResultatAfpPrivat().apply {
-            virkFom = dateAtNoon(2023, 2, 1)
+            virkFomLd = LocalDate.of(2023, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 4500
@@ -587,7 +584,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttAfpResultat = BeregningsResultatAfpPrivat().apply {
-            virkFom = dateAtNoon(2025, 7, 1)
+            virkFomLd = LocalDate.of(2025, 8, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 4800
@@ -626,7 +623,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2035, 1, 1)
 
         val beregningsresultat2025 = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2037, 7, 1)
+            virkFomLd = LocalDate.of(2037, 8, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 28000
@@ -785,7 +782,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns today
 
         val forrigeResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 2, 1)
+            virkFomLd = LocalDate.of(2025, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 18000
@@ -798,7 +795,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2026, 4, 1)
+            virkFomLd = LocalDate.of(2026, 5, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 19000
@@ -833,7 +830,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns today
 
         val forrigeResultat = BeregningsResultatAlderspensjon2016().apply {
-            virkFom = dateAtNoon(2027, 7, 1)
+            virkFomLd = LocalDate.of(2027, 8, 1)
             virkTom = null
             andelKapittel19 = 5
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
@@ -849,7 +846,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttResultat = BeregningsResultatAlderspensjon2016().apply {
-            virkFom = dateAtNoon(2028, 9, 1)
+            virkFomLd = LocalDate.of(2028, 10, 1)
             virkTom = null
             andelKapittel19 = 5
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
@@ -887,7 +884,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns today
 
         val forrigeResultat = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2037, 2, 1)
+            virkFomLd = LocalDate.of(2037, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 28000
@@ -895,7 +892,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttResultat = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2038, 4, 1)
+            virkFomLd = LocalDate.of(2038, 5, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 29000
@@ -931,7 +928,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2024, 1, 1)
 
         val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 2, 1)
+            virkFomLd = LocalDate.of(2025, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 15000
@@ -966,7 +963,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns today
 
         val forrigeResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 4, 1)
+            virkFomLd = LocalDate.of(2025, 5, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 18000
@@ -974,7 +971,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 7, 1)
+            virkFomLd = LocalDate.of(2025, 8, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 19000
@@ -1011,15 +1008,15 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2025, 1, 1)
 
         val resultat1 = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2030, 2, 1)
-            virkTom = dateAtNoon(2030, 6, 30)
+            virkFomLd = LocalDate.of(2030, 3, 1)
+            virkTom = LocalDate.of(2030, 7, 30).toNorwegianDateAtNoon()
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 18000
             }
         }
 
         val resultat2 = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2030, 7, 1)
+            virkFomLd = LocalDate.of(2030, 8, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000
@@ -1053,7 +1050,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2025, 6, 1)
 
         val forrigeAfpResultat = BeregningsResultatAfpPrivat().apply {
-            virkFom = dateAtNoon(2023, 2, 1)
+            virkFomLd = LocalDate.of(2023, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 4500
@@ -1090,7 +1087,7 @@ class SimuleringResultPreparerTest : FunSpec({
 
         // BeregningsResultatAlderspensjon2016 with andelKapittel19 not set (defaults to 0)
         val beregningsresultat2016 = BeregningsResultatAlderspensjon2016().apply {
-            virkFom = dateAtNoon(2027, 7, 1)
+            virkFomLd = LocalDate.of(2027, 8, 1)
             virkTom = null
             // andelKapittel19 not explicitly set, uses default 0
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
@@ -1153,7 +1150,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2021, 1, 1)
 
         val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2027, 2, 1)
+            virkFomLd = LocalDate.of(2027, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000
@@ -1192,7 +1189,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2021, 1, 1)
 
         val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2027, 2, 1)
+            virkFomLd = LocalDate.of(2027, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000
@@ -1290,7 +1287,7 @@ class SimuleringResultPreparerTest : FunSpec({
         )
 
         val beregningsresultat2025 = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2037, 2, 1)
+            virkFomLd = LocalDate.of(2037, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 28000
@@ -1317,7 +1314,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2025, 1, 1)
 
         val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2030, 7, 1)
+            virkFomLd = LocalDate.of(2030, 8, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000
@@ -1358,7 +1355,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2021, 1, 1)
 
         val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2027, 2, 1)
+            virkFomLd = LocalDate.of(2027, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000
@@ -1399,7 +1396,7 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2021, 1, 1)
 
         val beregningsresultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2027, 2, 1)
+            virkFomLd = LocalDate.of(2027, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000
@@ -1438,15 +1435,15 @@ class SimuleringResultPreparerTest : FunSpec({
         every { time.today() } returns LocalDate.of(2025, 1, 1)
 
         val gradertResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2028, 2, 1)
-            virkTom = dateAtNoon(2030, 1, 31)
+            virkFomLd = LocalDate.of(2028, 3, 1)
+            virkTom = LocalDate.of(2030, 2, 31).toNorwegianDateAtNoon()
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 10000
             }
         }
 
         val heltResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2030, 2, 1)
+            virkFomLd = LocalDate.of(2030, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000
@@ -1495,7 +1492,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val forrigeResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 2, 1)
+            virkFomLd = LocalDate.of(2025, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000 // Before subtraction
@@ -1504,7 +1501,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2026, 4, 1)
+            virkFomLd = LocalDate.of(2026, 5, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 21000
@@ -1552,7 +1549,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val forrigeResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 2, 1)
+            virkFomLd = LocalDate.of(2025, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 20000
@@ -1561,7 +1558,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2026, 4, 1)
+            virkFomLd = LocalDate.of(2026, 5, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 21000
@@ -1606,7 +1603,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val forrigeResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 2, 1)
+            virkFomLd = LocalDate.of(2025, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 22000
@@ -1615,7 +1612,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2026, 4, 1)
+            virkFomLd = LocalDate.of(2026, 5, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 23000
@@ -1660,7 +1657,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val forrigeResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 2, 1)
+            virkFomLd = LocalDate.of(2025, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 25000
@@ -1669,7 +1666,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2026, 4, 1)
+            virkFomLd = LocalDate.of(2026, 5, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 26000
@@ -1723,7 +1720,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val forrigeResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 2, 1)
+            virkFomLd = LocalDate.of(2025, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 30000
@@ -1734,7 +1731,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val nyttResultat = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2026, 4, 1)
+            virkFomLd = LocalDate.of(2026, 5, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 31000
@@ -1779,7 +1776,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val beregningsresultat2016 = BeregningsResultatAlderspensjon2016().apply {
-            virkFom = dateAtNoon(2027, 7, 1)
+            virkFomLd = LocalDate.of(2027, 8, 1)
             virkTom = null
             andelKapittel19 = 5 // 50%
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
@@ -1834,7 +1831,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val beregningsresultat2025 = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2037, 2, 1)
+            virkFomLd = LocalDate.of(2037, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 28000
@@ -1890,7 +1887,7 @@ class SimuleringResultPreparerTest : FunSpec({
             }
 
         val forrigeResultat = BeregningsResultatAlderspensjon2016().apply {
-            virkFom = dateAtNoon(2025, 7, 1)
+            virkFomLd = LocalDate.of(2025, 8, 1)
             virkTom = null
             andelKapittel19 = 5
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
@@ -1907,7 +1904,7 @@ class SimuleringResultPreparerTest : FunSpec({
 
         // Create new beregningsresultat for the simulation
         val nyttResultat = BeregningsResultatAlderspensjon2016().apply {
-            virkFom = dateAtNoon(2026, 9, 1) // After today
+            virkFomLd = LocalDate.of(2026, 10, 1) // After today
             virkTom = null
             andelKapittel19 = 5
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
@@ -1962,7 +1959,7 @@ class SimuleringResultPreparerTest : FunSpec({
             }
 
         val forrigeResultat = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2035, 2, 1)
+            virkFomLd = LocalDate.of(2035, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 26000
@@ -1976,7 +1973,7 @@ class SimuleringResultPreparerTest : FunSpec({
 
         // Create new beregningsresultat for the simulation
         val nyttResultat = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2036, 4, 1) // After today
+            virkFomLd = LocalDate.of(2036, 5, 1) // After today
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 28000
@@ -2054,9 +2051,8 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         // Create beregningsresultat - no forrigeResultat triggers findBeholdningFraPersongrunnlag
-        // Note: dateAtNoon uses zero-based month, so 6 = July
         val beregningsresultat2016 = BeregningsResultatAlderspensjon2016().apply {
-            virkFom = dateAtNoon(2027, 6, 1) // July 1 (zero-based month)
+            virkFomLd = LocalDate.of(2027, 7, 1)
             virkTom = null
             andelKapittel19 = 5
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
@@ -2164,9 +2160,8 @@ class SimuleringResultPreparerTest : FunSpec({
             regelverkTypeEnum = RegelverkTypeEnum.N_REG_N_OPPTJ
         }
 
-        // Note: dateAtNoon uses zero-based month, so 1 = February
         val beregningsresultat2025 = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2037, 1, 1) // February 1 (zero-based month)
+            virkFomLd = LocalDate.of(2037, 2, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 28000
@@ -2273,9 +2268,8 @@ class SimuleringResultPreparerTest : FunSpec({
             regelverkTypeEnum = RegelverkTypeEnum.N_REG_G_OPPTJ // Not in the EnumSet
         }
 
-        // Note: dateAtNoon uses zero-based month, so 1 = February
         val beregningsresultat2011 = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 1, 1) // February 1 (zero-based month)
+            virkFomLd = LocalDate.of(2025, 2, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 18000
@@ -2373,17 +2367,17 @@ class SimuleringResultPreparerTest : FunSpec({
                 Pensjonsbeholdning().apply {
                     ar = 2036 // Different year - should be filtered out
                     totalbelop = 3000000.0
-                    fom = dateAtNoon(2036, 0, 1) // January 2036
+                    fom = LocalDate.of(2036, 1, 1).toNorwegianDateAtNoon()
                 },
                 Pensjonsbeholdning().apply {
                     ar = 2037 // Matching year - first entry
                     totalbelop = 3400000.0
-                    fom = dateAtNoon(2037, 0, 1) // January 2037
+                    fom = LocalDate.of(2037, 1, 1).toNorwegianDateAtNoon()
                 },
                 Pensjonsbeholdning().apply {
                     ar = 2037 // Matching year - second entry (should be picked as "latest" due to later fom)
                     totalbelop = 3500000.0
-                    fom = dateAtNoon(2037, 6, 1) // July 2037 - later than first 2037 entry
+                    fom = LocalDate.of(2037, 7, 1).toNorwegianDateAtNoon() // later than first 2037 entry
                 }
             )
         }
@@ -2393,9 +2387,8 @@ class SimuleringResultPreparerTest : FunSpec({
             regelverkTypeEnum = RegelverkTypeEnum.N_REG_N_OPPTJ
         }
 
-        // Note: dateAtNoon uses zero-based month, so 1 = February
         val beregningsresultat2025 = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2037, 1, 1) // February 1 (zero-based month)
+            virkFomLd = LocalDate.of(2037, 2, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 28000
@@ -2501,9 +2494,8 @@ class SimuleringResultPreparerTest : FunSpec({
             regelverkTypeEnum = RegelverkTypeEnum.N_REG_N_OPPTJ
         }
 
-        // Note: dateAtNoon uses zero-based month, so 1 = February
         val beregningsresultat2025 = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2037, 1, 1) // February 1 (zero-based month)
+            virkFomLd = LocalDate.of(2037, 2, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 28000
@@ -2609,7 +2601,7 @@ class SimuleringResultPreparerTest : FunSpec({
 
         // Create beregningsresultat without beholdning (to trigger findBeholdningFraPersongrunnlag)
         val beregningsresultat2016 = BeregningsResultatAlderspensjon2016().apply {
-            virkFom = dateAtNoon(2027, 7, 1)
+            virkFomLd = LocalDate.of(2027, 8, 1)
             virkTom = null
             andelKapittel19 = 5
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
@@ -2706,7 +2698,7 @@ class SimuleringResultPreparerTest : FunSpec({
 
         // Create beregningsresultat without beholdning
         val beregningsresultat2025 = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2037, 2, 1)
+            virkFomLd = LocalDate.of(2037, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 28000
@@ -2799,7 +2791,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val beregningsresultat2011 = BeregningsResultatAlderspensjon2011().apply {
-            virkFom = dateAtNoon(2025, 2, 1)
+            virkFomLd = LocalDate.of(2025, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 18000
@@ -2900,7 +2892,7 @@ class SimuleringResultPreparerTest : FunSpec({
         }
 
         val beregningsresultat2025 = BeregningsResultatAlderspensjon2025().apply {
-            virkFom = dateAtNoon(2037, 2, 1)
+            virkFomLd = LocalDate.of(2037, 3, 1)
             virkTom = null
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 28000

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimuleringResultPreparerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimuleringResultPreparerTest.kt
@@ -1436,7 +1436,7 @@ class SimuleringResultPreparerTest : FunSpec({
 
         val gradertResultat = BeregningsResultatAlderspensjon2011().apply {
             virkFomLd = LocalDate.of(2028, 3, 1)
-            virkTom = LocalDate.of(2030, 2, 31).toNorwegianDateAtNoon()
+            virkTom = LocalDate.of(2030, 2, 28).toNorwegianDateAtNoon()
             pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
                 totalbelopNetto = 10000
             }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimulertOpptjeningAdderTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimulertOpptjeningAdderTest.kt
@@ -66,7 +66,7 @@ class SimulertOpptjeningAdderTest : FunSpec({
 
 private fun beregningsresultat2016(kalenderAar: Int, pensjonspoeng: Double) =
     BeregningsResultatAlderspensjon2016().apply {
-        virkFom = dateAtMidnight(kalenderAar, Calendar.JANUARY, 1)
+        virkFomLd = LocalDate.of(kalenderAar, 1, 1)
         beregningsResultat2011 = BeregningsResultatAlderspensjon2011().apply {
             beregningsInformasjonKapittel19 = BeregningsInformasjon().apply {
                 spt = Sluttpoengtall().apply {


### PR DESCRIPTION
Bakgrunn: pensjon-regler-api støtter nå datoer i form av `LocalDate` (feltene har suffix "Ld" for å skille dem fra de gamle `Date`-feltene).

Denne PR bytter ut `Date` med `LocalDate` i `AbstraktBeregningsResultat` og `BeregnAlderspensjon2011ForsteUttakRequest`.

NB: I `AbstraktBeregningsResultat` beholdes foreløpig `virkTom: Date`, da dette feltet brukes i kall til PEN, ikke til pensjon-regler-api.

I tillegg:

- Bruker `ImplementationUnrecoverableException` istedenfor den mindre spesifikke `RuntimeException`
- Noe refaktorering