### PR TITLE
Complete ACL for 'simuler FPP'

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpec.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpec.kt
@@ -2,14 +2,13 @@ package no.nav.pensjon.simulator.fpp
 
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.domain.regler.enum.AFPtypeEnum
+import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.SivilstandEnum
-import no.nav.pensjon.simulator.fpp.api.acl.v1.RelasjonTypeCodeV1
-import no.nav.pensjon.simulator.fpp.api.acl.v1.SimuleringTypeV1
+import no.nav.pensjon.simulator.person.Pid
 import java.time.LocalDate
 
-// PEN: no.nav.pensjon.pen.domain.api.kalkulator.PensjonskalkulatorInput
 data class FppSimuleringSpec(
-    val simuleringstype: SimuleringTypeV1,
+    val simuleringstype: SimuleringTypeEnum,
     val uttaksdato: LocalDate,
     val personopplysninger: Personopplysninger,
     val barneopplysninger: Barneopplysninger?,
@@ -19,7 +18,7 @@ data class FppSimuleringSpec(
 class Personopplysninger {
     var ident: String? = null
     var fodselsdato: LocalDate? = null
-    var valgtAfpOrdning: AFPtypeEnum? = null // PEN: String
+    var valgtAfpOrdning: AFPtypeEnum? = null
     var flyktning: Boolean? = null
     var antAarIUtlandet: Int? = null
     var forventetArbeidsinntekt: Int? = null
@@ -31,7 +30,7 @@ class Personopplysninger {
 }
 
 class AvdoedData {
-    var datoForDodsfall: LocalDate? = null // PEN: Date
+    var datoForDodsfall: LocalDate? = null
     var avdodAntAarIUtlandet: Int? = null
     var inntektPaaDodstidspunktHvisYrkesskade: Int? = null
     var avdodInntektMinst1G: Boolean? = null
@@ -43,8 +42,8 @@ class AvdoedData {
 
 class EpsData {
     var eps: Relasjon? = null
-    var valgtSivilstatus: SivilstatusType? = null // PEN: String
-    var registrertSivilstatus: SivilstandEnum? = null // PEN: String
+    var valgtSivilstatus: SivilstatusType? = null
+    var registrertSivilstatus: SivilstandEnum? = null
     var epsMottarPensjon: Boolean? = null
     var epsInntektOver2G: Boolean? = null
     var tidligereGiftEllerBarnMedSamboer: Boolean? = null
@@ -80,19 +79,17 @@ class OpptjeningFolketrygdenData {
     var ar: Int? = null
     var pensjonsgivendeInntekt: Int? = null
     var omsorgspoeng: Double? = null
-    var maksUforegrad: Int? = null // PEN: Int 0
+    var maksUforegrad: Int? = null
     var registrertePensjonspoeng: Double? = null
 }
 
-// PEN: no.nav.domain.pensjon.common.person.Person
-class PersonV1 {
-    var pid: String? = null // PEN: Pid
+class FppPerson {
+    var pid: Pid? = null
     var personUtland: PersonUtland? = null
 }
 
-// PEN: no.nav.domain.pensjon.common.person.Relasjon
 class Relasjon {
-    var relasjonsType: RelasjonTypeCodeV1? = null // PEN: String
-    var fom: LocalDate? = null // PEN: Calendar
-    var person: PersonV1? = null
+    var relasjonsType: RelasjonTypeCode? = null
+    var fom: LocalDate? = null
+    var person: FppPerson? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecCreator.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecCreator.kt
@@ -214,11 +214,11 @@ class FppSimuleringSpecCreator(
                 person.penPersonId = -2L
                 persongrunnlag.fodselsdatoLd = epsFoedselsdato()
             } else {
-                person.pid = relasjon.person?.pid?.let(::Pid)
+                person.pid = relasjon.person?.pid
                 persongrunnlag.fodselsdatoLd = personopplysninger.fodselsdato
             }
         } else if (simuleringType == GJENLEVENDE) {
-            val pid = personopplysninger.avdodList.firstOrNull()?.relasjon?.person?.pid?.let(::Pid)
+            val pid = personopplysninger.avdodList.firstOrNull()?.relasjon?.person?.pid
             person.pid = pid
             persongrunnlag.fodselsdatoLd = pid?.let(personService::foedselsdato)
         }
@@ -258,9 +258,8 @@ class FppSimuleringSpecCreator(
     ) =
         Persongrunnlag().apply {
             val relasjon: Relasjon? = avdoed?.relasjon
-            val relasjonType: RelasjonTypeCode = relasjon?.relasjonsType?.internalValue ?: RelasjonTypeCode.UKJENT
-            val relatertPersonDto: PersonV1? = relasjon?.person //TODO map to domain
-            val relatertPid = relatertPersonDto?.pid?.let(::Pid)
+            val relasjonType: RelasjonTypeCode = relasjon?.relasjonsType ?: RelasjonTypeCode.UKJENT
+            val relatertPid = relasjon?.person?.pid
             val relatertPenPerson = PenPerson().apply { pid = relatertPid }
             val relatertPerson: Person? = relatertPid?.let(personService::person)
             val foedselsdato: LocalDate? = relatertPerson?.foedselsdato

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/RelasjonTypeCode.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/RelasjonTypeCode.kt
@@ -3,8 +3,12 @@ package no.nav.pensjon.simulator.fpp
 // PEN: no.nav.domain.pensjon.common.person.enums.RelasjonTypeCode
 enum class RelasjonTypeCode {
     BARN,
+    EKTE,
     ENKE,
     FARA,
+    FOBA,
+    FOFA,
+    FOMO,
     GJPA,
     GLAD,
     MORA,
@@ -14,5 +18,7 @@ enum class RelasjonTypeCode {
     SEPR,
     SKIL,
     SKPA,
+    SOSKEN,
+    MEDMOR,
     UKJENT // not in PEN
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/FppController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/FppController.kt
@@ -7,14 +7,16 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import mu.KotlinLogging
 import no.nav.pensjon.simulator.common.api.ControllerBase
 import no.nav.pensjon.simulator.fpp.FppSimuleringFacade
-import no.nav.pensjon.simulator.fpp.FppSimuleringResult
-import no.nav.pensjon.simulator.fpp.FppSimuleringSpec
-import no.nav.pensjon.simulator.fpp.api.acl.v1.SimuleringTypeV1
+import no.nav.pensjon.simulator.fpp.api.v1.acl.FppSimuleringResultMapper.toDto
+import no.nav.pensjon.simulator.fpp.api.v1.acl.FppSimuleringResultDto
+import no.nav.pensjon.simulator.fpp.api.v1.acl.FppSimuleringSpecDto
+import no.nav.pensjon.simulator.fpp.api.v1.acl.FppSimuleringSpecMapper.fromDto
+import no.nav.pensjon.simulator.fpp.api.v1.acl.SimuleringstypeDto
+import no.nav.pensjon.simulator.fpp.api.v1.acl.ProblemDto
+import no.nav.pensjon.simulator.fpp.api.v1.acl.ProblemtypeDto
 import no.nav.pensjon.simulator.statistikk.StatistikkService
 import no.nav.pensjon.simulator.tech.json.writeValueAsRedactedString
 import no.nav.pensjon.simulator.tech.trace.TraceAid
-import no.nav.pensjon.simulator.validity.Problem
-import no.nav.pensjon.simulator.validity.ProblemType
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -30,7 +32,7 @@ class FppController(
     private val service: FppSimuleringFacade,
     private val traceAid: TraceAid,
     private val jsonMapper: JsonMapper,
-    statistikk: StatistikkService,
+    statistikk: StatistikkService
 ) : ControllerBase(traceAid = traceAid, statistikk = statistikk) {
     private val log = KotlinLogging.logger {}
 
@@ -69,17 +71,17 @@ class FppController(
         ]
     )
     fun simulerForFppV1(
-        @RequestParam("simuleringstype") simuleringType: SimuleringTypeV1,
-        @RequestBody spec: FppSimuleringSpec
-    ): ResponseEntity<FppSimuleringResult> {
+        @RequestParam("simuleringstype") simuleringType: SimuleringstypeDto,
+        @RequestBody spec: FppSimuleringSpecDto
+    ): ResponseEntity<FppSimuleringResultDto> {
         traceAid.begin()
         countCall(functionName = FUNCTION_ID)
         log.info { "spec ${jsonMapper.writeValueAsRedactedString(spec)}" }
 
         return try {
             registrerHendelse(simuleringstype = simuleringType.internalValue)
-            val result = service.simulerPensjon(simuleringType.internalValue, spec)
-            ResponseEntity.status(HttpStatus.OK).body(result)
+            val result = service.simulerPensjon(simuleringType.internalValue, fromDto(spec))
+            ResponseEntity.status(HttpStatus.OK).body(toDto(result))
         } catch (e: Exception) {
             log.error(e) { "$FUNCTION_ID intern feil for spec ${jsonMapper.writeValueAsRedactedString(spec)}" }
             throw e
@@ -91,7 +93,7 @@ class FppController(
     override fun errorMessage() = ERROR_MESSAGE
 
     @ExceptionHandler(value = [Exception::class])
-    private fun internalError(e: Exception): ResponseEntity<FppSimuleringResult> =
+    private fun internalError(e: Exception): ResponseEntity<FppSimuleringResultDto> =
         ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problem(e))
 
     private companion object {
@@ -100,11 +102,11 @@ class FppController(
         private const val FUNCTION_ID = "fpp"
 
         private fun problem(e: Exception) =
-            FppSimuleringResult(
+            FppSimuleringResultDto(
                 afpOrdning = null,
                 beregnetAfp = null,
-                problem = Problem(
-                    type = ProblemType.ANNEN_KLIENTFEIL,
+                problem = ProblemDto(
+                    type = ProblemtypeDto.ANNEN_KLIENTFEIL,
                     beskrivelse = e.message ?: e.javaClass.simpleName
                 )
             )

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/AfpTypeDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/AfpTypeDto.kt
@@ -1,0 +1,26 @@
+package no.nav.pensjon.simulator.fpp.api.v1.acl
+
+import no.nav.pensjon.simulator.core.domain.regler.enum.AFPtypeEnum
+
+enum class AfpTypeDto(val internalValue: AFPtypeEnum) {
+    // LO/NHO
+    LONHO(internalValue = AFPtypeEnum.LONHO),
+
+    // Spekter
+    NAVO(internalValue = AFPtypeEnum.NAVO),
+
+    // Finansnæringen
+    FINANS(internalValue = AFPtypeEnum.FINANS),
+
+    // AFP Stat
+    AFPSTAT(internalValue = AFPtypeEnum.AFPSTAT),
+
+    // AFP i kommunal sektor
+    AFPKOM(internalValue = AFPtypeEnum.AFPKOM),
+
+    // Konvertert offentlig
+    KONV_O(internalValue = AFPtypeEnum.KONV_O),
+
+    // Konvertert privat
+    KONV_K(internalValue = AFPtypeEnum.KONV_K)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/FppSimuleringResultDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/FppSimuleringResultDto.kt
@@ -1,8 +1,17 @@
-package no.nav.pensjon.simulator.afp.offentlig.pre2025
+package no.nav.pensjon.simulator.fpp.api.v1.acl
 
 import java.time.LocalDate
 
-data class FolketrygdberegnetAfp(
+data class FppSimuleringResultDto(
+    val afpOrdning: AfpTypeDto?,
+    val beregnetAfp: FolketrygdberegnetAfpDto?,
+    val problem: ProblemDto? = null
+)
+
+/**
+ * Corresponds 1-to-1 with PEN's no.nav.pensjon.pen.domain.api.beregning.FolketrygdberegnetAfp
+ */
+data class FolketrygdberegnetAfpDto(
     val totalbelopAfp: Int?, // totalt AFP-beløp
     val virkFom: LocalDate?, // virkningsdato (fra og med)
     val tidligereArbeidsinntekt: Int?,
@@ -17,4 +26,9 @@ data class FolketrygdberegnetAfp(
     val afpTillegg: Int?, // AFP-tillegg
     val fpp: Double?, // framtidige pensjonspoeng
     val sertillegg: Int? // særtillegg
+)
+
+data class ProblemDto(
+    val type: ProblemtypeDto,
+    val beskrivelse: String
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/FppSimuleringResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/FppSimuleringResultMapper.kt
@@ -1,0 +1,43 @@
+package no.nav.pensjon.simulator.fpp.api.v1.acl
+
+import no.nav.pensjon.simulator.afp.offentlig.pre2025.FolketrygdberegnetAfp
+import no.nav.pensjon.simulator.fpp.FppSimuleringResult
+import no.nav.pensjon.simulator.validity.Problem
+
+object FppSimuleringResultMapper {
+
+    fun toDto(source: FppSimuleringResult) =
+        FppSimuleringResultDto(
+            afpOrdning = AfpTypeDto.entries.firstOrNull { it.internalValue == source.afpOrdning } ?: AfpTypeDto.AFPSTAT,
+            beregnetAfp = source.beregnetAfp?.let(::folketrygdberegnetAfp),
+            problem = source.problem?.let(::problem)
+        )
+
+    /**
+     * Corresponds 1-to-1 with PEN's no.nav.pensjon.pen.domain.api.beregning.FolketrygdberegnetAfp
+     */
+    private fun folketrygdberegnetAfp(source: FolketrygdberegnetAfp) =
+        FolketrygdberegnetAfpDto(
+            totalbelopAfp = source.totalbelopAfp,
+            virkFom = source.virkFom,
+            tidligereArbeidsinntekt = source.tidligereArbeidsinntekt,
+            grunnbelop = source.grunnbelop,
+            sluttpoengtall = source.sluttpoengtall,
+            trygdetid = source.trygdetid,
+            poengar = source.poengar,
+            poeangar_f92 = source.poeangar_f92,
+            poeangar_e91 = source.poeangar_e91,
+            grunnpensjon = source.grunnpensjon,
+            tilleggspensjon = source.tilleggspensjon,
+            afpTillegg = source.afpTillegg,
+            fpp = source.fpp,
+            sertillegg = source.sertillegg
+        )
+
+    private fun problem(source: Problem) =
+        ProblemDto(
+            type = ProblemtypeDto.entries.firstOrNull { it.internalValue == source.type }
+                ?: ProblemtypeDto.ANNEN_SERVERFEIL,
+            beskrivelse = source.beskrivelse
+        )
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/FppSimuleringSpecDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/FppSimuleringSpecDto.kt
@@ -1,0 +1,98 @@
+package no.nav.pensjon.simulator.fpp.api.v1.acl
+
+import java.time.LocalDate
+
+// PEN: no.nav.pensjon.pen.domain.api.kalkulator.PensjonskalkulatorInput
+data class FppSimuleringSpecDto(
+    val simuleringstype: SimuleringstypeDto,
+    val uttaksdato: LocalDate,
+    val personopplysninger: PersonopplysningerDto,
+    val barneopplysninger: BarneopplysningerDto?,
+    val opptjeningFolketrygden: OpptjeningFolketrygdenDto?
+)
+
+class PersonopplysningerDto {
+    var ident: String? = null
+    var fodselsdato: LocalDate? = null
+    var valgtAfpOrdning: AfpTypeDto? = null
+    var flyktning: Boolean? = null
+    var antAarIUtlandet: Int? = null
+    var forventetArbeidsinntekt: Int? = null
+    var forventetArbeidsinntektGjenlevende: Long? = null
+    var inntektMndForAfp: Int? = null
+    var erUnderUtdanning: Boolean? = null // for barnepensjon
+    var epsData: EpsDataDto? = null
+    var avdodList: List<AvdoedDataDto> = emptyList()
+}
+
+class AvdoedDataDto {
+    var datoForDodsfall: LocalDate? = null // PEN: Date
+    var avdodAntAarIUtlandet: Int? = null
+    var inntektPaaDodstidspunktHvisYrkesskade: Int? = null
+    var avdodInntektMinst1G: Boolean? = null
+    var avdodMedlemFolketrygden: Boolean? = null
+    var avdodFlyktning: Boolean? = null
+    var dodAvYrkesskade: Boolean? = null
+    var relasjon: RelasjonDto? = null
+}
+
+class EpsDataDto {
+    var eps: RelasjonDto? = null
+    var valgtSivilstatus: SivilstatusDto? = null
+    var registrertSivilstatus: SivilstandDto? = null
+    var epsMottarPensjon: Boolean? = null
+    var epsInntektOver2G: Boolean? = null
+    var tidligereGiftEllerBarnMedSamboer: Boolean? = null
+    var erEpsInntektOver1G: Boolean? = null
+}
+
+class BarneopplysningerDto {
+    var barn: List<BarneopplysningerDataDto> = emptyList()
+    var sosken: List<BarneopplysningerSoeskenDataDto> = emptyList()
+}
+
+class BarneopplysningerDataDto {
+    var fnr: String? = null
+    var borMedBeggeForeldre = false
+    var erInntektOver1G = false
+}
+
+class BarneopplysningerSoeskenDataDto {
+    var fnr: String? = null
+    var underUtdanning: Boolean? = null
+    var oppdrattSammen: Boolean? = null
+    var helSosken: Boolean? = null
+}
+
+class OpptjeningFolketrygdenDto {
+    var egenOpptjeningFolketrygden: List<OpptjeningFolketrygdenDataDto> = emptyList()
+    var avdodesOpptjeningFolketrygden: List<OpptjeningFolketrygdenDataDto> = emptyList()
+    var morsOpptjeningFolketrygden: List<OpptjeningFolketrygdenDataDto> = emptyList()
+    var farsOpptjeningFolketrygden: List<OpptjeningFolketrygdenDataDto> = emptyList()
+}
+
+class OpptjeningFolketrygdenDataDto {
+    var ar: Int? = null
+    var pensjonsgivendeInntekt: Int? = null
+    var omsorgspoeng: Double? = null
+    var maksUforegrad: Int? = null // PEN: Int 0
+    var registrertePensjonspoeng: Double? = null
+}
+
+// PEN: no.nav.domain.pensjon.common.person.Person
+class PersonDto {
+    var pid: String? = null
+    var personUtland: PersonUtlandDto? = null
+}
+
+// PEN: no.nav.domain.pensjon.common.person.Relasjon
+class RelasjonDto {
+    var relasjonsType: RelasjonstypeDto? = null
+    var fom: LocalDate? = null // PEN: Calendar
+    var person: PersonDto? = null
+}
+
+// PEN: no.nav.domain.pensjon.common.person.PersonUtland
+class PersonUtlandDto {
+    var statsborgerskap: String? = null // LandkodeEnum
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/FppSimuleringSpecMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/FppSimuleringSpecMapper.kt
@@ -1,0 +1,111 @@
+package no.nav.pensjon.simulator.fpp.api.v1.acl
+
+import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
+import no.nav.pensjon.simulator.fpp.*
+import no.nav.pensjon.simulator.person.Pid
+
+object FppSimuleringSpecMapper {
+
+    fun fromDto(source: FppSimuleringSpecDto) =
+        FppSimuleringSpec(
+            simuleringstype = source.simuleringstype.internalValue,
+            uttaksdato = source.uttaksdato,
+            personopplysninger = personopplysninger(source.personopplysninger),
+            barneopplysninger = source.barneopplysninger?.let(::barneopplysninger),
+            opptjeningFolketrygden = source.opptjeningFolketrygden?.let(::opptjeningFolketrygden),
+        )
+
+    private fun personopplysninger(source: PersonopplysningerDto) =
+        Personopplysninger().apply {
+            ident = source.ident
+            fodselsdato = source.fodselsdato
+            valgtAfpOrdning = source.valgtAfpOrdning?.internalValue
+            flyktning = source.flyktning
+            antAarIUtlandet = source.antAarIUtlandet
+            forventetArbeidsinntekt = source.forventetArbeidsinntekt
+            forventetArbeidsinntektGjenlevende = source.forventetArbeidsinntektGjenlevende
+            inntektMndForAfp = source.inntektMndForAfp
+            erUnderUtdanning = source.erUnderUtdanning
+            epsData = source.epsData?.let(::epsData)
+            avdodList = source.avdodList.map(::avdoedData)
+        }
+
+    private fun avdoedData(source: AvdoedDataDto) =
+        AvdoedData().apply {
+            datoForDodsfall = source.datoForDodsfall
+            avdodAntAarIUtlandet = source.avdodAntAarIUtlandet
+            inntektPaaDodstidspunktHvisYrkesskade = source.inntektPaaDodstidspunktHvisYrkesskade
+            avdodInntektMinst1G = source.avdodInntektMinst1G
+            avdodMedlemFolketrygden = source.avdodMedlemFolketrygden
+            avdodFlyktning = source.avdodFlyktning
+            dodAvYrkesskade = source.dodAvYrkesskade
+            relasjon = source.relasjon?.let(::relasjon)
+        }
+
+    private fun epsData(source: EpsDataDto) =
+        EpsData().apply {
+            eps = source.eps?.let(::relasjon)
+            valgtSivilstatus = source.valgtSivilstatus?.internalValue
+            registrertSivilstatus = source.registrertSivilstatus?.internalValue
+            epsMottarPensjon = source.epsMottarPensjon
+            epsInntektOver2G = source.epsInntektOver2G
+            tidligereGiftEllerBarnMedSamboer = source.tidligereGiftEllerBarnMedSamboer
+            erEpsInntektOver1G = source.erEpsInntektOver1G
+        }
+
+    private fun barneopplysninger(source: BarneopplysningerDto) =
+        Barneopplysninger().apply {
+            barn = source.barn.map(::barneopplysningerData)
+            sosken = source.sosken.map(::barneopplysningerSoeskenData)
+        }
+
+    private fun barneopplysningerData(source: BarneopplysningerDataDto) =
+        BarneopplysningerData().apply {
+            fnr = source.fnr
+            borMedBeggeForeldre = source.borMedBeggeForeldre
+            erInntektOver1G = source.erInntektOver1G
+        }
+
+    private fun barneopplysningerSoeskenData(source: BarneopplysningerSoeskenDataDto) =
+        BarneopplysningerSoeskenData().apply {
+            fnr = source.fnr
+            underUtdanning = source.underUtdanning
+            oppdrattSammen = source.oppdrattSammen
+            helSosken = source.helSosken
+        }
+
+    private fun opptjeningFolketrygden(source: OpptjeningFolketrygdenDto) =
+        OpptjeningFolketrygden().apply {
+            egenOpptjeningFolketrygden = source.egenOpptjeningFolketrygden.map(::opptjeningFolketrygdenData)
+            avdodesOpptjeningFolketrygden = source.avdodesOpptjeningFolketrygden.map(::opptjeningFolketrygdenData)
+            morsOpptjeningFolketrygden = source.morsOpptjeningFolketrygden.map(::opptjeningFolketrygdenData)
+            farsOpptjeningFolketrygden = source.farsOpptjeningFolketrygden.map(::opptjeningFolketrygdenData)
+        }
+
+    private fun opptjeningFolketrygdenData(source: OpptjeningFolketrygdenDataDto) =
+        OpptjeningFolketrygdenData().apply {
+            ar = source.ar
+            pensjonsgivendeInntekt = source.pensjonsgivendeInntekt
+            omsorgspoeng = source.omsorgspoeng
+            maksUforegrad = source.maksUforegrad
+            registrertePensjonspoeng = source.registrertePensjonspoeng
+        }
+
+    private fun person(source: PersonDto) =
+        FppPerson().apply {
+            pid = source.pid?.let(::Pid)
+            personUtland = source.personUtland?.let(::personUtland)
+        }
+
+    private fun personUtland(source: PersonUtlandDto) =
+        PersonUtland().apply {
+            statsborgerskap = LandkodeEnum.entries.firstOrNull { it.name == source.statsborgerskap }
+        }
+
+    private fun relasjon(source: RelasjonDto) =
+        Relasjon().apply {
+            relasjonsType = source.relasjonsType?.internalValue
+            fom = source.fom
+            person = source.person?.let(::person)
+        }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/ProblemtypeDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/ProblemtypeDto.kt
@@ -1,0 +1,25 @@
+package no.nav.pensjon.simulator.fpp.api.v1.acl
+
+import no.nav.pensjon.simulator.validity.ProblemType
+import org.springframework.http.HttpStatus
+
+enum class ProblemtypeDto(
+    val internalValue: ProblemType,
+    val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST
+) {
+    UGYLDIG_UTTAKSDATO(internalValue = ProblemType.UGYLDIG_UTTAKSDATO),
+    UGYLDIG_UTTAKSGRAD(internalValue = ProblemType.UGYLDIG_UTTAKSGRAD),
+    UGYLDIG_SIVILSTATUS(internalValue = ProblemType.UGYLDIG_SIVILSTATUS),
+    UGYLDIG_INNTEKT(internalValue = ProblemType.UGYLDIG_INNTEKT),
+    UGYLDIG_ANTALL_AAR(internalValue = ProblemType.UGYLDIG_ANTALL_AAR),
+    UGYLDIG_PERSONIDENT(internalValue = ProblemType.UGYLDIG_PERSONIDENT),
+    PERSON_IKKE_FUNNET(internalValue = ProblemType.PERSON_IKKE_FUNNET, httpStatus = HttpStatus.NOT_FOUND),
+    PERSON_FOR_HOEY_ALDER(internalValue = ProblemType.PERSON_FOR_HOEY_ALDER),
+    UTILSTREKKELIG_OPPTJENING(internalValue = ProblemType.UTILSTREKKELIG_OPPTJENING, httpStatus = HttpStatus.OK),
+    UTILSTREKKELIG_TRYGDETID(internalValue = ProblemType.UTILSTREKKELIG_TRYGDETID, httpStatus = HttpStatus.OK),
+    ANNEN_KLIENTFEIL(internalValue = ProblemType.ANNEN_KLIENTFEIL),
+    IMPLEMENTASJONSFEIL(internalValue = ProblemType.IMPLEMENTASJONSFEIL, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR),
+    INTERN_DATAFEIL(internalValue = ProblemType.INTERN_DATA_INKONSISTENS, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR),
+    TREDJEPARTSFEIL(internalValue = ProblemType.TREDJEPARTSFEIL, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR),
+    ANNEN_SERVERFEIL(internalValue = ProblemType.ANNEN_SERVERFEIL, httpStatus = HttpStatus.INTERNAL_SERVER_ERROR)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/RelasjonstypeDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/RelasjonstypeDto.kt
@@ -1,4 +1,4 @@
-package no.nav.pensjon.simulator.fpp.api.acl.v1
+package no.nav.pensjon.simulator.fpp.api.v1.acl
 
 import no.nav.pensjon.simulator.fpp.RelasjonTypeCode
 
@@ -7,10 +7,14 @@ import no.nav.pensjon.simulator.fpp.RelasjonTypeCode
  * Anti-corruption.
  * Versjonert utgave av relasjonstyper for bruk i API-et (isolerer API-et fra den interne representasjonen i domenet).
  */
-enum class RelasjonTypeCodeV1(val internalValue: RelasjonTypeCode) {
+enum class RelasjonstypeDto(val internalValue: RelasjonTypeCode) {
     BARN(internalValue = RelasjonTypeCode.BARN),
+    EKTE(internalValue = RelasjonTypeCode.EKTE),
     ENKE(internalValue = RelasjonTypeCode.ENKE),
     FARA(internalValue = RelasjonTypeCode.FARA),
+    FOBA(internalValue = RelasjonTypeCode.FOBA),
+    FOFA(internalValue = RelasjonTypeCode.FOFA),
+    FOMO(internalValue = RelasjonTypeCode.FOMO),
     GJPA(internalValue = RelasjonTypeCode.GJPA),
     GLAD(internalValue = RelasjonTypeCode.GLAD),
     MORA(internalValue = RelasjonTypeCode.MORA),
@@ -19,5 +23,7 @@ enum class RelasjonTypeCodeV1(val internalValue: RelasjonTypeCode) {
     SEPA(internalValue = RelasjonTypeCode.SEPA),
     SEPR(internalValue = RelasjonTypeCode.SEPR),
     SKIL(internalValue = RelasjonTypeCode.SKIL),
-    SKPA(internalValue = RelasjonTypeCode.SKPA)
+    SKPA(internalValue = RelasjonTypeCode.SKPA),
+    SOSKEN(internalValue = RelasjonTypeCode.SOSKEN),
+    MEDMOR(internalValue = RelasjonTypeCode.MEDMOR)
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/SimuleringstypeDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/SimuleringstypeDto.kt
@@ -1,4 +1,4 @@
-package no.nav.pensjon.simulator.fpp.api.acl.v1
+package no.nav.pensjon.simulator.fpp.api.v1.acl
 
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
 
@@ -6,7 +6,7 @@ import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
  * Anti-corruption.
  * Versjonert utgave av simuleringstyper for bruk i API-et (isolerer API-et fra den interne representasjonen i domenet).
  */
-enum class SimuleringTypeV1(val internalValue: SimuleringTypeEnum) {
+enum class SimuleringstypeDto(val internalValue: SimuleringTypeEnum) {
     /**
      * Tidsbegrenset AFP i offentlig sektor
      */

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/SivilstandDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/SivilstandDto.kt
@@ -1,0 +1,55 @@
+package no.nav.pensjon.simulator.fpp.api.v1.acl
+
+import no.nav.pensjon.simulator.core.domain.regler.enum.SivilstandEnum
+
+enum class SivilstandDto(val internalValue: SivilstandEnum) {
+    /**
+     * Enke/-mann
+     */
+    ENKE(internalValue = SivilstandEnum.ENKE),
+
+    /**
+     * Gift
+     */
+    GIFT(internalValue = SivilstandEnum.GIFT),
+
+    /**
+     * Gjenlevende partner
+     */
+    GJPA(internalValue = SivilstandEnum.GJPA),
+
+    /**
+     * Uoppgitt
+     */
+    NULL(internalValue = SivilstandEnum.NULL),
+
+    /**
+     * Registrert partner
+     */
+    REPA(internalValue = SivilstandEnum.REPA),
+
+    /**
+     * Separert partner
+     */
+    SEPA(internalValue = SivilstandEnum.SEPA),
+
+    /**
+     * Separert
+     */
+    SEPR(internalValue = SivilstandEnum.SEPR),
+
+    /**
+     * Skilt
+     */
+    SKIL(internalValue = SivilstandEnum.SKIL),
+
+    /**
+     * Skilt partner
+     */
+    SKPA(internalValue = SivilstandEnum.SKPA),
+
+    /**
+     * Ugift
+     */
+    UGIF(internalValue = SivilstandEnum.UGIF)
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/SivilstatusDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/fpp/api/v1/acl/SivilstatusDto.kt
@@ -1,0 +1,21 @@
+package no.nav.pensjon.simulator.fpp.api.v1.acl
+
+import no.nav.pensjon.simulator.core.domain.SivilstatusType
+
+enum class SivilstatusDto(val internalValue: SivilstatusType) {
+    ENKE(internalValue = SivilstatusType.ENKE),
+    GIFT(internalValue = SivilstatusType.GIFT),
+    GLAD(internalValue = SivilstatusType.GLAD),
+    GJES(internalValue = SivilstatusType.GJES),
+    GJPA(internalValue = SivilstatusType.GJPA),
+    GJSA(internalValue = SivilstatusType.GJSA),
+    REPA(internalValue = SivilstatusType.REPA),
+    PLAD(internalValue = SivilstatusType.PLAD),
+    SAMB(internalValue = SivilstatusType.SAMB),
+    SEPR(internalValue = SivilstatusType.SEPR),
+    SEPA(internalValue = SivilstatusType.SEPA),
+    SKIL(internalValue = SivilstatusType.SKIL),
+    SKPA(internalValue = SivilstatusType.SKPA),
+    UGIF(internalValue = SivilstatusType.UGIF),
+    NULL(internalValue = SivilstatusType.NULL)
+}

--- a/src/test/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecCreatorTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/fpp/FppSimuleringSpecCreatorTest.kt
@@ -12,7 +12,6 @@ import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.domain.regler.enum.*
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum.*
 import no.nav.pensjon.simulator.core.exception.ImplementationUnrecoverableException
-import no.nav.pensjon.simulator.fpp.api.acl.v1.RelasjonTypeCodeV1
 import no.nav.pensjon.simulator.g.GrunnbeloepService
 import no.nav.pensjon.simulator.person.GeneralPersonService
 import no.nav.pensjon.simulator.person.Person
@@ -74,13 +73,13 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
     }
 
     fun relasjon(
-        relasjonsType: RelasjonTypeCodeV1? = null,
+        relasjonstype: RelasjonTypeCode? = null,
         fom: LocalDate? = null,
-        pid: String? = null
+        pid: Pid
     ) = Relasjon().apply {
-        this.relasjonsType = relasjonsType
+        this.relasjonsType = relasjonstype
         this.fom = fom
-        this.person = pid?.let { PersonV1().apply { this.pid = it } }
+        this.person = FppPerson().apply { this.pid = pid }
     }
 
     fun avdoedData(
@@ -604,8 +603,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                         valgtSivilstatus = SivilstatusType.GIFT,
                         registrertSivilstatus = SivilstandEnum.GIFT,
                         eps = relasjon(
-                            relasjonsType = RelasjonTypeCodeV1.GLAD,
-                            pid = epsPid.value
+                            relasjonstype = RelasjonTypeCode.GLAD,
+                            pid = epsPid
                         )
                     )
                 ),
@@ -684,8 +683,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                         valgtSivilstatus = SivilstatusType.GIFT,
                         registrertSivilstatus = SivilstandEnum.GIFT,
                         eps = relasjon(
-                            relasjonsType = RelasjonTypeCodeV1.GLAD,
-                            pid = epsPid.value
+                            relasjonstype = RelasjonTypeCode.GLAD,
+                            pid = epsPid
                         )
                     )
                 ),
@@ -712,8 +711,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                         registrertSivilstatus = SivilstandEnum.GIFT,
                         epsMottarPensjon = true,
                         eps = relasjon(
-                            relasjonsType = RelasjonTypeCodeV1.GLAD,
-                            pid = epsPid.value
+                            relasjonstype = RelasjonTypeCode.GLAD,
+                            pid = epsPid
                         )
                     )
                 ),
@@ -739,8 +738,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                         registrertSivilstatus = SivilstandEnum.GIFT,
                         epsMottarPensjon = false,
                         eps = relasjon(
-                            relasjonsType = RelasjonTypeCodeV1.GLAD,
-                            pid = epsPid.value
+                            relasjonstype = RelasjonTypeCode.GLAD,
+                            pid = epsPid
                         )
                     )
                 ),
@@ -784,7 +783,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                     epsData = epsData(
                         valgtSivilstatus = SivilstatusType.GIFT,
                         registrertSivilstatus = SivilstandEnum.GIFT, // match
-                        eps = relasjon(pid = epsPid.value)
+                        eps = relasjon(pid = epsPid)
                     )
                 ),
                 opptjeningFolketrygden = null,
@@ -806,7 +805,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                     epsData = epsData(
                         valgtSivilstatus = SivilstatusType.GIFT,
                         registrertSivilstatus = SivilstandEnum.GIFT,
-                        eps = relasjon(pid = epsPid.value)
+                        eps = relasjon(pid = epsPid)
                     )
                 ),
                 opptjeningFolketrygden = null,
@@ -828,7 +827,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
     context("GJENLEVENDE simulering") {
         should("alltid inkludere EPS-persongrunnlag med AVDOD-rolle") {
             val avdoed = avdoedData(
-                relasjon = relasjon(pid = epsPid.value)
+                relasjon = relasjon(pid = epsPid)
             )
 
             val result = creator().createSpec(
@@ -905,7 +904,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                 avdodMedlemFolketrygden = true,
                 avdodInntektMinst1G = true,
                 dodAvYrkesskade = false,
-                relasjon = relasjon(pid = epsPid.value)
+                relasjon = relasjon(pid = epsPid)
             )
 
             val result = creator().createSpec(
@@ -931,7 +930,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                 datoForDodsfall = doedsdato,
                 dodAvYrkesskade = true,
                 inntektPaaDodstidspunktHvisYrkesskade = 750000,
-                relasjon = relasjon(pid = epsPid.value)
+                relasjon = relasjon(pid = epsPid)
             )
 
             val result = creator().createSpec(
@@ -953,7 +952,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
         }
 
         should("bruke avdødes opptjeningsgrunnlag for EPS ved GJENLEVENDE") {
-            val avdoed = avdoedData(relasjon = relasjon(pid = epsPid.value))
+            val avdoed = avdoedData(relasjon = relasjon(pid = epsPid))
             val opptjening = opptjeningFolketrygden(
                 avdodesOpptjening = listOf(
                     opptjeningData(ar = 2015, pensjonsgivendeInntekt = 400000, omsorgspoeng = 0.0)
@@ -976,7 +975,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
         should("beregne EPS FPI-beløp som G+1 når avdødInntektMinst1G er true") {
             val avdoed = avdoedData(
                 avdodInntektMinst1G = true,
-                relasjon = relasjon(pid = epsPid.value)
+                relasjon = relasjon(pid = epsPid)
             )
 
             val result = creator().createSpec(
@@ -993,7 +992,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
         should("beregne EPS FPI-beløp som 0 når avdødInntektMinst1G er false") {
             val avdoed = avdoedData(
                 avdodInntektMinst1G = false,
-                relasjon = relasjon(pid = epsPid.value)
+                relasjon = relasjon(pid = epsPid)
             )
 
             val result = creator().createSpec(
@@ -1056,8 +1055,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
-                    relasjonsType = RelasjonTypeCodeV1.MORA,
-                    pid = morPid.value
+                    relasjonstype = RelasjonTypeCode.MORA,
+                    pid = morPid
                 )
             )
 
@@ -1090,8 +1089,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
-                    relasjonsType = RelasjonTypeCodeV1.MORA,
-                    pid = morPid.value
+                    relasjonstype = RelasjonTypeCode.MORA,
+                    pid = morPid
                 )
             )
 
@@ -1115,8 +1114,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
-                    relasjonsType = RelasjonTypeCodeV1.MORA,
-                    pid = morPid.value
+                    relasjonstype = RelasjonTypeCode.MORA,
+                    pid = morPid
                 )
             )
 
@@ -1140,8 +1139,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
-                    relasjonsType = RelasjonTypeCodeV1.MORA,
-                    pid = morPid.value
+                    relasjonstype = RelasjonTypeCode.MORA,
+                    pid = morPid
                 )
             )
 
@@ -1165,8 +1164,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
-                    relasjonsType = RelasjonTypeCodeV1.MORA,
-                    pid = morPid.value
+                    relasjonstype = RelasjonTypeCode.MORA,
+                    pid = morPid
                 )
             )
 
@@ -1196,8 +1195,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                 avdodAntAarIUtlandet = 2,
                 avdodInntektMinst1G = true,
                 relasjon = relasjon(
-                    relasjonsType = RelasjonTypeCodeV1.MORA,
-                    pid = morPid.value
+                    relasjonstype = RelasjonTypeCode.MORA,
+                    pid = morPid
                 )
             )
 
@@ -1239,8 +1238,8 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
             val avdoed = avdoedData(
                 relasjon = relasjon(
-                    relasjonsType = RelasjonTypeCodeV1.FARA,
-                    pid = farPid.value
+                    relasjonstype = RelasjonTypeCode.FARA,
+                    pid = farPid
                 )
             )
 
@@ -1264,10 +1263,10 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
             every { personService.person(farPid) } returns svenskPerson(LocalDate.of(1968, 8, 20))
 
             val avdoedMor = avdoedData(
-                relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
+                relasjon = relasjon(relasjonstype = RelasjonTypeCode.MORA, pid = morPid)
             )
             val avdoedFar = avdoedData(
-                relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.FARA, pid = farPid.value)
+                relasjon = relasjon(relasjonstype = RelasjonTypeCode.FARA, pid = farPid)
             )
 
             val opptjening = opptjeningFolketrygden(
@@ -1304,7 +1303,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
             val personService = arrangeMor(morPid)
 
             val avdoed = avdoedData(
-                relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
+                relasjon = relasjon(relasjonstype = RelasjonTypeCode.MORA, pid = morPid)
             )
 
             val opptjening = opptjeningFolketrygden(
@@ -1331,7 +1330,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                 datoForDodsfall = doedsdato,
                 dodAvYrkesskade = true,
                 inntektPaaDodstidspunktHvisYrkesskade = 600000,
-                relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
+                relasjon = relasjon(relasjonstype = RelasjonTypeCode.MORA, pid = morPid)
             )
 
             val result = creator(personService = personService).createSpec(
@@ -1357,7 +1356,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
             every { personService.person(soeskenPid) } returns norskPerson(soeskenFoedselsdato)
 
             val avdoed = avdoedData(
-                relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
+                relasjon = relasjon(relasjonstype = RelasjonTypeCode.MORA, pid = morPid)
             )
 
             val soeskenData = BarneopplysningerSoeskenData().apply {
@@ -1408,7 +1407,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
             }
 
             val avdoed = avdoedData(
-                relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
+                relasjon = relasjon(relasjonstype = RelasjonTypeCode.MORA, pid = morPid)
             )
 
             val soeskenData = BarneopplysningerSoeskenData().apply {
@@ -1438,7 +1437,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
             val personService = arrangeMor(morPid)
 
             val avdoed = avdoedData(
-                relasjon = relasjon(relasjonsType = RelasjonTypeCodeV1.MORA, pid = morPid.value)
+                relasjon = relasjon(relasjonstype = RelasjonTypeCode.MORA, pid = morPid)
             )
 
             val barneopplysninger = Barneopplysninger().apply {
@@ -1493,9 +1492,9 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
 
     context("EPS statsborgerskap") {
         should("hente statsborgerskap fra epsData relasjon") {
-            val epsRelasjon = relasjon(pid = epsPid.value).apply {
-                person = PersonV1().apply {
-                    pid = epsPid.value
+            val epsRelasjon = relasjon(pid = epsPid).apply {
+                person = FppPerson().apply {
+                    pid = epsPid
                     personUtland = PersonUtland().apply {
                         statsborgerskap = LandkodeEnum.SWE
                     }
@@ -1525,7 +1524,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                 personopplysninger = personopplysninger(
                     epsData = epsData(
                         valgtSivilstatus = SivilstatusType.GIFT,
-                        eps = relasjon(pid = epsPid.value)
+                        eps = relasjon(pid = epsPid)
                     )
                 ),
                 opptjeningFolketrygden = null,
@@ -1890,7 +1889,7 @@ class FppSimuleringSpecCreatorTest : ShouldSpec({
                     epsData = epsData(
                         valgtSivilstatus = SivilstatusType.GIFT,
                         registrertSivilstatus = SivilstandEnum.GIFT,
-                        eps = relasjon(pid = epsPid.value)
+                        eps = relasjon(pid = epsPid)
                     )
                 ),
                 opptjeningFolketrygden = null,


### PR DESCRIPTION
Lager et komplett anti-corruption-layer for FPP-tjenesten (egne DTO-er `FppSimuleringSpecDto` og `FppSimuleringResultDto` som mappes til/fra domeneklassene `FppSimuleringSpec`/`FppSimuleringResult`).

Legger også til manglende `EKTE`-verdi i `RelasjonTypeCode`.