### PR TITLE
Use 'brukFremtidigInntekt = false' for Norsk Pensjon

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/api/samhandler/np/v2/acl/spec/SimuleringSpecMapperForNorskPensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/api/samhandler/np/v2/acl/spec/SimuleringSpecMapperForNorskPensjon.kt
@@ -27,7 +27,7 @@ class SimuleringSpecMapperForNorskPensjon(
      * Takes a specification in the form of a data transfer object (DTO) and maps it to a domain object.
      */
     fun fromDto(source: SimuleringSpecDto): SimuleringSpec {
-        val pid: Pid = source.personident.let(::Pid)
+        val pid = Pid(source.personident)
         val foersteUttak = source.foersteUttak
         val foersteUttakFom: LocalDate = foersteUttak.fomDato
         val heltUttak = source.heltUttak
@@ -47,8 +47,8 @@ class SimuleringSpecMapperForNorskPensjon(
             pid = pid,
             foedselDato = personService.foedselsdato(pid),
             avdoed = null,
-            isTpOrigSimulering = true, // true for samhandler
-            simulerForTp = false,
+            isTpOrigSimulering = true, // "Tp" er her Norsk Pensjon, som originerer simuleringen
+            simulerForTp = false, // simulerer ikke som grunnlag for tjenestepensjonssimulering
             uttakGrad = uttaksgrad(source),
             forventetInntektBeloep = source.aarligInntektFoerUttak ?: 0,
             inntektUnderGradertUttakBeloep = gradertUttak?.aarligInntekt ?: 0,
@@ -58,7 +58,7 @@ class SimuleringSpecMapperForNorskPensjon(
             utlandAntallAar = source.aarIUtlandetEtter16 ?: 0,
             utlandPeriodeListe = mutableListOf(),
             fremtidigInntektListe = mutableListOf(), //source.fremtidigInntektListe.orEmpty().map(::inntekt).toMutableList(),
-            brukFremtidigInntekt = true,
+            brukFremtidigInntekt = false, // bruker forventetInntektBeloep etc. istedenfor fremtidigInntektListe
             inntektOver1GAntallAar = 0,
             flyktning = null,
             livsvarigOffentligAfp = null,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,8 @@ spring.flyway.url=${psdb.jdbc.url}
 spring.flyway.user=${psdb.username}
 spring.flyway.password=${psdb.password}
 
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true
 springdoc.use-fqn=true
 
 azure-app.client-id=${AZURE_APP_CLIENT_ID:b9c95cee-76d7-43ba-82e9-d6011f623b9a}

--- a/src/test/kotlin/no/nav/pensjon/simulator/api/samhandler/np/v2/acl/spec/SimuleringSpecMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/api/samhandler/np/v2/acl/spec/SimuleringSpecMapperTest.kt
@@ -45,7 +45,7 @@ class SimuleringSpecMapperTest : ShouldSpec({
                 utlandAntallAar = 1,
                 utlandPeriodeListe = mutableListOf(),
                 fremtidigInntektListe = mutableListOf(),
-                brukFremtidigInntekt = true,
+                brukFremtidigInntekt = false,
                 inntektOver1GAntallAar = 0,
                 flyktning = null,
                 epsHarInntektOver2G = false,


### PR DESCRIPTION
Setter `brukFremtidigInntekt = false` for Norsk Pensjon, da de ikke angir fremtidige inntekter som liste.

I tillegg:

- Forenklet mapping av `Pid`
- Ekstra kommentarer
- Angir `springdoc.*.enabled=true` eksplisitt for å unngå warning ved oppstart