### PR TITLE
TPP-265 Include 'problem' in result

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/acl/result/SimuleringResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/acl/result/SimuleringResultMapper.kt
@@ -22,7 +22,7 @@ object SimuleringResultMapper {
             tidsbegrensetOffentligAfp = pensjon?.pre2025OffentligAfp?.let(::tidsbegrensetOffentligAfp),
             privatAfpListe = pensjon?.privatAfp.orEmpty().map(::privatAfp),
             primaerTrygdetid = pensjon?.primaerTrygdetid?.let(::trygdetid),
-            vilkaarsproevingsresultat = vilkaarsproevingsresultat(source?.alternativ),
+            vilkaarsproevingsresultat = vilkaarsproevingsresultat(source?.alternativ, source?.problem),
             pensjonsgivendeInntektListe = pensjon?.opptjeningGrunnlagListe.orEmpty().map(::opptjeningGrunnlag),
             problem = source?.problem?.let(::problem)
         )
@@ -112,10 +112,10 @@ object SimuleringResultMapper {
             erUtilstrekkelig = source.erTilstrekkelig.not()
         )
 
-    private fun vilkaarsproevingsresultat(source: SimulertAlternativ?) =
+    private fun vilkaarsproevingsresultat(alternativ: SimulertAlternativ?, problem: Problem?) =
         VilkaarsproevingsresultatDto(
-            erInnvilget = source == null,
-            alternativ = source?.let(::alternativ)
+            erInnvilget = alternativ == null && problem == null,
+            alternativ = alternativ?.let(::alternativ)
         )
 
     private fun opptjeningGrunnlag(source: OpptjeningGrunnlag) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/exception/KonsistensenIGrunnlagetErFeilException.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/exception/KonsistensenIGrunnlagetErFeilException.kt
@@ -2,4 +2,9 @@ package no.nav.pensjon.simulator.core.exception
 
 // PEN070KonsistensenIGrunnlagetErFeilException
 // Can be replaced by RegelmotorValideringException?
-class KonsistensenIGrunnlagetErFeilException(e: Throwable) : RuntimeException(e)
+class KonsistensenIGrunnlagetErFeilException(
+    message: String? = "Konsistensen i grunnlaget er feil",
+    e: Throwable
+) : RuntimeException(message, e) {
+    constructor(e: Throwable) : this(e.toString(), e)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/exception/UtilstrekkeligOpptjeningException.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/exception/UtilstrekkeligOpptjeningException.kt
@@ -1,4 +1,4 @@
 package no.nav.pensjon.simulator.core.exception
 
 // PEN: no.nav.domain.pensjon.kjerne.exception.PEN225AvslagVilkarsprovingForLavtTidligUttakException
-class UtilstrekkeligOpptjeningException(message: String? = null) : RuntimeException(message)
+class UtilstrekkeligOpptjeningException(message: String? = "Utilstrekkelig opptjening") : RuntimeException(message)

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/exception/UtilstrekkeligTrygdetidException.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/exception/UtilstrekkeligTrygdetidException.kt
@@ -1,4 +1,4 @@
 package no.nav.pensjon.simulator.core.exception
 
 // no.nav.domain.pensjon.kjerne.exception.PEN224AvslagVilkarsprovingForKortTrygdetidException
-class UtilstrekkeligTrygdetidException : RuntimeException()
+class UtilstrekkeligTrygdetidException(message: String? = "Utilstrekkelig trygdetid") : RuntimeException(message)

--- a/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/TjenestepensjonSimuleringPre2025Facade.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/TjenestepensjonSimuleringPre2025Facade.kt
@@ -41,9 +41,9 @@ class TjenestepensjonSimuleringPre2025Facade(
         } catch (e: RegelmotorValideringException) {
             problem(e)
         } catch (e: UtilstrekkeligOpptjeningException) {
-            problem(e)
+            problem(e, type = ProblemType.UTILSTREKKELIG_OPPTJENING)
         } catch (e: UtilstrekkeligTrygdetidException) {
-            problem(e)
+            problem(e, type = ProblemType.UTILSTREKKELIG_TRYGDETID)
         }
 
     private fun problem(e: RuntimeException, type: ProblemType? = null) =

--- a/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/api/TjenestepensjonPre2025Controller.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/api/TjenestepensjonPre2025Controller.kt
@@ -19,6 +19,8 @@ import no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v1.SimulerOffent
 import no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v2.SimulerOffentligTjenestepensjonResultMapperV2.toDto
 import no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v2.SimulerOffentligTjenestepensjonSpecV2
 import no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v3.FeilkodeV3
+import no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v3.Pre2025TpV3Problem
+import no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v3.Pre2025TpV3ProblemType
 import no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v3.SimulerOffentligTjenestepensjonResultMapperV3
 import no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v3.SimulerOffentligTjenestepensjonResultV3
 import no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v3.SimulerOffentligTjenestepensjonSpecV3
@@ -163,7 +165,7 @@ class TjenestepensjonPre2025Controller(
             log.debug { "$FUNCTION_ID_V3 response: $resultV3" }
 
             return ResponseEntity
-                .status(result.problem?.let { HttpStatus.UNPROCESSABLE_ENTITY } ?: HttpStatus.OK)
+                .status(resultV3.problem?.kode?.httpStatus ?: HttpStatus.OK)
                 .body(resultV3)
         } catch (e: Exception) {
             log.error(e) { "$FUNCTION_ID intern feil for spec ${jsonMapper.writeValueAsRedactedString(specV3)}" }
@@ -177,7 +179,7 @@ class TjenestepensjonPre2025Controller(
 
     @ExceptionHandler(value = [Exception::class])
     private fun internalError(e: Exception): ResponseEntity<SimulerOffentligTjenestepensjonResultV3> =
-        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problem())
+        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problem(e))
 
     companion object {
         const val FUNCTION_ID = "nav-tps-pre-2025"
@@ -185,11 +187,15 @@ class TjenestepensjonPre2025Controller(
         const val FUNCTION_ID_V3 = "nav-tps-pre-2025-v3"
         const val ERROR_MESSAGE = "feil ved simulering av tjenestepensjon pre 2025"
 
-        private fun problem() =
+        private fun problem(e: Exception) =
             SimulerOffentligTjenestepensjonResultV3(
                 simulertPensjonListe = emptyList(),
                 feilkode = FeilkodeV3.TEKNISK_FEIL,
-                relevanteTpOrdninger = emptyList()
+                relevanteTpOrdninger = emptyList(),
+                problem = Pre2025TpV3Problem(
+                    kode = Pre2025TpV3ProblemType.ANNEN_SERVERFEIL,
+                    beskrivelse = e.message ?: ERROR_MESSAGE
+                )
             )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/api/acl/v3/SimulerOffentligTjenestepensjonResultMapperV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/api/acl/v3/SimulerOffentligTjenestepensjonResultMapperV3.kt
@@ -2,43 +2,55 @@ package no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v3
 
 import no.nav.pensjon.simulator.core.util.toNorwegianDate
 import no.nav.pensjon.simulator.tjenestepensjon.pre2025.SimulerOffentligTjenestepensjonResult
+import no.nav.pensjon.simulator.tjenestepensjon.pre2025.Utbetalingsperiode
+import no.nav.pensjon.simulator.validity.Problem
 
 object SimulerOffentligTjenestepensjonResultMapperV3 {
 
-    fun toDto(result: SimulerOffentligTjenestepensjonResult): SimulerOffentligTjenestepensjonResultV3 {
+    fun toDto(result: SimulerOffentligTjenestepensjonResult): SimulerOffentligTjenestepensjonResultV3 =
+        when {
+            result.brukerErIkkeMedlemAvTPOrdning ->
+                SimulerOffentligTjenestepensjonResultV3(
+                    simulertPensjonListe = emptyList(),
+                    feilkode = FeilkodeV3.BRUKER_IKKE_MEDLEM_AV_TP_ORDNING
+                )
 
-        if (result.brukerErIkkeMedlemAvTPOrdning) {
-            return SimulerOffentligTjenestepensjonResultV3(emptyList(), FeilkodeV3.BRUKER_IKKE_MEDLEM_AV_TP_ORDNING)
-        }
+            result.brukerErMedlemAvTPOrdningSomIkkeStoettes ->
+                SimulerOffentligTjenestepensjonResultV3(
+                    simulertPensjonListe = null,
+                    feilkode = FeilkodeV3.TP_ORDNING_STOETTES_IKKE,
+                    relevanteTpOrdninger = result.relevanteTpOrdninger
+                )
 
-        if (result.brukerErMedlemAvTPOrdningSomIkkeStoettes) {
-            return SimulerOffentligTjenestepensjonResultV3(
-                simulertPensjonListe = null,
-                feilkode = FeilkodeV3.TP_ORDNING_STOETTES_IKKE,
-                relevanteTpOrdninger = result.relevanteTpOrdninger
+            else -> SimulerOffentligTjenestepensjonResultV3(
+                simulertPensjonListe = listOf(pensjon(result)),
+                feilkode = result.feilkode?.let(FeilkodeV3::externalValue),
+                relevanteTpOrdninger = result.relevanteTpOrdninger,
+                problem = result.problem?.let(::problem)
             )
         }
 
-        val simulertPensjon = SimulertPensjonResultV3(
+    private fun pensjon(result: SimulerOffentligTjenestepensjonResult) =
+        SimulertPensjonResultV3(
             tpnr = result.tpnr,
             navnOrdning = result.navnOrdning,
             inkluderteOrdninger = result.inkluderteOrdningerListe,
             leverandorUrl = result.leverandorUrl,
-            utbetalingsperioder = result.utbetalingsperiodeListe.map {
-                UtbetalingsperiodeResultV3(
-                    grad = it.uttaksgrad,
-                    arligUtbetaling = it.arligUtbetaling,
-                    datoFom = it.datoFom.toNorwegianDate(),
-                    datoTom = it.datoTom?.toNorwegianDate(),
-                    ytelsekode = it.ytelsekode?.toString()
-                )
-            }
+            utbetalingsperioder = result.utbetalingsperiodeListe.map(::utbetalingsperiode)
         )
 
-        return SimulerOffentligTjenestepensjonResultV3(
-            listOf(simulertPensjon),
-            feilkode = result.feilkode?.let(FeilkodeV3::externalValue),
-            relevanteTpOrdninger = result.relevanteTpOrdninger
+    private fun utbetalingsperiode(source: Utbetalingsperiode) =
+        UtbetalingsperiodeResultV3(
+            grad = source.uttaksgrad,
+            arligUtbetaling = source.arligUtbetaling,
+            datoFom = source.datoFom.toNorwegianDate(), //TODO use LocalDate
+            datoTom = source.datoTom?.toNorwegianDate(),
+            ytelsekode = source.ytelsekode?.toString() //TODO use enum
         )
-    }
+
+    private fun problem(source: Problem) =
+        Pre2025TpV3Problem(
+            kode = Pre2025TpV3ProblemType.from(internalValue = source.type),
+            beskrivelse = source.beskrivelse
+        )
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/api/acl/v3/SimulerOffentligTjenestepensjonResultV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/api/acl/v3/SimulerOffentligTjenestepensjonResultV3.kt
@@ -1,7 +1,47 @@
 package no.nav.pensjon.simulator.tjenestepensjon.pre2025.api.acl.v3
 
+import jakarta.validation.constraints.NotNull
+import no.nav.pensjon.simulator.validity.ProblemType
+import org.springframework.http.HttpStatus
+
 data class SimulerOffentligTjenestepensjonResultV3(
     val simulertPensjonListe: List<SimulertPensjonResultV3>? = null,
     val feilkode: FeilkodeV3? = null,
     val relevanteTpOrdninger: List<String>? = emptyList(),
+    val problem: Pre2025TpV3Problem? = null
 )
+
+data class Pre2025TpV3Problem(
+    @field:NotNull val kode: Pre2025TpV3ProblemType,
+    @field:NotNull val beskrivelse: String
+)
+
+enum class Pre2025TpV3ProblemType(
+    val internalValue: ProblemType,
+    val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST
+) {
+    UGYLDIG_UTTAKSDATO(internalValue = ProblemType.UGYLDIG_UTTAKSDATO),
+    UGYLDIG_UTTAKSGRAD(internalValue = ProblemType.UGYLDIG_UTTAKSGRAD),
+    UGYLDIG_SIVILSTATUS(internalValue = ProblemType.UGYLDIG_SIVILSTATUS),
+    UGYLDIG_INNTEKT(internalValue = ProblemType.UGYLDIG_INNTEKT),
+    UGYLDIG_ANTALL_AAR(internalValue = ProblemType.UGYLDIG_ANTALL_AAR),
+    UGYLDIG_PERSONIDENT(internalValue = ProblemType.UGYLDIG_PERSONIDENT),
+    PERSON_IKKE_FUNNET(internalValue = ProblemType.PERSON_IKKE_FUNNET, httpStatus = HttpStatus.NOT_FOUND),
+    PERSON_FOR_HOEY_ALDER(internalValue = ProblemType.PERSON_FOR_HOEY_ALDER),
+    UTILSTREKKELIG_OPPTJENING(internalValue = ProblemType.UTILSTREKKELIG_OPPTJENING),
+    UTILSTREKKELIG_TRYGDETID(internalValue = ProblemType.UTILSTREKKELIG_TRYGDETID),
+    ANNEN_KLIENTFEIL(internalValue = ProblemType.ANNEN_KLIENTFEIL),
+    INTERN_DATA_INKONSISTENS(
+        internalValue = ProblemType.INTERN_DATA_INKONSISTENS,
+        httpStatus = HttpStatus.INTERNAL_SERVER_ERROR
+    ),
+    IMPLEMENTASJONSFEIL(internalValue = ProblemType.IMPLEMENTASJONSFEIL, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR),
+    TREDJEPARTSFEIL(internalValue = ProblemType.TREDJEPARTSFEIL, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR),
+    ANNEN_SERVERFEIL(internalValue = ProblemType.ANNEN_SERVERFEIL, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR);
+
+    companion object {
+
+        fun from(internalValue: ProblemType): Pre2025TpV3ProblemType =
+            entries.firstOrNull { it.internalValue == internalValue } ?: ANNEN_SERVERFEIL
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativSimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/UfoereAlternativSimuleringServiceTest.kt
@@ -1,18 +1,11 @@
 package no.nav.pensjon.simulator.alderspensjon.alternativ
 
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.pensjon.simulator.alder.Alder
-import no.nav.pensjon.simulator.alderspensjon.alternativ.UfoereAlternativSimuleringServiceTestObjects.arrangeAvslaattUtkanttilfelle
-import no.nav.pensjon.simulator.alderspensjon.alternativ.UfoereAlternativSimuleringServiceTestObjects.arrangeGradertUttakEtterAvslaatt60ProsentUttak
-import no.nav.pensjon.simulator.alderspensjon.alternativ.UfoereAlternativSimuleringServiceTestObjects.arrangeGradertUttakEtterAvslaattHeltUttak
-import no.nav.pensjon.simulator.alderspensjon.alternativ.UfoereAlternativSimuleringServiceTestObjects.arrangeIngenInnvilgedeUttak
-import no.nav.pensjon.simulator.alderspensjon.alternativ.UfoereAlternativSimuleringServiceTestObjects.foedselsdato
-import no.nav.pensjon.simulator.alderspensjon.alternativ.UfoereAlternativSimuleringServiceTestObjects.normertPensjoneringsdato
-import no.nav.pensjon.simulator.alderspensjon.alternativ.UfoereAlternativSimuleringServiceTestObjects.simuleringSpec
 import no.nav.pensjon.simulator.core.SimulatorCore
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
@@ -25,242 +18,247 @@ import no.nav.pensjon.simulator.testutil.Arrange
 import no.nav.pensjon.simulator.testutil.TestObjects.pid
 import java.time.LocalDate
 
-class UfoereAlternativSimuleringServiceTest : FunSpec({
+class UfoereAlternativSimuleringServiceTest : ShouldSpec({
 
-    test("simulerAlternativHvisUtkanttilfelletInnvilges should return no result if utkanttilfellet avslått") {
-        val service = UfoereAlternativSimuleringService(
-            simulator = arrangeAvslaattUtkanttilfelle(),
-            normalderService = Arrange.normalder(foedselsdato()),
-            alternativtUttakService = mockk(),
-            time = { LocalDate.of(2025, 1, 1) }
-        )
-
-        service.simulerAlternativHvisUtkanttilfelletInnvilges(
-            spec = simuleringSpec(
-                foersteUttakDato = LocalDate.of(2030, 2, 1),
-                uttaksgrad = UttakGradKode.P_60,
-                heltUttakDato = LocalDate.of(2032, 2, 1)
+    context("simulerAlternativHvisUtkanttilfelletInnvilges") {
+        should("return no result if utkanttilfellet avslått") {
+            val service = UfoereAlternativSimuleringService(
+                simulator = arrangeAvslaattUtkanttilfelle(),
+                normalderService = Arrange.normalder(foedselsdato),
+                alternativtUttakService = mockk(),
+                time = { LocalDate.of(2025, 1, 1) }
             )
-        )?.alternativ shouldBe SimulertAlternativ(
-            gradertUttakAlder = null,
-            uttakGrad = UttakGradKode.P_0,
-            heltUttakAlder = SimulertUttakAlder(alder = Alder(0, 0), uttakDato = LocalDate.MIN),
-            resultStatus = SimulatorResultStatus.NONE // i.e. no result
-        )
+
+            service.simulerAlternativHvisUtkanttilfelletInnvilges(
+                spec = simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2030, 2, 1),
+                    uttaksgrad = UttakGradKode.P_60,
+                    heltUttakDato = LocalDate.of(2032, 2, 1)
+                )
+            )?.alternativ shouldBe SimulertAlternativ(
+                gradertUttakAlder = null,
+                uttakGrad = UttakGradKode.P_0,
+                heltUttakAlder = SimulertUttakAlder(alder = Alder(0, 0), uttakDato = LocalDate.MIN),
+                resultStatus = SimulatorResultStatus.NONE // i.e. no result
+            )
+        }
     }
 
-    test("simulerMedFallendeUttaksgrad for gradert uttak should return: alternativ med lavere grad men samme uttaksdato") {
-        val service = UfoereAlternativSimuleringService(
-            simulator = arrangeGradertUttakEtterAvslaatt60ProsentUttak(),
-            normalderService = Arrange.normalder(foedselsdato()),
-            alternativtUttakService = mockk(),
-            time = { LocalDate.of(2025, 1, 1) }
-        )
+    context("simulerMedFallendeUttaksgrad for gradert uttak") {
+        should("return alternativ med lavere grad men samme uttaksdato") {
+            val service = UfoereAlternativSimuleringService(
+                simulator = arrangeGradertUttakEtterAvslaatt60ProsentUttak(),
+                normalderService = Arrange.normalder(foedselsdato),
+                alternativtUttakService = mockk(),
+                time = { LocalDate.of(2025, 1, 1) }
+            )
 
-        service.simulerMedFallendeUttaksgrad(
-            spec = simuleringSpec(
-                foersteUttakDato = LocalDate.of(2030, 2, 1),
-                uttaksgrad = UttakGradKode.P_60,
-                heltUttakDato = LocalDate.of(2032, 2, 1)
-            ),
-            exception = UtilstrekkeligOpptjeningException()
-        ).alternativ shouldBe SimulertAlternativ(
-            gradertUttakAlder = SimulertUttakAlder(alder = Alder(63, 0), uttakDato = LocalDate.of(2030, 2, 1)),
-            uttakGrad = UttakGradKode.P_40,
-            heltUttakAlder = SimulertUttakAlder(alder = Alder(65, 0), uttakDato = LocalDate.of(2032, 2, 1)),
-            resultStatus = SimulatorResultStatus.GOOD
-        )
-    }
-
-    test("simulerMedFallendeUttaksgrad for helt uttak should return: alternativ med lavere grad med helt uttak-dato som ny gradert uttak-dato") {
-        val service = UfoereAlternativSimuleringService(
-            simulator = arrangeGradertUttakEtterAvslaattHeltUttak(),
-            normalderService = Arrange.normalder(foedselsdato()),
-            alternativtUttakService = mockk(),
-            time = { LocalDate.of(2025, 1, 1) }
-        )
-
-        service.simulerMedFallendeUttaksgrad(
-            spec = simuleringSpec(
-                foersteUttakDato = LocalDate.of(2030, 2, 1),
-                uttaksgrad = UttakGradKode.P_100,
-                heltUttakDato = null // brukes bare ved gradert uttak (etterfulgt av helt uttak)
-            ),
-            exception = UtilstrekkeligTrygdetidException()
-        ).alternativ shouldBe SimulertAlternativ(
-            gradertUttakAlder = SimulertUttakAlder(alder = Alder(63, 0), uttakDato = LocalDate.of(2030, 2, 1)),
-            uttakGrad = UttakGradKode.P_60,
-            heltUttakAlder = SimulertUttakAlder(alder = Alder(67, 0), uttakDato = normertPensjoneringsdato()),
-            resultStatus = SimulatorResultStatus.GOOD
-        )
-    }
-
-    test("simulerMedFallendeUttaksgrad for ingen innvilgede uttak should throw exception") {
-        val service = UfoereAlternativSimuleringService(
-            simulator = arrangeIngenInnvilgedeUttak(),
-            normalderService = Arrange.normalder(foedselsdato()),
-            alternativtUttakService = mockk(),
-            time = { LocalDate.of(2025, 1, 1) }
-        )
-
-        shouldThrow<UtilstrekkeligOpptjeningException> {
             service.simulerMedFallendeUttaksgrad(
                 spec = simuleringSpec(
                     foersteUttakDato = LocalDate.of(2030, 2, 1),
-                    uttaksgrad = UttakGradKode.P_50,
+                    uttaksgrad = UttakGradKode.P_60,
                     heltUttakDato = LocalDate.of(2032, 2, 1)
                 ),
                 exception = UtilstrekkeligOpptjeningException()
+            ).alternativ shouldBe SimulertAlternativ(
+                gradertUttakAlder = SimulertUttakAlder(alder = Alder(63, 0), uttakDato = LocalDate.of(2030, 2, 1)),
+                uttakGrad = UttakGradKode.P_40,
+                heltUttakAlder = SimulertUttakAlder(alder = Alder(65, 0), uttakDato = LocalDate.of(2032, 2, 1)),
+                resultStatus = SimulatorResultStatus.GOOD
             )
-        }.message shouldBe null
+        }
     }
-})
 
-private object UfoereAlternativSimuleringServiceTestObjects {
+    context("simulerMedFallendeUttaksgrad for helt uttak") {
+        should("return alternativ med lavere grad med helt uttak-dato som ny gradert uttak-dato") {
+            val service = UfoereAlternativSimuleringService(
+                simulator = arrangeGradertUttakEtterAvslaattHeltUttak(),
+                normalderService = Arrange.normalder(foedselsdato),
+                alternativtUttakService = mockk(),
+                time = { LocalDate.of(2025, 1, 1) }
+            )
 
-    fun arrangeGradertUttakEtterAvslaatt60ProsentUttak(): SimulatorCore =
-        mockk<SimulatorCore>().apply {
-            arrangeFoedselsdato(this)
+            service.simulerMedFallendeUttaksgrad(
+                spec = simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2030, 2, 1),
+                    uttaksgrad = UttakGradKode.P_100,
+                    heltUttakDato = null // brukes bare ved gradert uttak (etterfulgt av helt uttak)
+                ),
+                exception = UtilstrekkeligTrygdetidException()
+            ).alternativ shouldBe SimulertAlternativ(
+                gradertUttakAlder = SimulertUttakAlder(alder = Alder(63, 0), uttakDato = LocalDate.of(2030, 2, 1)),
+                uttakGrad = UttakGradKode.P_60,
+                heltUttakAlder = SimulertUttakAlder(alder = Alder(67, 0), uttakDato = normertPensjoneringsdato),
+                resultStatus = SimulatorResultStatus.GOOD
+            )
+        }
+    }
 
-            // Etter avslag på 60 % forsøkes det med neste lavere uttaksgrad (50 %):
-            every {
-                simuler(
-                    simuleringSpec(
+    context("simulerMedFallendeUttaksgrad for ingen innvilgede uttak") {
+        should("throw exception") {
+            val service = UfoereAlternativSimuleringService(
+                simulator = arrangeIngenInnvilgedeUttak(),
+                normalderService = Arrange.normalder(foedselsdato),
+                alternativtUttakService = mockk(),
+                time = { LocalDate.of(2025, 1, 1) }
+            )
+
+            shouldThrow<UtilstrekkeligOpptjeningException> {
+                service.simulerMedFallendeUttaksgrad(
+                    spec = simuleringSpec(
                         foersteUttakDato = LocalDate.of(2030, 2, 1),
                         uttaksgrad = UttakGradKode.P_50,
                         heltUttakDato = LocalDate.of(2032, 2, 1)
-                    )
+                    ),
+                    exception = UtilstrekkeligOpptjeningException()
                 )
-            } throws UtilstrekkeligOpptjeningException() // => avslag igjen
-
-            // Etter avslag på 50 % forsøkes det med neste lavere uttaksgrad (40 %):
-            every {
-                simuler(
-                    simuleringSpec(
-                        foersteUttakDato = LocalDate.of(2030, 2, 1),
-                        uttaksgrad = UttakGradKode.P_40,
-                        heltUttakDato = LocalDate.of(2032, 2, 1)
-                    )
-                )
-            } returns SimulatorOutput() // => innvilget
+            }.message shouldBe "Utilstrekkelig opptjening"
         }
-
-    fun arrangeGradertUttakEtterAvslaattHeltUttak(): SimulatorCore =
-        mockk<SimulatorCore>().apply {
-            arrangeFoedselsdato(this)
-
-            // Etter avslått helt uttak forsøkes det med høyeste graderte uttaksgrad (80 %):
-            every {
-                simuler(
-                    simuleringSpec(
-                        foersteUttakDato = LocalDate.of(2030, 2, 1),
-                        uttaksgrad = UttakGradKode.P_80,
-                        heltUttakDato = normertPensjoneringsdato()
-                    )
-                )
-            } throws UtilstrekkeligOpptjeningException() // => avslag igjen
-
-            // Etter avslag på 80 % forsøkes det med neste lavere uttaksgrad (60 %):
-            every {
-                simuler(
-                    simuleringSpec(
-                        foersteUttakDato = LocalDate.of(2030, 2, 1),
-                        uttaksgrad = UttakGradKode.P_60,
-                        heltUttakDato = normertPensjoneringsdato()
-                    )
-                )
-            } returns SimulatorOutput() // => innvilget
-        }
-
-    fun arrangeIngenInnvilgedeUttak(): SimulatorCore =
-        mockk<SimulatorCore>().apply {
-            arrangeFoedselsdato(this)
-
-            // Etter avslag på 50 % forsøkes det med neste lavere uttaksgrad (40 %):
-            every {
-                simuler(
-                    simuleringSpec(
-                        foersteUttakDato = LocalDate.of(2030, 2, 1),
-                        uttaksgrad = UttakGradKode.P_40,
-                        heltUttakDato = LocalDate.of(2032, 2, 1)
-                    )
-                )
-            } throws UtilstrekkeligTrygdetidException() // => avslag
-
-            // Siste forsøk: Laveste uttaksgrad (20 %):
-            every {
-                simuler(
-                    simuleringSpec(
-                        foersteUttakDato = LocalDate.of(2030, 2, 1),
-                        uttaksgrad = UttakGradKode.P_20,
-                        heltUttakDato = LocalDate.of(2032, 2, 1)
-                    )
-                )
-            } throws UtilstrekkeligOpptjeningException() // => avslag igjen
-        }
-
-    fun arrangeAvslaattUtkanttilfelle(): SimulatorCore =
-        mockk<SimulatorCore>().apply {
-            arrangeFoedselsdato(this)
-
-            every {
-                simuler(
-                    simuleringSpec(
-                        foersteUttakDato = LocalDate.of(2030, 2, 1), // konstant dato for gradert uttak
-                        uttaksgrad = UttakGradKode.P_20, // minste uttaksgrad
-                        heltUttakDato = normertPensjoneringsdato()
-                    )
-                )
-            } throws UtilstrekkeligTrygdetidException()
-        }
-
-    fun foedselsdato(): LocalDate = LocalDate.of(1967, 1, 9)
-
-    /**
-     * Normert pensjoneringsdato = fødselsmånedens 1. dag + normalder + 1 måned
-     * I dette tilfellet blir datoen: 1967-01-01 + 67 år + 1 måned = 2034-02-01
-     */
-    fun normertPensjoneringsdato() = LocalDate.of(2034, 2, 1)
-
-    /**
-     * IndexBasedSimulering.tryIndex: discriminator.simuler(indexSimulatorSpec)
-     */
-    fun simuleringSpec(foersteUttakDato: LocalDate, uttaksgrad: UttakGradKode, heltUttakDato: LocalDate?) =
-        SimuleringSpec(
-            type = SimuleringTypeEnum.ALDER_M_AFP_PRIVAT,
-            sivilstatus = SivilstatusType.UGIF,
-            epsHarPensjon = false,
-            foersteUttakDato = foersteUttakDato,
-            heltUttakDato = heltUttakDato,
-            pid = pid,
-            foedselDato = foedselsdato(),
-            avdoed = null,
-            isTpOrigSimulering = false,
-            simulerForTp = false,
-            uttakGrad = uttaksgrad,
-            forventetInntektBeloep = 250000,
-            inntektUnderGradertUttakBeloep = 125000,
-            inntektEtterHeltUttakBeloep = 67500,
-            inntektEtterHeltUttakAntallAar = null,
-            foedselAar = 1967,
-            utlandAntallAar = 3,
-            utlandPeriodeListe = mutableListOf(),
-            fremtidigInntektListe = mutableListOf(),
-            brukFremtidigInntekt = true,
-            inntektOver1GAntallAar = 0,
-            flyktning = false,
-            epsHarInntektOver2G = true,
-            livsvarigOffentligAfp = null,
-            pre2025OffentligAfp = null,
-            erAnonym = false,
-            ignoreAvslag = false,
-            isHentPensjonsbeholdninger = true,
-            isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = false,
-            onlyVilkaarsproeving = false,
-            epsKanOverskrives = false
-        )
-
-    private fun arrangeFoedselsdato(simulator: SimulatorCore) {
-        every { simulator.fetchFoedselsdato(pid) } returns foedselsdato()
     }
+})
+
+private val foedselsdato = LocalDate.of(1967, 1, 9)
+
+/**
+ * Normert pensjoneringsdato = fødselsmånedens 1. dag + normalder + 1 måned
+ * I dette tilfellet blir datoen: 1967-01-01 + 67 år + 1 måned = 2034-02-01
+ */
+private val normertPensjoneringsdato = LocalDate.of(2034, 2, 1)
+
+private fun arrangeFoedselsdato(simulator: SimulatorCore) {
+    every { simulator.fetchFoedselsdato(pid) } returns foedselsdato
 }
+
+private fun arrangeGradertUttakEtterAvslaatt60ProsentUttak(): SimulatorCore =
+    mockk<SimulatorCore>().apply {
+        arrangeFoedselsdato(this)
+
+        // Etter avslag på 60 % forsøkes det med neste lavere uttaksgrad (50 %):
+        every {
+            simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2030, 2, 1),
+                    uttaksgrad = UttakGradKode.P_50,
+                    heltUttakDato = LocalDate.of(2032, 2, 1)
+                )
+            )
+        } throws UtilstrekkeligOpptjeningException() // => avslag igjen
+
+        // Etter avslag på 50 % forsøkes det med neste lavere uttaksgrad (40 %):
+        every {
+            simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2030, 2, 1),
+                    uttaksgrad = UttakGradKode.P_40,
+                    heltUttakDato = LocalDate.of(2032, 2, 1)
+                )
+            )
+        } returns SimulatorOutput() // => innvilget
+    }
+
+private fun arrangeGradertUttakEtterAvslaattHeltUttak(): SimulatorCore =
+    mockk<SimulatorCore>().apply {
+        arrangeFoedselsdato(this)
+
+        // Etter avslått helt uttak forsøkes det med høyeste graderte uttaksgrad (80 %):
+        every {
+            simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2030, 2, 1),
+                    uttaksgrad = UttakGradKode.P_80,
+                    heltUttakDato = normertPensjoneringsdato
+                )
+            )
+        } throws UtilstrekkeligOpptjeningException() // => avslag igjen
+
+        // Etter avslag på 80 % forsøkes det med neste lavere uttaksgrad (60 %):
+        every {
+            simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2030, 2, 1),
+                    uttaksgrad = UttakGradKode.P_60,
+                    heltUttakDato = normertPensjoneringsdato
+                )
+            )
+        } returns SimulatorOutput() // => innvilget
+    }
+
+private fun arrangeIngenInnvilgedeUttak(): SimulatorCore =
+    mockk<SimulatorCore>().apply {
+        arrangeFoedselsdato(this)
+
+        // Etter avslag på 50 % forsøkes det med neste lavere uttaksgrad (40 %):
+        every {
+            simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2030, 2, 1),
+                    uttaksgrad = UttakGradKode.P_40,
+                    heltUttakDato = LocalDate.of(2032, 2, 1)
+                )
+            )
+        } throws UtilstrekkeligTrygdetidException() // => avslag
+
+        // Siste forsøk: Laveste uttaksgrad (20 %):
+        every {
+            simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2030, 2, 1),
+                    uttaksgrad = UttakGradKode.P_20,
+                    heltUttakDato = LocalDate.of(2032, 2, 1)
+                )
+            )
+        } throws UtilstrekkeligOpptjeningException() // => avslag igjen
+    }
+
+private fun arrangeAvslaattUtkanttilfelle(): SimulatorCore =
+    mockk<SimulatorCore>().apply {
+        arrangeFoedselsdato(this)
+
+        every {
+            simuler(
+                simuleringSpec(
+                    foersteUttakDato = LocalDate.of(2030, 2, 1), // konstant dato for gradert uttak
+                    uttaksgrad = UttakGradKode.P_20, // minste uttaksgrad
+                    heltUttakDato = normertPensjoneringsdato
+                )
+            )
+        } throws UtilstrekkeligTrygdetidException()
+    }
+
+/**
+ * IndexBasedSimulering.tryIndex: discriminator.simuler(indexSimulatorSpec)
+ */
+private fun simuleringSpec(foersteUttakDato: LocalDate, uttaksgrad: UttakGradKode, heltUttakDato: LocalDate?) =
+    SimuleringSpec(
+        type = SimuleringTypeEnum.ALDER_M_AFP_PRIVAT,
+        sivilstatus = SivilstatusType.UGIF,
+        epsHarPensjon = false,
+        foersteUttakDato = foersteUttakDato,
+        heltUttakDato = heltUttakDato,
+        pid = pid,
+        foedselDato = foedselsdato,
+        avdoed = null,
+        isTpOrigSimulering = false,
+        simulerForTp = false,
+        uttakGrad = uttaksgrad,
+        forventetInntektBeloep = 250000,
+        inntektUnderGradertUttakBeloep = 125000,
+        inntektEtterHeltUttakBeloep = 67500,
+        inntektEtterHeltUttakAntallAar = null,
+        foedselAar = 1967,
+        utlandAntallAar = 3,
+        utlandPeriodeListe = mutableListOf(),
+        fremtidigInntektListe = mutableListOf(),
+        brukFremtidigInntekt = true,
+        inntektOver1GAntallAar = 0,
+        flyktning = false,
+        epsHarInntektOver2G = true,
+        livsvarigOffentligAfp = null,
+        pre2025OffentligAfp = null,
+        erAnonym = false,
+        ignoreAvslag = false,
+        isHentPensjonsbeholdninger = true,
+        isOutputSimulertBeregningsinformasjonForAllKnekkpunkter = false,
+        onlyVilkaarsproeving = false,
+        epsKanOverskrives = false
+    )

--- a/src/test/kotlin/no/nav/pensjon/simulator/api/nav/v2/acl/result/SimuleringResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/api/nav/v2/acl/result/SimuleringResultMapperTest.kt
@@ -7,6 +7,8 @@ import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertGarantipensjon
 import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertPensjon
 import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertPensjonEllerAlternativ
 import no.nav.pensjon.simulator.trygdetid.Trygdetid
+import no.nav.pensjon.simulator.validity.Problem
+import no.nav.pensjon.simulator.validity.ProblemType
 
 class SimuleringResultMapperTest : ShouldSpec({
 
@@ -123,5 +125,36 @@ class SimuleringResultMapperTest : ShouldSpec({
             pensjonsgivendeInntektListe = emptyList(),
             problem = null
         )
+    }
+
+    context("problem") {
+        should("map problem, set erInnvilget = false") {
+            SimuleringResultMapper.toDto(
+                source = SimulertPensjonEllerAlternativ(
+                    pensjon = null,
+                    alternativ = null,
+                    problem = Problem(
+                        type = ProblemType.PERSON_IKKE_FUNNET,
+                        beskrivelse = "x"
+                    )
+                )
+            ) shouldBe SimuleringResultDto(
+                alderspensjonListe = emptyList(),
+                alderspensjonMaanedsbeloep = UttaksbeloepDto(gradertUttakBeloep = null, heltUttakBeloep = 0),
+                livsvarigOffentligAfpListe = emptyList(),
+                tidsbegrensetOffentligAfp = null,
+                privatAfpListe = emptyList(),
+                primaerTrygdetid = null,
+                vilkaarsproevingsresultat = VilkaarsproevingsresultatDto(
+                    erInnvilget = false,
+                    alternativ = null
+                ),
+                pensjonsgivendeInntektListe = emptyList(),
+                problem = ProblemDto(
+                    kode = ProblemTypeDto.PERSON_IKKE_FUNNET,
+                    beskrivelse = "x"
+                )
+            )
+        }
     }
 })

--- a/src/test/kotlin/no/nav/pensjon/simulator/orch/AlderspensjonOgPrivatAfpServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/orch/AlderspensjonOgPrivatAfpServiceTest.kt
@@ -208,7 +208,7 @@ class AlderspensjonOgPrivatAfpServiceTest : ShouldSpec({
             with(result) {
                 suksess shouldBe false
                 problem?.type shouldBe ProblemType.UTILSTREKKELIG_TRYGDETID
-                problem?.beskrivelse shouldBe "Ukjent feil - UtilstrekkeligTrygdetidException"
+                problem?.beskrivelse shouldBe "Utilstrekkelig trygdetid"
             }
         }
     }

--- a/src/test/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/TjenestepensjonSimuleringPre2025FacadeTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/TjenestepensjonSimuleringPre2025FacadeTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import no.nav.pensjon.simulator.afp.offentlig.pre2025.Pre2025OffentligAfpAvslaattException
 import no.nav.pensjon.simulator.afp.offentlig.pre2025.TidsbegrensetOffentligAfpAvslagAarsak
 import no.nav.pensjon.simulator.core.exception.KonsistensenIGrunnlagetErFeilException
+import no.nav.pensjon.simulator.core.exception.UtilstrekkeligOpptjeningException
 import no.nav.pensjon.simulator.testutil.TestObjects.simuleringSpec
 import no.nav.pensjon.simulator.validity.Problem
 import no.nav.pensjon.simulator.validity.ProblemType
@@ -34,6 +35,16 @@ class TjenestepensjonSimuleringPre2025FacadeTest : ShouldSpec({
                 tjenestepensjonSimulator = mockk()
             ).simuler(simuleringSpec, stillingsprosentSpec)
                 .problem shouldBe Problem(type = ProblemType.PERSON_FOR_LAV_ALDER, beskrivelse = AVSLAGSBESKRIVELSE)
+        }
+    }
+
+    context("utilstrekkelig opptjening") {
+        should("gi resultat med 'utilstrekkelig opptjening' og problembeskrivelse") {
+            TjenestepensjonSimuleringPre2025Facade(
+                beregningService = arrangeProblem(e = UtilstrekkeligOpptjeningException(message = "10 kroner")),
+                tjenestepensjonSimulator = mockk()
+            ).simuler(simuleringSpec, stillingsprosentSpec)
+                .problem shouldBe Problem(type = ProblemType.UTILSTREKKELIG_OPPTJENING, beskrivelse = "10 kroner")
         }
     }
 


### PR DESCRIPTION
Endringen gjør at årsaken til eventuell feil i alderspensjonssimuleringdelen av tjenestepensjonsimulering inkluderes i responsen (i form av et `problem`-felt).

Dette gjelder 'Simuler offentlig tjenestepensjon pre-2025 V3'.

Øvrige endringer:

- Inkluderer en default-message i exception-typene som ikke har noe obligatorisk `message`-felt i konstruktøren.
- Refaktorering av `SimulerOffentligTjenestepensjonResultMapperV3` og `UfoereAlternativSimuleringServiceTest`.
- Setter `erInnvilget` til `false` når `problem`-feltet har verdi.