### PR TITLE
FAGSYSTEM-430879 Fix for multiple 0-uttak

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgrad.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgrad.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.simulator.afp.offentlig.pre2025
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
+import no.nav.pensjon.simulator.core.domain.reglerextend.grunnlag.copy
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.krav.KravService
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
@@ -85,24 +86,36 @@ class Pre2025OffentligAfpUttaksgrad(
         private fun ubetingetHeltUttak(fom: LocalDate): Uttaksgrad =
             uttaksgrad(fom, grad = 100, tom = null)
 
+        /**
+         * Fjerner siste eksisterende uttaksgradperiode med 0 %,
+         * da det skal legges til en 0-periode som dekker AFP-perioden.
+         * Terminerer også alderspensjon (setter t.o.m.-dato), da den ikke kan kombineres med tidsbegrenset AFP.
+         * NB: Dette gjøres på en kopi av uttaksgradene, slik at de opprinnelige uttaksgradene ikke blir endret.
+         */
         private fun behandleVedtatteUttaksgrader(
             kravhode: Kravhode?,
             afpFom: LocalDate
         ): MutableList<Uttaksgrad> {
-            // Fjern siste eksisterende uttaksgradperiode med 0 %,
-            // da det skal legges til en 0-periode som dekker AFP-perioden:
-            val uttaksgradListe = kravhode?.uttaksgradListe.orEmpty()
-                .filter { it.fomDatoLd != siste0UttakFom(kravhode) }
-                .toMutableList()
+            val uttaksgradListe = kravhode?.uttaksgradListe.orEmpty().map { it.copy() }.toMutableList()
 
-            // Terminer alderspensjon (kan ikke kombineres med tidsbegrenset AFP):
-            replaceNullTom(uttaksgradListe, tom = afpFom.minusDays(1))
+            val listeUtenSiste0Uttak =
+                siste0UttakFom(uttaksgradListe)?.let { listeUten0Uttak(uttaksgradListe, fom = it) }
+                    ?: uttaksgradListe
 
-            return uttaksgradListe
+            replaceNullTom(uttaksgradListe = listeUtenSiste0Uttak, tom = afpFom.minusDays(1))
+            return listeUtenSiste0Uttak
         }
 
-        private fun siste0UttakFom(kravhode: Kravhode?): LocalDate? =
-            kravhode?.uttaksgradListe.orEmpty().filter { it.uttaksgrad == 0 }.maxOfOrNull { it.fomDatoLd!! }
+        private fun listeUten0Uttak(uttaksgradListe: List<Uttaksgrad>, fom: LocalDate): MutableList<Uttaksgrad> =
+            uttaksgradListe
+                .filterNot { it.uttaksgrad == 0 && it.fomDatoLd == fom }
+                .toMutableList()
+
+        private fun siste0UttakFom(uttaksgradListe: List<Uttaksgrad>): LocalDate? =
+            uttaksgradListe
+                .filter { it.uttaksgrad == 0 }
+                .mapNotNull { it.fomDatoLd }
+                .maxOrNull()
 
         // PEN: SimulerAFPogAPCommandHelper.updateUttaksgradWithTomDateNull
         private fun replaceNullTom(uttaksgradListe: List<Uttaksgrad>, tom: LocalDate) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgrad.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgrad.kt
@@ -3,7 +3,6 @@ package no.nav.pensjon.simulator.afp.offentlig.pre2025
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
-import no.nav.pensjon.simulator.core.domain.reglerextend.grunnlag.copy
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.krav.KravService
 import no.nav.pensjon.simulator.normalder.NormertPensjonsalderService
@@ -90,10 +89,11 @@ class Pre2025OffentligAfpUttaksgrad(
             kravhode: Kravhode?,
             afpFom: LocalDate
         ): MutableList<Uttaksgrad> {
-            // Fjern eksisterende uttaksgradperioder med 0 %,
-            // da det skal legges til en 0-periode som dekker AFP-perioden
-            // (gjøres på en kopi av uttaksgradperiodene, slik at det ikke er noen endringer i originalen):
-            val uttaksgradListe = uttaksgraderUten0(kravhode).map { it.copy() }.toMutableList()
+            // Fjern siste eksisterende uttaksgradperiode med 0 %,
+            // da det skal legges til en 0-periode som dekker AFP-perioden:
+            val uttaksgradListe = kravhode?.uttaksgradListe.orEmpty()
+                .filter { it.fomDatoLd != siste0UttakFom(kravhode) }
+                .toMutableList()
 
             // Terminer alderspensjon (kan ikke kombineres med tidsbegrenset AFP):
             replaceNullTom(uttaksgradListe, tom = afpFom.minusDays(1))
@@ -101,8 +101,8 @@ class Pre2025OffentligAfpUttaksgrad(
             return uttaksgradListe
         }
 
-        private fun uttaksgraderUten0(kravhode: Kravhode?): List<Uttaksgrad> =
-            kravhode?.uttaksgradListe.orEmpty().filter { it.uttaksgrad != 0 }
+        private fun siste0UttakFom(kravhode: Kravhode?): LocalDate? =
+            kravhode?.uttaksgradListe.orEmpty().filter { it.uttaksgrad == 0 }.maxOfOrNull { it.fomDatoLd!! }
 
         // PEN: SimulerAFPogAPCommandHelper.updateUttaksgradWithTomDateNull
         private fun replaceNullTom(uttaksgradListe: List<Uttaksgrad>, tom: LocalDate) {

--- a/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgradTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/Pre2025OffentligAfpUttaksgradTest.kt
@@ -123,7 +123,7 @@ class Pre2025OffentligAfpUttaksgradTest : ShouldSpec({
             with(uttaksgradListe[0]) {
                 // Terminert alderspensjonsperiode:
                 fomDatoLd shouldBe LocalDate.of(2024, 1, 1)
-                tomDatoLd shouldBe historiskAlderspensjonTom
+                tomDatoLd shouldBe historiskAlderspensjonTom // 2026-02-28
                 uttaksgrad shouldBe 100
             }
             with(uttaksgradListe[1]) {
@@ -140,12 +140,69 @@ class Pre2025OffentligAfpUttaksgradTest : ShouldSpec({
             }
         }
     }
+
+    context("flere perioder med 0-uttak") {
+        should("uttaksgradlisten være kontinuerlig") {
+            val startdatoForAfp = LocalDate.of(2026, 6, 1)
+            val foedselsdato = LocalDate.of(1960, 12, 15)
+            // Med normalder 67 år 0 måneder blir ubetinget uttaksdato 2028-01-01
+
+            val uttaksgradListe = Pre2025OffentligAfpUttaksgrad(
+                kravService = arrangeKravMedFlere0Uttak(),
+                normalderService = Arrange.normalder(foedselsdato) // normalder 67 år 0 måneder
+            ).uttaksgradListe(
+                spec = simuleringSpec(foersteUttakDato = startdatoForAfp),
+                forrigeAlderspensjonBeregningResultat = BeregningsResultatAlderspensjon2016().apply { kravId = 1L },
+                foedselsdato
+            )
+
+            uttaksgradListe.size shouldBe 7
+            uttaksgradListe.sortBy { it.fomDatoLd }
+            with(uttaksgradListe[0]) {
+                uttaksgrad shouldBe 100
+                fomDatoLd shouldBe LocalDate.of(2023, 1, 1)
+                tomDatoLd shouldBe LocalDate.of(2024, 6, 30)
+            }
+            with(uttaksgradListe[1]) {
+                uttaksgrad shouldBe 0
+                fomDatoLd shouldBe LocalDate.of(2024, 7, 1)
+                tomDatoLd shouldBe LocalDate.of(2024, 12, 31)
+            }
+            with(uttaksgradListe[2]) {
+                uttaksgrad shouldBe 100
+                fomDatoLd shouldBe LocalDate.of(2025, 1, 1)
+                tomDatoLd shouldBe LocalDate.of(2025, 7, 31)
+            }
+            with(uttaksgradListe[3]) {
+                uttaksgrad shouldBe 0
+                fomDatoLd shouldBe LocalDate.of(2025, 8, 1)
+                tomDatoLd shouldBe LocalDate.of(2026, 1, 31)
+            }
+            with(uttaksgradListe[4]) {
+                uttaksgrad shouldBe 100
+                fomDatoLd shouldBe LocalDate.of(2026, 2, 1)
+                tomDatoLd shouldBe LocalDate.of(2026, 5, 31)
+            }
+            // AFP-periode:
+            with(uttaksgradListe[5]) {
+                uttaksgrad shouldBe 0
+                fomDatoLd shouldBe LocalDate.of(2026, 6, 1)
+                tomDatoLd shouldBe LocalDate.of(2027, 12, 31)
+            }
+            // Alderspensjon etter AFP, f.o.m. ubetinget uttaksdato:
+            with(uttaksgradListe[6]) {
+                uttaksgrad shouldBe 100
+                fomDatoLd shouldBe LocalDate.of(2028, 1, 1)
+                tomDatoLd shouldBe null
+            }
+        }
+    }
 })
 
 private val historiskAlderspensjonTom = LocalDate.of(2026, 2, 28)
 
 private fun arrangeKrav(loepende0Uttak: Uttaksgrad): KravService =
-    mockk<KravService>().apply {
+    mockk {
         every { fetchKravhode(any()) } returns Kravhode().apply {
             uttaksgradListe = mutableListOf(
                 Uttaksgrad().apply {
@@ -154,6 +211,44 @@ private fun arrangeKrav(loepende0Uttak: Uttaksgrad): KravService =
                     tomDatoLd = historiskAlderspensjonTom
                 },
                 loepende0Uttak
+            )
+        }
+    }
+
+private fun arrangeKravMedFlere0Uttak(): KravService =
+    mockk {
+        every { fetchKravhode(any()) } returns Kravhode().apply {
+            uttaksgradListe = mutableListOf(
+                Uttaksgrad().apply {
+                    uttaksgrad = 100
+                    fomDatoLd = LocalDate.of(2023, 1, 1)
+                    tomDatoLd = LocalDate.of(2024, 6, 30)
+                },
+                Uttaksgrad().apply {
+                    uttaksgrad = 0
+                    fomDatoLd = LocalDate.of(2024, 7, 1)
+                    tomDatoLd = LocalDate.of(2024, 12, 31)
+                },
+                Uttaksgrad().apply {
+                    uttaksgrad = 100
+                    fomDatoLd = LocalDate.of(2025, 1, 1)
+                    tomDatoLd = LocalDate.of(2025, 7, 31)
+                },
+                Uttaksgrad().apply {
+                    uttaksgrad = 0
+                    fomDatoLd = LocalDate.of(2025, 8, 1)
+                    tomDatoLd = LocalDate.of(2026, 1, 31)
+                },
+                Uttaksgrad().apply {
+                    uttaksgrad = 100
+                    fomDatoLd = LocalDate.of(2026, 2, 1)
+                    tomDatoLd = LocalDate.of(2026, 5, 31)
+                },
+                Uttaksgrad().apply {
+                    uttaksgrad = 0
+                    fomDatoLd = LocalDate.of(2026, 6, 1)
+                    tomDatoLd = null
+                },
             )
         }
     }


### PR DESCRIPTION
Gjelder tidsbegrenset offentlig AFP der alderspensjonshistorikken har flere perioder med 0 % uttaksgrad.
Endringen gjør at kun siste uttak med 0 % påvirkes, ikke mellomliggende perioder med 0-uttak.
Dermed blir det ikke "hull" i uttaksperiodene.