### PR TITLE
Set virkFomLd in response from PEN

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/AbstraktBeregningsResultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/AbstraktBeregningsResultat.kt
@@ -19,6 +19,8 @@ import java.util.*
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 abstract class AbstraktBeregningsResultat {
+    @Deprecated("Use virkFomLd instead")
+    var virkFom: Date? = null // NB: required in call to PEN
     var virkFomLd: LocalDate? = null
     var pensjonUnderUtbetaling: PensjonUnderUtbetaling? = null
     var uttaksgrad = 0

--- a/src/main/kotlin/no/nav/pensjon/simulator/ytelse/client/pen/acl/PenLoependeYtelserResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/ytelse/client/pen/acl/PenLoependeYtelserResultMapper.kt
@@ -30,7 +30,9 @@ object PenLoependeYtelserResultMapper {
             forrigeBeregningsresultat = source.forrigeBeregningsresultat,
             forrigeVilkarsvedtakListe = source.forrigeVilkarsvedtakListe.orEmpty().map(::vilkaarsvedtak),
             avdoed = source.avdoed?.let(::avdoedYtelser)
-        )
+        ).apply {
+            this.forrigeBeregningsresultat?.let { it.virkFomLd = it.virkFom?.toNorwegianLocalDate() }
+        }
 
     private fun vilkaarsvedtak(source: PenVilkaarsvedtak) =
         VilkarsVedtak().apply {

--- a/src/main/kotlin/no/nav/pensjon/simulator/ytelse/client/pen/acl/PenLoependeYtelserResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/ytelse/client/pen/acl/PenLoependeYtelserResultMapper.kt
@@ -2,6 +2,7 @@ package no.nav.pensjon.simulator.ytelse.client.pen.acl
 
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravlinje
 import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
+import no.nav.pensjon.simulator.core.util.toNorwegianLocalDate
 import no.nav.pensjon.simulator.person.Pid
 import no.nav.pensjon.simulator.vedtak.VilkaarsvedtakKravlinje
 import no.nav.pensjon.simulator.ytelse.AlderspensjonYtelser
@@ -66,7 +67,9 @@ object PenLoependeYtelserResultMapper {
         PrivatAfpYtelser(
             virkningFom = source.virkningFom,
             forrigeBeregningsresultat = source.forrigeBeregningsresultat
-        )
+        ).apply {
+            this.forrigeBeregningsresultat?.let { it.virkFomLd = it.virkFom?.toNorwegianLocalDate() }
+        }
 
     private fun avdoedYtelser(source: PenInformasjonOmAvdoed) =
         InformasjonOmAvdoed(


### PR DESCRIPTION
Siden `virkFomLd` brukes i kall til pensjon-regler, og `virkFom` brukes (inntil videre) i kall til pensjon-pen, må begge feltene ha verdi.