### PR TITLE
TPP-227 Handle 'løpende 0-uttak' for 'tidsbegrenset AFP'

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgrad.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgrad.kt
@@ -3,11 +3,12 @@ package no.nav.pensjon.simulator.afp.offentlig.pre2025
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
-import no.nav.pensjon.simulator.core.domain.reglerextend.grunnlag.copy
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
+import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.krav.KravService
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
+import no.nav.pensjon.simulator.validity.BadSpecException
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
@@ -29,19 +30,25 @@ class Pre2025OffentligAfpUttaksgrad(
         val ubetingetUttakDato: LocalDate = ubetingetUttakDato(foedselsdato)
 
         if (forrigeAlderspensjonBeregningResultat == null) {
-            return mutableListOf(uttaksgrad(fom = ubetingetUttakDato, grad = 100, tom = null))
+            return mutableListOf(ubetingetHeltUttak(fom = ubetingetUttakDato))
         }
 
         val eksisterendeKravhode: Kravhode? =
             forrigeAlderspensjonBeregningResultat.kravId?.let(kravService::fetchKravhode)
 
-        val uttaksgradListe: MutableList<Uttaksgrad> = mutableListOf()
-        uttaksgradListe.addAll(eksisterendeKravhode?.uttaksgradListe.orEmpty().map { it.copy() })
-        spec.foersteUttakDato?.let { replaceNullTom(uttaksgradListe, it.minusDays(1)) }
+        val afpFom: LocalDate = spec.foersteUttakDato!!
+        val uttaksgradListe: MutableList<Uttaksgrad> = behandleVedtatteUttaksgrader(eksisterendeKravhode, afpFom)
+        val minimumAfpFom: LocalDate? = alderspensjonTom(uttaksgradListe)?.plusDays(1)
+        minimumAfpFom?.let { validateAfpStart(afpFom, minimumFom = it) }
+        val alderspensjonTerminertFom = minimumAfpFom?.coerceAtMost(afpFom)
 
-        val foersteTom: LocalDate = ubetingetUttakDato.minusDays(1)
-        uttaksgradListe.add(uttaksgrad(fom = spec.foersteUttakDato, grad = 0, tom = foersteTom))
-        uttaksgradListe.add(uttaksgrad(fom = ubetingetUttakDato, grad = 100, tom = null))
+        // Fra alderspensjonens slutt t.o.m. AFP-periodens slutt må uttaksgraden være 0:
+        val afpTom: LocalDate = ubetingetUttakDato.minusDays(1)
+        uttaksgradListe.add(uttaksgrad(fom = alderspensjonTerminertFom, grad = 0, tom = afpTom))
+
+        // Ta ut hel alderspensjon ved normert pensjonsalder (dagen etter AFP-periodens slutt):
+        uttaksgradListe.add(ubetingetHeltUttak(fom = ubetingetUttakDato))
+
         return uttaksgradListe
     }
 
@@ -55,6 +62,28 @@ class Pre2025OffentligAfpUttaksgrad(
 
     private companion object {
 
+        private fun alderspensjonTom(uttaksgradListe: List<Uttaksgrad>): LocalDate? =
+            uttaksgradListe.maxByOrNull { it.tomDato!! }?.tomDato?.toNorwegianLocalDate()
+
+        private fun ubetingetHeltUttak(fom: LocalDate): Uttaksgrad =
+            uttaksgrad(fom, grad = 100, tom = null)
+
+        private fun behandleVedtatteUttaksgrader(
+            kravhode: Kravhode?,
+            afpFom: LocalDate
+        ): MutableList<Uttaksgrad> {
+            // Fjern eksisterende uttaksgradperioder med 0 %, da det skal legges til en 0-periode som dekker AFP-perioden:
+            val uttaksgradListe = uttaksgraderUten0(kravhode).toMutableList()
+
+            // Terminer alderspensjon (kan ikke kombineres med tidsbegrenset AFP):
+            replaceNullTom(uttaksgradListe, tom = afpFom.minusDays(1))
+
+            return uttaksgradListe
+        }
+
+        private fun uttaksgraderUten0(kravhode: Kravhode?): List<Uttaksgrad> =
+            kravhode?.uttaksgradListe.orEmpty().filter { it.uttaksgrad != 0 }
+
         // PEN: SimulerAFPogAPCommandHelper.updateUttaksgradWithTomDateNull
         private fun replaceNullTom(uttaksgradListe: List<Uttaksgrad>, tom: LocalDate) {
             uttaksgradListe.forEach {
@@ -65,12 +94,19 @@ class Pre2025OffentligAfpUttaksgrad(
             }
         }
 
-        // PEN: SimulerAFPogAPCommandHelper.createUttaksgrad
         private fun uttaksgrad(fom: LocalDate?, grad: Int, tom: LocalDate?) =
             Uttaksgrad().apply {
                 fomDato = fom?.toNorwegianDateAtNoon()
                 tomDato = tom?.toNorwegianDateAtNoon()
                 uttaksgrad = grad
             }
+
+        private fun validateAfpStart(afpFom: LocalDate, minimumFom: LocalDate) {
+            if (afpFom.isBefore(minimumFom)) {
+                throw BadSpecException(
+                    "For tidlig uttak av AFP (må starte etter alderspensjonsperiodens slutt, dvs. tidligst $minimumFom)"
+                )
+            }
+        }
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgrad.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgrad.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.simulator.afp.offentlig.pre2025
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.domain.reglerextend.grunnlag.copy
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
 import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
@@ -27,27 +28,24 @@ class Pre2025OffentligAfpUttaksgrad(
         forrigeAlderspensjonBeregningResultat: AbstraktBeregningsResultat?,
         foedselsdato: LocalDate
     ): MutableList<Uttaksgrad> {
-        val ubetingetUttakDato: LocalDate = ubetingetUttakDato(foedselsdato)
+        val ubetingetUttakFom: LocalDate = ubetingetUttakDato(foedselsdato)
 
         if (forrigeAlderspensjonBeregningResultat == null) {
-            return mutableListOf(ubetingetHeltUttak(fom = ubetingetUttakDato))
+            return mutableListOf(ubetingetHeltUttak(fom = ubetingetUttakFom))
         }
 
         val eksisterendeKravhode: Kravhode? =
             forrigeAlderspensjonBeregningResultat.kravId?.let(kravService::fetchKravhode)
 
         val afpFom: LocalDate = spec.foersteUttakDato!!
-        val uttaksgradListe: MutableList<Uttaksgrad> = behandleVedtatteUttaksgrader(eksisterendeKravhode, afpFom)
-        val minimumAfpFom: LocalDate? = alderspensjonTom(uttaksgradListe)?.plusDays(1)
-        minimumAfpFom?.let { validateAfpStart(afpFom, minimumFom = it) }
-        val alderspensjonTerminertFom = minimumAfpFom?.coerceAtMost(afpFom)
 
-        // Fra alderspensjonens slutt t.o.m. AFP-periodens slutt må uttaksgraden være 0:
-        val afpTom: LocalDate = ubetingetUttakDato.minusDays(1)
-        uttaksgradListe.add(uttaksgrad(fom = alderspensjonTerminertFom, grad = 0, tom = afpTom))
+        val uttaksgradListe: MutableList<Uttaksgrad> = behandleVedtatteUttaksgrader(eksisterendeKravhode, afpFom)
+        // I uttaksgradListe har alle elementer nå en definert t.o.m.-dato
+
+        terminerEksisterendeAlderspensjon(uttaksgradListe, afpFom, ubetingetUttakFom)
 
         // Ta ut hel alderspensjon ved normert pensjonsalder (dagen etter AFP-periodens slutt):
-        uttaksgradListe.add(ubetingetHeltUttak(fom = ubetingetUttakDato))
+        uttaksgradListe.add(ubetingetHeltUttak(fom = ubetingetUttakFom))
 
         return uttaksgradListe
     }
@@ -62,8 +60,30 @@ class Pre2025OffentligAfpUttaksgrad(
 
     private companion object {
 
-        private fun alderspensjonTom(uttaksgradListe: List<Uttaksgrad>): LocalDate? =
+        /**
+         * Sikrer at det ikke tas ut alderspensjon før eller i AFP-perioden,
+         * siden tidsbegrenset AFP må være avsluttet før alderspensjonen kan starte.
+         */
+        private fun terminerEksisterendeAlderspensjon(
+            uttaksgradListe: MutableList<Uttaksgrad>,
+            afpFom: LocalDate,
+            ubetingetUttakFom: LocalDate
+        ) {
+            if (uttaksgradListe.isEmpty()) return
+
+            val minimumAfpFom: LocalDate = alderspensjonTom(uttaksgradListe).plusDays(1)
+            validateAfpStart(afpFom, minimumFom = minimumAfpFom)
+            val alderspensjonTerminertFom = minimumAfpFom.coerceAtMost(afpFom)
+            // Fra alderspensjonens slutt t.o.m. AFP-periodens slutt må uttaksgraden være 0:
+            val afpTom: LocalDate = ubetingetUttakFom.minusDays(1)
+            uttaksgradListe.add(uttaksgrad(fom = alderspensjonTerminertFom, grad = 0, tom = afpTom))
+        }
+
+        private fun alderspensjonTom(uttaksgradListe: List<Uttaksgrad>): LocalDate =
             uttaksgradListe.maxByOrNull { it.tomDato!! }?.tomDato?.toNorwegianLocalDate()
+                ?: throw IllegalStateException(
+                    "uttaksgradListe må inneholde minst ett element og alle elementer må ha definert tomDato"
+                )
 
         private fun ubetingetHeltUttak(fom: LocalDate): Uttaksgrad =
             uttaksgrad(fom, grad = 100, tom = null)
@@ -72,8 +92,10 @@ class Pre2025OffentligAfpUttaksgrad(
             kravhode: Kravhode?,
             afpFom: LocalDate
         ): MutableList<Uttaksgrad> {
-            // Fjern eksisterende uttaksgradperioder med 0 %, da det skal legges til en 0-periode som dekker AFP-perioden:
-            val uttaksgradListe = uttaksgraderUten0(kravhode).toMutableList()
+            // Fjern eksisterende uttaksgradperioder med 0 %,
+            // da det skal legges til en 0-periode som dekker AFP-perioden
+            // (gjøres på en kopi av uttaksgradperiodene, slik at det ikke er noen endringer i originalen):
+            val uttaksgradListe = uttaksgraderUten0(kravhode).map { it.copy() }.toMutableList()
 
             // Terminer alderspensjon (kan ikke kombineres med tidsbegrenset AFP):
             replaceNullTom(uttaksgradListe, tom = afpFom.minusDays(1))

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgradTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgradTest.kt
@@ -1,15 +1,23 @@
 package no.nav.pensjon.simulator.afp.offentlig.pre2025
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.mockk
+import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsResultatAlderspensjon2016
+import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
+import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.util.toNorwegianDateAtNoon
+import no.nav.pensjon.simulator.krav.KravService
 import no.nav.pensjon.simulator.testutil.Arrange
 import no.nav.pensjon.simulator.testutil.TestDateUtil.dateAtNoon
 import no.nav.pensjon.simulator.testutil.TestObjects.simuleringSpec
+import no.nav.pensjon.simulator.validity.BadSpecException
 import java.time.LocalDate
 import java.util.*
 
-class Pre2025OffentligAfpUttaksgradTest : FunSpec({
+class Pre2025OffentligAfpUttaksgradTest : ShouldSpec({
 
     /**
      * Tester at uttaksgrad-listen ved førstegangsuttak inneholder 100 % grad f.o.m. 1. dag i måneden etter at
@@ -18,21 +26,144 @@ class Pre2025OffentligAfpUttaksgradTest : FunSpec({
      * Med fødselsdato 1963-01-15 og normalder 67 år, så oppnås normalder 2030-01-15.
      * 1. dag i måneden etter dette er 2030-02-01.
      */
-    test("uttaksgradListe ved førstegangsuttak skal inneholde 100 % uttaksgrad") {
-        val uttaksgradListe = Pre2025OffentligAfpUttaksgrad(
-            kravService = mockk(),
-            normalderService = Arrange.normalder(foedselsdato = LocalDate.of(1963, 1, 15))
-        ).uttaksgradListe(
-            spec = simuleringSpec,
-            forrigeAlderspensjonBeregningResultat = null, // => førstegangsuttak
-            foedselsdato = LocalDate.of(1963, 1, 15)
-        )
+    context("førstegangsuttak") {
+        should("uttaksgradliste inneholde 100 % uttaksgrad") {
+            val uttaksgradListe = Pre2025OffentligAfpUttaksgrad(
+                kravService = mockk(),
+                normalderService = Arrange.normalder(foedselsdato = LocalDate.of(1963, 1, 15))
+            ).uttaksgradListe(
+                spec = simuleringSpec,
+                forrigeAlderspensjonBeregningResultat = null, // => førstegangsuttak
+                foedselsdato = LocalDate.of(1963, 1, 15)
+            )
 
-        uttaksgradListe.size shouldBe 1
-        with(uttaksgradListe[0]) {
-            fomDato shouldBe dateAtNoon(2030, Calendar.FEBRUARY, 1)
-            tomDato shouldBe null // => tidsubegrenset
-            uttaksgrad shouldBe 100
+            uttaksgradListe.size shouldBe 1
+            with(uttaksgradListe[0]) {
+                fomDato shouldBe dateAtNoon(2030, Calendar.FEBRUARY, 1)
+                tomDato shouldBe null // => tidsubegrenset
+                uttaksgrad shouldBe 100
+            }
+        }
+    }
+
+    context("AFP-perioden overlapper alderspensjonsperioden") {
+        should("gi beskrivende feilmelding") {
+            // AFP-perioden overlapper alderspensjonsperioden med 1 måned:
+            val startdatoForAfp = historiskAlderspensjonTom.minusMonths(1).plusDays(1)
+            val loepende0Uttak: Uttaksgrad = loepende0Uttak(fom = startdatoForAfp)
+            val foedselsdato = LocalDate.of(1962, 1, 15)
+
+            shouldThrow<BadSpecException> {
+                Pre2025OffentligAfpUttaksgrad(
+                    kravService = arrangeKrav(loepende0Uttak),
+                    normalderService = Arrange.normalder(foedselsdato)
+                ).uttaksgradListe(
+                    spec = simuleringSpec(foersteUttakDato = startdatoForAfp),
+                    forrigeAlderspensjonBeregningResultat = BeregningsResultatAlderspensjon2016().apply { kravId = 1L },
+                    foedselsdato
+                )
+            }.message shouldBe
+                    "For tidlig uttak av AFP (må starte etter alderspensjonsperiodens slutt, dvs. tidligst 2026-03-01)"
+        }
+    }
+
+    context("løpende 0-uttak fra samme dato som startdato for AFP") {
+        should("uttaksgradliste inneholde 0 % uttaksgrad") {
+            val startdatoForAfp = historiskAlderspensjonTom.plusDays(1)
+            val loepende0Uttak: Uttaksgrad = loepende0Uttak(fom = startdatoForAfp)
+            val foedselsdato = LocalDate.of(1962, 1, 15)
+            // Med normalder 67 år 0 måneder blir ubetinget uttaksdato 2029-02-01
+
+            val uttaksgradListe = Pre2025OffentligAfpUttaksgrad(
+                kravService = arrangeKrav(loepende0Uttak),
+                normalderService = Arrange.normalder(foedselsdato) // normalder 67 år 0 måneder
+            ).uttaksgradListe(
+                spec = simuleringSpec(foersteUttakDato = startdatoForAfp),
+                forrigeAlderspensjonBeregningResultat = BeregningsResultatAlderspensjon2016().apply { kravId = 1L },
+                foedselsdato
+            )
+
+            uttaksgradListe.size shouldBe 3
+            with(uttaksgradListe[0]) {
+                // Terminert alderspensjonsperiode:
+                fomDato shouldBe LocalDate.of(2024, 1, 1).toNorwegianDateAtNoon()
+                tomDato shouldBe historiskAlderspensjonTom.toNorwegianDateAtNoon()
+                uttaksgrad shouldBe 100
+            }
+            with(uttaksgradListe[1]) {
+                // AFP-periode:
+                fomDato shouldBe LocalDate.of(2026, 3, 1).toNorwegianDateAtNoon()
+                tomDato shouldBe LocalDate.of(2029, 1, 31).toNorwegianDateAtNoon()
+                uttaksgrad shouldBe 0
+            }
+            with(uttaksgradListe[2]) {
+                // Alderspensjon etter AFP, f.o.m. ubetinget uttaksdato:
+                fomDato shouldBe LocalDate.of(2029, 2, 1).toNorwegianDateAtNoon()
+                tomDato shouldBe null // => tidsubegrenset
+                uttaksgrad shouldBe 100
+            }
+        }
+    }
+
+    context("løpende 0-uttak fra måneden før startdato for AFP, med gap mellom historisk alderspensjon og AFP-perioden") {
+        should("uttaksgradlisten være kontinuerlig") {
+            // 1 måneds gap mellom historisk alderspensjon og AFP-perioden:
+            val startdatoForAfp = historiskAlderspensjonTom.plusMonths(1).plusDays(1)
+            val loepende0Uttak: Uttaksgrad = loepende0Uttak(fom = startdatoForAfp.minusMonths(1))
+            val foedselsdato = LocalDate.of(1962, 1, 15)
+            // Med normalder 67 år 0 måneder blir ubetinget uttaksdato 2029-02-01
+
+            val uttaksgradListe = Pre2025OffentligAfpUttaksgrad(
+                kravService = arrangeKrav(loepende0Uttak),
+                normalderService = Arrange.normalder(foedselsdato) // normalder 67 år 0 måneder
+            ).uttaksgradListe(
+                spec = simuleringSpec(foersteUttakDato = startdatoForAfp),
+                forrigeAlderspensjonBeregningResultat = BeregningsResultatAlderspensjon2016().apply { kravId = 1L },
+                foedselsdato
+            )
+
+            uttaksgradListe.size shouldBe 3
+            with(uttaksgradListe[0]) {
+                // Terminert alderspensjonsperiode:
+                fomDato shouldBe LocalDate.of(2024, 1, 1).toNorwegianDateAtNoon()
+                tomDato shouldBe historiskAlderspensjonTom.toNorwegianDateAtNoon()
+                uttaksgrad shouldBe 100
+            }
+            with(uttaksgradListe[1]) {
+                // AFP-periode:
+                fomDato shouldBe LocalDate.of(2026, 3, 1).toNorwegianDateAtNoon()
+                tomDato shouldBe LocalDate.of(2029, 1, 31).toNorwegianDateAtNoon()
+                uttaksgrad shouldBe 0
+            }
+            with(uttaksgradListe[2]) {
+                // Alderspensjon etter AFP, f.o.m. ubetinget uttaksdato:
+                fomDato shouldBe LocalDate.of(2029, 2, 1).toNorwegianDateAtNoon()
+                tomDato shouldBe null // => tidsubegrenset
+                uttaksgrad shouldBe 100
+            }
         }
     }
 })
+
+private val historiskAlderspensjonTom = LocalDate.of(2026, 2, 28)
+
+private fun arrangeKrav(loepende0Uttak: Uttaksgrad): KravService =
+    mockk<KravService>().apply {
+        every { fetchKravhode(any()) } returns Kravhode().apply {
+            uttaksgradListe = mutableListOf(
+                Uttaksgrad().apply {
+                    uttaksgrad = 100
+                    fomDato = LocalDate.of(2024, 1, 1).toNorwegianDateAtNoon()
+                    tomDato = historiskAlderspensjonTom.toNorwegianDateAtNoon()
+                },
+                loepende0Uttak
+            )
+        }
+    }
+
+private fun loepende0Uttak(fom: LocalDate) =
+    Uttaksgrad().apply {
+        uttaksgrad = 0
+        fomDato = fom.toNorwegianDateAtNoon()
+        tomDato = null
+    }


### PR DESCRIPTION
Fikser problemet med at man ikke kan simulere tidsbegrenset offentlig AFP f.o.m. samme måned som alderspensjonsuttaket er satt til 0.