### PR TITLE
Updates for pensjon-regler-api v2.0.0

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContext.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContext.kt
@@ -22,13 +22,11 @@ import no.nav.pensjon.simulator.regel.client.RegelClient
 import no.nav.pensjon.simulator.tech.cache.CacheConfigurator.createCache
 import org.springframework.cache.caffeine.CaffeineCacheManager
 import org.springframework.stereotype.Component
-import tools.jackson.databind.json.JsonMapper
 import java.time.LocalDate
 
 @Component
 class SimulatorContext(
     private val regelService: GenericRegelClient,
-    private val objectMapper: JsonMapper,
     cacheManager: CaffeineCacheManager
 ) : RegelClient {
 
@@ -48,7 +46,7 @@ class SimulatorContext(
                 sakId = sakId?.toString()
             )
 
-        validerResponse(response.pakkseddel, spec, objectMapper, "beregnAlderspensjon2011FoersteUttak")
+        validerResponse(response.pakkseddel, spec, "beregnAlderspensjon2011FoersteUttak")
 
         return response.beregningsResultat?.apply {
             virkTomLd = null
@@ -70,7 +68,7 @@ class SimulatorContext(
                 sakId = sakId?.toString()
             )
 
-        validerResponse(response.pakkseddel, spec, objectMapper, "beregnAlderspensjon2016FoersteUttak")
+        validerResponse(response.pakkseddel, spec, "beregnAlderspensjon2016FoersteUttak")
 
         return response.beregningsResultat?.apply {
             virkTomLd = null
@@ -92,7 +90,7 @@ class SimulatorContext(
                 sakId = sakId?.toString()
             )
 
-        validerResponse(response.pakkseddel, spec, objectMapper, "beregnAlderspensjon2025FoersteUttak")
+        validerResponse(response.pakkseddel, spec, "beregnAlderspensjon2025FoersteUttak")
 
         return response.beregningsResultat?.apply {
             virkTomLd = null
@@ -141,7 +139,7 @@ class SimulatorContext(
                 sakId = sakId?.toString()
             )
 
-        validerResponse(response.pakkseddel, spec, objectMapper, "revurderingAlderspensjon2011")
+        validerResponse(response.pakkseddel, spec, "revurderingAlderspensjon2011")
         return response.revurdertBeregningsResultat!!
     }
 
@@ -158,7 +156,7 @@ class SimulatorContext(
                 sakId = sakId?.toString()
             )
 
-        validerResponse(response.pakkseddel, spec, objectMapper, "revurderingAlderspensjon2016")
+        validerResponse(response.pakkseddel, spec, "revurderingAlderspensjon2016")
         return response.revurdertBeregningsResultat!!
     }
 
@@ -175,7 +173,7 @@ class SimulatorContext(
                 sakId = sakId?.toString()
             )
 
-        validerResponse(response.pakkseddel, spec, objectMapper, "revurderingAlderspensjon2025")
+        validerResponse(response.pakkseddel, spec, "revurderingAlderspensjon2025")
         return response.revurdertBeregningsResultat!!
     }
 
@@ -238,7 +236,7 @@ class SimulatorContext(
                 sakId = sakId?.toString()
             )
 
-        validerResponse(response.pakkseddel, spec, objectMapper, "vilkaarsproevUbetingetAlderspensjon")
+        validerResponse(response.pakkseddel, spec, "vilkaarsproevUbetingetAlderspensjon")
         return response.vedtaksliste
     }
 
@@ -257,7 +255,7 @@ class SimulatorContext(
             sakId = sakId?.toString()
         )
 
-        validerResponse(response.pakkseddel, spec, objectMapper, "vilkarsprovAlderspensjon2011")
+        validerResponse(response.pakkseddel, spec, "vilkarsprovAlderspensjon2011")
         return response.vedtaksliste
     }
 
@@ -276,7 +274,7 @@ class SimulatorContext(
             sakId = sakId?.toString()
         )
 
-        validerResponse(response.pakkseddel, spec, objectMapper, "vilkarsprovAlderspensjon2016")
+        validerResponse(response.pakkseddel, spec, "vilkarsprovAlderspensjon2016")
         return response.vedtaksliste
     }
 
@@ -295,7 +293,7 @@ class SimulatorContext(
             sakId = sakId?.toString()
         )
 
-        validerResponse(response.pakkseddel, spec, objectMapper, "vilkaarsproevAlderspensjon2025")
+        validerResponse(response.pakkseddel, spec, "vilkaarsproevAlderspensjon2025")
         return response.vedtaksliste
     }
 
@@ -329,7 +327,7 @@ class SimulatorContext(
             sakId = sakId?.toString()
         )
 
-        validerOgFerdigstillResponse(response, kravIsUfoeretrygd, spec, objectMapper, "fastsettTrygdetid")
+        validerOgFerdigstillResponse(response, kravIsUfoeretrygd, spec, "fastsettTrygdetid")
         return response
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContextUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContextUtil.kt
@@ -13,7 +13,6 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Pensjonsbeholdning
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonOpptjeningsgrunnlag
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresultat
 import no.nav.pensjon.simulator.core.domain.regler.to.*
-import no.nav.pensjon.simulator.core.exception.KanIkkeBeregnesException
 import no.nav.pensjon.simulator.core.exception.RegelmotorValideringException
 import tools.jackson.databind.ObjectMapper
 import java.math.RoundingMode
@@ -67,10 +66,9 @@ object SimulatorContextUtil {
         result: TrygdetidResponse,
         kravGjelderUfoeretrygd: Boolean,
         spec: Any,
-        objectMapper: ObjectMapper,
         call: String
     ) {
-        validerResponse(result.pakkseddel, spec, objectMapper, call)
+        validerResponse(result.pakkseddel, spec, call)
 
         result.trygdetid?.apply {
             tt_67_75 = 0 // since this value is not mapped to PEN domain in original PEN code
@@ -118,26 +116,17 @@ object SimulatorContextUtil {
     // RegelHelper.validateResponse
     fun validerResponse(pakkseddel: Pakkseddel) {
         val kontrollTjenesteOk = pakkseddel.kontrollTjenesteOk
-        val annenTjenesteOk = pakkseddel.annenTjenesteOk
-        if (kontrollTjenesteOk && annenTjenesteOk) return
+        if (kontrollTjenesteOk) return
 
         val message = pakkseddel.merknaderAsString()
-
-        if (kontrollTjenesteOk) {
-            log.warn { "regler validering andre merknader - $message" }
-            throw KanIkkeBeregnesException(message, pakkseddel.merknadListe)
-        } else {
-            log.warn { "regler validering kontroll merknader - $message" }
-            throw RegelmotorValideringException(message, pakkseddel.merknadListe)
-        }
+        log.warn { "regler validering kontroll merknader - $message" }
+        throw RegelmotorValideringException(message, pakkseddel.merknadListe)
     }
 
-    fun validerResponse(pakkseddel: Pakkseddel, spec: Any, objectMapper: ObjectMapper, call: String) {
+    fun validerResponse(pakkseddel: Pakkseddel, spec: Any, call: String) {
         val kontrollTjenesteOk = pakkseddel.kontrollTjenesteOk
-        val annenTjenesteOk = pakkseddel.annenTjenesteOk
-        if (kontrollTjenesteOk && annenTjenesteOk) return
+        if (kontrollTjenesteOk) return
 
-        val message = pakkseddel.merknaderAsString()
 
         (spec as? RevurderingAlderspensjon2025Request)?.let {
             log.warn {
@@ -145,15 +134,9 @@ object SimulatorContextUtil {
             }
         }
 
-        log.debug { "regler validering error for $call - " + objectMapper.writeValueAsString(spec) }
-
-        if (kontrollTjenesteOk) {
-            log.error { "$call - regler validering andre merknader - $message => KanIkkeBeregnesException" }
-            throw KanIkkeBeregnesException(message, pakkseddel.merknadListe)
-        } else {
-            log.error { "$call - regler validering kontroll merknader - $message => RegelmotorValideringException" }
-            throw RegelmotorValideringException(message, pakkseddel.merknadListe)
-        }
+        val message = pakkseddel.merknaderAsString()
+        log.error { "$call - regler validering kontroll merknader - $message => RegelmotorValideringException" }
+        throw RegelmotorValideringException(message, pakkseddel.merknadListe)
     }
 
     private fun preprocess(pensjon: PensjonUnderUtbetaling) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContextUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContextUtil.kt
@@ -14,7 +14,6 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.PersonOpptjeningsgru
 import no.nav.pensjon.simulator.core.domain.regler.simulering.Simuleringsresultat
 import no.nav.pensjon.simulator.core.domain.regler.to.*
 import no.nav.pensjon.simulator.core.exception.RegelmotorValideringException
-import tools.jackson.databind.ObjectMapper
 import java.math.RoundingMode
 import java.time.LocalDate
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AfpPrivatLivsvarig as PrivatAfp

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/beregn/AlderspensjonBeregner.kt
@@ -158,7 +158,7 @@ class AlderspensjonBeregner(private val context: SimulatorContext) {
             }
         }
 
-        // SIMDOM-ADD
+        // Extra
         private fun innvilgetVedtak(source: VilkarsVedtak) =
             /* TODO check if copy needed:
         VilkarsVedtak(source).also {
@@ -223,7 +223,6 @@ class AlderspensjonBeregner(private val context: SimulatorContext) {
                 virkFomLd = spec.virkFom
                 kravhode = spec.kravhode
                 vilkarsvedtakListe = spec.vilkarsvedtakListe
-                infoPavirkendeYtelse = spec.infoPavirkendeYtelse
                 epsMottarPensjon = spec.epsMottarPensjon
                 afpPrivatLivsvarig = spec.privatAfp
                 afpOffentligLivsvarigGrunnlag = spec.livsvarigOffentligAfpGrunnlag

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/Pakkseddel.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/Pakkseddel.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.domain.regler
 
 import com.fasterxml.jackson.annotation.JsonGetter
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 /**
  * Denne klassen representerer en pakkseddel som leveres sammen med resultatet
  * fra en regeltjeneste.

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/Pakkseddel.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/Pakkseddel.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.domain.regler
 
 import com.fasterxml.jackson.annotation.JsonGetter
 
-// Copied from pensjon-regler-api 2026-01-16
+// 2026-06-04
 /**
  * Denne klassen representerer en pakkseddel som leveres sammen med resultatet
  * fra en regeltjeneste.
@@ -20,13 +20,6 @@ class Pakkseddel {
      */
     @get:JsonGetter
     val kontrollTjenesteOk: Boolean
-        get() = merknadListe.isEmpty()
-
-    /**
-     * Er 'true' dersom ingen feilmeldinger er vedlagt pakkseddelen (merknadslisten er tom).
-     */
-    @get:JsonGetter
-    val annenTjenesteOk: Boolean
         get() = merknadListe.isEmpty()
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/AvkortingsinformasjonUT.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/AvkortingsinformasjonUT.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.domain.regler.beregning2011
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 /**
  * Angir detaljer rund avkortingen av uføretrygd.
  */

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/AvkortingsinformasjonUT.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/AvkortingsinformasjonUT.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.domain.regler.beregning2011
 
-// 2025-03-20
+// 2026-06-04
 /**
  * Angir detaljer rund avkortingen av uføretrygd.
  */
@@ -8,7 +8,7 @@ class AvkortingsinformasjonUT : AbstraktAvkortingsinformasjon() {
     /**
      * beløpsgrense.
      */
-    var belopsgrense = 0
+    var fribeløp = 0
 
     /**
      * Sum av inntektskomponentene som ble lagt til grunn.
@@ -18,17 +18,12 @@ class AvkortingsinformasjonUT : AbstraktAvkortingsinformasjon() {
     /**
      * Inntekt under denne grensen gir ikke utslag i avkorting.
      */
-    var inntektsgrense = 0
-    /**
-     * @return the inntektsgrenseNesteAr
-     */
-    /**
-     * @param inntektsgrenseNesteAr the inntektsgrenseNesteAr to set
-     */
+    var bunnfradrag = 0
+
     /**
      * Inntektsgrense nest år settes når neste års inntektsgrense beregnes
      */
-    var inntektsgrenseNesteAr = 0
+    var bunnfradragNesteAr = 0
 
     /**
      * Inntektstaket for påfålgende år fastsatt på bakgrunn av siste gjeldende OIFU i året. Feltet er kun angitt dersom inntektstak neste år avviker fra gjeldende inntektstak.
@@ -38,7 +33,7 @@ class AvkortingsinformasjonUT : AbstraktAvkortingsinformasjon() {
     /**
      * Angir dekningsgrad av tapt arbeidsevne.
      */
-    var kompensasjonsgrad = 0.0
+    var reduksjonsprosent = 0.0
 
     /**
      * Oppjustert inntekt etter uførhet.

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/BeregningsInformasjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/BeregningsInformasjon.kt
@@ -1,6 +1,5 @@
 package no.nav.pensjon.simulator.core.domain.regler.beregning2011
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.pensjon.simulator.core.domain.regler.Merknad
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
 import no.nav.pensjon.simulator.core.domain.regler.beregning.Sluttpoengtall
@@ -9,12 +8,12 @@ import no.nav.pensjon.simulator.core.domain.regler.enum.JustertPeriodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.ResultattypeEnum
 
-// 2025-03-10
+// 2026-06-04
 class BeregningsInformasjon {
     var forholdstallUttak = 0.0
-    var forholdstall67 = 0.0
+    var forholdstallVedNormertPensjonsalder = 0.0
     var delingstallUttak = 0.0
-    var delingstall67 = 0.0
+    var delingstallVedNormertPensjonsalder = 0.0
     var spt: Sluttpoengtall? = null
     var opt: Sluttpoengtall? = null
     var ypt: Sluttpoengtall? = null
@@ -48,29 +47,13 @@ class BeregningsInformasjon {
 
     //--- Extra:
 
-    var epsPaavirkerBeregning = false // deprecated
-
     // from PEN no.nav.domain.pensjon.kjerne.beregning2011.BeregningsInformasjon
     var epsMottarPensjon: Boolean = false
     var epsOver2G: Boolean = false
 
-    @JsonIgnore
-    var unclearedDelingstallUttak: Double? = null
-
-    @JsonIgnore
-    var unclearedDelingstall67: Double? = null
-
-    val internDelingstallUttak: Double
-        @JsonIgnore get() = unclearedDelingstallUttak ?: delingstallUttak
-
-    val internDelingstall67: Double
-        @JsonIgnore get() = unclearedDelingstall67 ?: delingstall67
-
-    // delingstallUttak, delingstall67 are not mapped in legacy simulering, hence set to zero:
+    // delingstallUttak, delingstallVedNormertPensjonsalder are not mapped in legacy simulering, hence set to zero:
     fun clearDelingstall() {
-        unclearedDelingstallUttak = delingstallUttak
         delingstallUttak = 0.0
-        unclearedDelingstall67 = delingstall67
-        delingstall67 = 0.0
+        delingstallVedNormertPensjonsalder = 0.0
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/BeregningsInformasjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/BeregningsInformasjon.kt
@@ -8,7 +8,7 @@ import no.nav.pensjon.simulator.core.domain.regler.enum.JustertPeriodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.LandkodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.ResultattypeEnum
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class BeregningsInformasjon {
     var forholdstallUttak = 0.0
     var forholdstallVedNormertPensjonsalder = 0.0

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/BeregningsInformasjonMinstenivatilleggPensjonistpar.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/BeregningsInformasjonMinstenivatilleggPensjonistpar.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.domain.regler.beregning2011
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class BeregningsInformasjonMinstenivatilleggPensjonistpar {
     /**
      * Beregnet pensjon pensjon

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/BeregningsInformasjonMinstenivatilleggPensjonistpar.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/BeregningsInformasjonMinstenivatilleggPensjonistpar.kt
@@ -1,56 +1,68 @@
 package no.nav.pensjon.simulator.core.domain.regler.beregning2011
 
+// 2026-06-04
 class BeregningsInformasjonMinstenivatilleggPensjonistpar {
     /*
      * Beregnet pensjon pensjon
      */
-    var samletPensjon: Double = 0.0
-    /*
-     * Minstepensjonsniva sats
-     */
-    var mpnSatsOrdinaer: Double = 0.0
-    /*
-     * Garantipensjonpensjonsniva sats
-     */
-    var garPNSatsOrdinaer: Double = 0.0
-    /*
-     * saertillegg sats
-     */
-    var stSatsOrdinaer: Double = 0.0
-    /*
-     * tt anvendt brukt i alderspensjon etter kapittel 19
-     */
-    var tt_anv_AP: Int = 0
-    /*
-     * tt anvendt brukt i alderspensjon etter kapittel 20
-     */
-    var tt_anv_AP_Kapittel20: Int = 0
+    var samletPensjon = 0.0
 
     /*
-     * tt anvendt brukt i uforepensjon
-     */
-    var tt_anv_UP: Int = 0
-    /*
-     * trygdetid i prorata beregning
-     */
-    var prorataUP: Double = 0.0
-    /*
-     * teller for proratabrok
-     */
-    var prorataUPTeller: Int = 0
-    /*
-     * nevner for proratabrok
-     */
-    var prorataUPNevner: Int = 0
-    /*
-     * personens gjeldende uttaksgrad
-     */
-    var uttaksgrad: Int = 0
-    /*
-     * personens gjeldende uforegrad
-     */
-    var uforegrad: Int = 0
+       * Minstepensjonsniva sats
+       */
+    var mpnSatsOrdinaer = 0.0
 
+    /*
+       * Garantipensjonpensjonsniva sats
+       */
+    var garPNSatsOrdinaer = 0.0
+
+    /*
+       * saertillegg sats
+       */
+    var stSatsOrdinaer = 0.0
+
+    /*
+       * tt anvendt brukt i alderspensjon etter kapittel 19
+       */
+    var tt_anv_AP = 0
+
+    /*
+       * tt anvendt brukt i alderspensjon etter kapittel 20
+       */
+    var tt_anv_AP_Kapittel20 = 0
+
+    /*
+       * tt anvendt brukt i uforepensjon
+       */
+    var tt_anv_UP = 0
+
+    /*
+       * trygdetid i prorata beregning
+       */
+    var prorataUP = 0.0
+
+    /*
+       * teller for proratabrok
+       */
+    var prorataUPTeller = 0
+
+    /*
+       * nevner for proratabrok
+       */
+    var prorataUPNevner = 0
+
+    /*
+       * personens gjeldende uttaksgrad
+       */
+    var uttaksgrad = 0
+
+    /*
+       * personens gjeldende uforegrad
+       */
+    var uforegrad = 0
+
+    //--- Extra:
     constructor() : super() {}
 
     constructor(beregningsInformasjonMinstenivatilleggPensjonistpar: BeregningsInformasjonMinstenivatilleggPensjonistpar) {
@@ -67,31 +79,5 @@ class BeregningsInformasjonMinstenivatilleggPensjonistpar {
         uttaksgrad = beregningsInformasjonMinstenivatilleggPensjonistpar.uttaksgrad
         uforegrad = beregningsInformasjonMinstenivatilleggPensjonistpar.uforegrad
     }
-
-    constructor(
-            samletPensjon: Double = 0.0,
-            mpnSatsOrdinaer: Double = 0.0,
-            garPNSatsOrdinaer: Double = 0.0,
-            stSatsOrdinaer: Double = 0.0,
-            tt_anv_AP: Int = 0,
-            tt_anv_AP_Kapittel20: Int = 0,
-            tt_anv_UP: Int = 0,
-            prorataUP: Double = 0.0,
-            prorataUPTeller: Int = 0,
-            prorataUPNevner: Int = 0,
-            uttaksgrad: Int = 0,
-            uforegrad: Int = 0) {
-        this.samletPensjon = samletPensjon
-        this.mpnSatsOrdinaer = mpnSatsOrdinaer
-        this.garPNSatsOrdinaer = garPNSatsOrdinaer
-        this.stSatsOrdinaer = stSatsOrdinaer
-        this.tt_anv_AP = tt_anv_AP
-        this.tt_anv_AP_Kapittel20 = tt_anv_AP_Kapittel20
-        this.tt_anv_UP = tt_anv_UP
-        this.prorataUP = prorataUP
-        this.prorataUPTeller = prorataUPTeller
-        this.prorataUPNevner = prorataUPNevner
-        this.uttaksgrad = uttaksgrad
-        this.uforegrad = uforegrad
-    }
+    // end extra
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/BeregningsInformasjonMinstenivatilleggPensjonistpar.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/BeregningsInformasjonMinstenivatilleggPensjonistpar.kt
@@ -2,64 +2,64 @@ package no.nav.pensjon.simulator.core.domain.regler.beregning2011
 
 // 2026-06-04
 class BeregningsInformasjonMinstenivatilleggPensjonistpar {
-    /*
+    /**
      * Beregnet pensjon pensjon
      */
     var samletPensjon = 0.0
 
-    /*
-       * Minstepensjonsniva sats
-       */
+    /**
+     * Minstepensjonsniva sats
+     */
     var mpnSatsOrdinaer = 0.0
 
-    /*
-       * Garantipensjonpensjonsniva sats
-       */
+    /**
+     * Garantipensjonpensjonsniva sats
+     */
     var garPNSatsOrdinaer = 0.0
 
-    /*
-       * saertillegg sats
-       */
+    /**
+     * saertillegg sats
+     */
     var stSatsOrdinaer = 0.0
 
-    /*
-       * tt anvendt brukt i alderspensjon etter kapittel 19
-       */
+    /**
+     * tt anvendt brukt i alderspensjon etter kapittel 19
+     */
     var tt_anv_AP = 0
 
-    /*
-       * tt anvendt brukt i alderspensjon etter kapittel 20
-       */
+    /**
+     * tt anvendt brukt i alderspensjon etter kapittel 20
+     */
     var tt_anv_AP_Kapittel20 = 0
 
-    /*
-       * tt anvendt brukt i uforepensjon
-       */
+    /**
+     * tt anvendt brukt i uforepensjon
+     */
     var tt_anv_UP = 0
 
-    /*
-       * trygdetid i prorata beregning
-       */
+    /**
+     * trygdetid i prorata beregning
+     */
     var prorataUP = 0.0
 
-    /*
-       * teller for proratabrok
-       */
+    /**
+     * teller for proratabrok
+     */
     var prorataUPTeller = 0
 
-    /*
-       * nevner for proratabrok
-       */
+    /**
+     * nevner for proratabrok
+     */
     var prorataUPNevner = 0
 
-    /*
-       * personens gjeldende uttaksgrad
-       */
+    /**
+     * personens gjeldende uttaksgrad
+     */
     var uttaksgrad = 0
 
-    /*
-       * personens gjeldende uforegrad
-       */
+    /**
+     * personens gjeldende uforegrad
+     */
     var uforegrad = 0
 
     //--- Extra:

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/Pensjonstillegg.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/Pensjonstillegg.kt
@@ -7,7 +7,7 @@ import no.nav.pensjon.simulator.core.domain.regler.enum.FormelKodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.MinstePensjonsnivaSatsEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 @JsonSubTypes(
     JsonSubTypes.Type(value = BasisPensjonstillegg::class)
 )

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/Pensjonstillegg.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/beregning2011/Pensjonstillegg.kt
@@ -7,31 +7,31 @@ import no.nav.pensjon.simulator.core.domain.regler.enum.FormelKodeEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.MinstePensjonsnivaSatsEnum
 import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
 
-// 2025-03-23
+// 2026-06-04
 @JsonSubTypes(
     JsonSubTypes.Type(value = BasisPensjonstillegg::class)
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 open class Pensjonstillegg : Ytelseskomponent {
-    var forholdstall67 = 0.0
+    var forholdstallVedNormertPensjonsalder = 0.0
     var minstepensjonsnivaSats = 0.0
     var minstepensjonsnivaSatsTypeEnum: MinstePensjonsnivaSatsEnum? = null
     var justertMinstePensjonsniva: JustertMinstePensjonsniva? = null
 
-    override var ytelsekomponentTypeEnum: YtelseskomponentTypeEnum = YtelseskomponentTypeEnum.PT
+    override val ytelsekomponentTypeEnum: YtelseskomponentTypeEnum = YtelseskomponentTypeEnum.PT
 
     constructor() {
         formelKodeEnum = FormelKodeEnum.PenTx
     }
 
-    constructor(source: Pensjonstillegg) : super(source) {
-        forholdstall67 = source.forholdstall67
-        minstepensjonsnivaSats = source.minstepensjonsnivaSats
-        if (source.minstepensjonsnivaSatsTypeEnum != null) {
-            minstepensjonsnivaSatsTypeEnum = source.minstepensjonsnivaSatsTypeEnum
+    constructor(pt: Pensjonstillegg) : super(pt) {
+        forholdstallVedNormertPensjonsalder = pt.forholdstallVedNormertPensjonsalder
+        minstepensjonsnivaSats = pt.minstepensjonsnivaSats
+        if (pt.minstepensjonsnivaSatsTypeEnum != null) {
+            minstepensjonsnivaSatsTypeEnum = pt.minstepensjonsnivaSatsTypeEnum
         }
-        if (source.justertMinstePensjonsniva != null) {
-            justertMinstePensjonsniva = JustertMinstePensjonsniva(source.justertMinstePensjonsniva!!)
+        if (pt.justertMinstePensjonsniva != null) {
+            justertMinstePensjonsniva = JustertMinstePensjonsniva(pt.justertMinstePensjonsniva!!)
         }
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2011ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2011ForsteUttakRequest.kt
@@ -7,7 +7,7 @@ import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import java.time.LocalDate
 import java.util.*
 
-// 2026-04-10
+// 2026-06-04
 class BeregnAlderspensjon2011ForsteUttakRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2011ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2011ForsteUttakRequest.kt
@@ -7,7 +7,7 @@ import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import java.time.LocalDate
 import java.util.*
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class BeregnAlderspensjon2011ForsteUttakRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2016ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2016ForsteUttakRequest.kt
@@ -7,7 +7,7 @@ import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import java.time.LocalDate
 import java.util.Vector
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class BeregnAlderspensjon2016ForsteUttakRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2016ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2016ForsteUttakRequest.kt
@@ -7,7 +7,7 @@ import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import java.time.LocalDate
 import java.util.Vector
 
-// 2026-05-05
+// 2026-06-04
 class BeregnAlderspensjon2016ForsteUttakRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2025ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2025ForsteUttakRequest.kt
@@ -8,7 +8,7 @@ import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import java.time.LocalDate
 import java.util.Vector
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class BeregnAlderspensjon2025ForsteUttakRequest : ServiceRequest() {
     var virkFomLd: LocalDate? = null
     var kravhode: Kravhode? = null

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2025ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/BeregnAlderspensjon2025ForsteUttakRequest.kt
@@ -8,12 +8,11 @@ import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import java.time.LocalDate
 import java.util.Vector
 
-// 2026-05-05
+// 2026-06-04
 class BeregnAlderspensjon2025ForsteUttakRequest : ServiceRequest() {
     var virkFomLd: LocalDate? = null
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()
-    var infoPavirkendeYtelse: InfoPavirkendeYtelse? = null
     var epsMottarPensjon = false
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null
     var afpOffentligLivsvarigGrunnlag: AfpOffentligLivsvarigGrunnlag? = null

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovAlderspensjon67Resultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovAlderspensjon67Resultat.kt
@@ -2,8 +2,8 @@ package no.nav.pensjon.simulator.core.domain.regler.vedtak
 
 import no.nav.pensjon.simulator.core.domain.regler.beregning.Beregning
 
+// 2026-06-04
 class VilkarsprovAlderspensjon67Resultat : AbstraktVilkarsprovResultat() {
-
     var beregningVedUttak: Beregning? = null
     var halvMinstePensjon = 0
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovAlderspensjon67Resultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovAlderspensjon67Resultat.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.domain.regler.vedtak
 
 import no.nav.pensjon.simulator.core.domain.regler.beregning.Beregning
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class VilkarsprovAlderspensjon67Resultat : AbstraktVilkarsprovResultat() {
     var beregningVedUttak: Beregning? = null
     var halvMinstePensjon = 0

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovAlderspensjonResultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovAlderspensjonResultat.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.domain.regler.vedtak
 
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 
-// 2025-03-11
+// 2026-06-04
 class VilkarsprovAlderspensjonResultat : AbstraktVilkarsprovResultat() {
     var beregningVedUttak: AbstraktBeregningsResultat? = null
     var vilkarsprovInformasjon: VilkarsprovInformasjon? = null

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovAlderspensjonResultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovAlderspensjonResultat.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.domain.regler.vedtak
 
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.AbstraktBeregningsResultat
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class VilkarsprovAlderspensjonResultat : AbstraktVilkarsprovResultat() {
     var beregningVedUttak: AbstraktBeregningsResultat? = null
     var vilkarsprovInformasjon: VilkarsprovInformasjon? = null

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon.kt
@@ -7,7 +7,7 @@ import no.nav.pensjon.simulator.core.domain.regler.beregning2011.FremskrevetAfpL
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.FremskrevetPensjonUnderUtbetaling
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.PensjonUnderUtbetaling
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 @JsonSubTypes(
     JsonSubTypes.Type(value = VilkarsprovInformasjon2011::class),
     JsonSubTypes.Type(value = VilkarsprovInformasjon2016::class),

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon.kt
@@ -7,7 +7,7 @@ import no.nav.pensjon.simulator.core.domain.regler.beregning2011.FremskrevetAfpL
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.FremskrevetPensjonUnderUtbetaling
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.PensjonUnderUtbetaling
 
-// 2026-04-23
+// 2026-06-04
 @JsonSubTypes(
     JsonSubTypes.Type(value = VilkarsprovInformasjon2011::class),
     JsonSubTypes.Type(value = VilkarsprovInformasjon2016::class),

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2011.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2011.kt
@@ -2,8 +2,8 @@ package no.nav.pensjon.simulator.core.domain.regler.vedtak
 
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 
+// 2026-06-04
 class VilkarsprovInformasjon2011 : VilkarsprovInformasjon() {
-
     var mpn67: JustertMinstePensjonsniva? = null
     var mpn67ProRata: JustertMinstePensjonsniva? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2011.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2011.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.domain.regler.vedtak
 
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class VilkarsprovInformasjon2011 : VilkarsprovInformasjon() {
     var mpn67: JustertMinstePensjonsniva? = null
     var mpn67ProRata: JustertMinstePensjonsniva? = null

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2016.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2016.kt
@@ -1,7 +1,7 @@
 package no.nav.pensjon.simulator.core.domain.regler.vedtak
 
+// 2026-06-04
 class VilkarsprovInformasjon2016 : VilkarsprovInformasjon() {
-
     var vektetPensjonsniva = 0.0
     var vektetPensjonsnivaProRata = 0.0
     var vilkarsprovInformasjon2011: VilkarsprovInformasjon2011? = null

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2016.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2016.kt
@@ -1,6 +1,6 @@
 package no.nav.pensjon.simulator.core.domain.regler.vedtak
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class VilkarsprovInformasjon2016 : VilkarsprovInformasjon() {
     var vektetPensjonsniva = 0.0
     var vektetPensjonsnivaProRata = 0.0

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2025.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2025.kt
@@ -3,9 +3,9 @@ package no.nav.pensjon.simulator.core.domain.regler.vedtak
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Beholdninger
 
+// 2026-06-04
 class VilkarsprovInformasjon2025 : VilkarsprovInformasjon() {
-
-    var garPN67: JustertGarantipensjonsniva? = null
-    var garPN67ProRata: JustertGarantipensjonsniva? = null
-    var beholdningerVed67: Beholdninger? = null
+    var garPNvedNormertPensjonsalder: JustertGarantipensjonsniva? = null
+    var garPNvedNormertPensjonsalderProRata: JustertGarantipensjonsniva? = null
+    var beholdningerVedNormertPensjonsalder: Beholdninger? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2025.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovInformasjon2025.kt
@@ -3,7 +3,7 @@ package no.nav.pensjon.simulator.core.domain.regler.vedtak
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.*
 import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Beholdninger
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class VilkarsprovInformasjon2025 : VilkarsprovInformasjon() {
     var garPNvedNormertPensjonsalder: JustertGarantipensjonsniva? = null
     var garPNvedNormertPensjonsalderProRata: JustertGarantipensjonsniva? = null

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovUforetrygdResultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovUforetrygdResultat.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.domain.regler.vedtak
 
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsresultatUforetrygd
 
-// 2026-06-04
+// Copied from pensjon-regler-api v2.0.0 2026-06-04
 class VilkarsprovUforetrygdResultat : AbstraktVilkarsprovResultat() {
     /**
      * Beregning av uføretrygden ved vilkårsprøving av halv minsteytelse.

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovUforetrygdResultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/vedtak/VilkarsprovUforetrygdResultat.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.simulator.core.domain.regler.vedtak
 
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.BeregningsresultatUforetrygd
 
-// Copied from pensjon-regler-api 2026-03-05
+// 2026-06-04
 class VilkarsprovUforetrygdResultat : AbstraktVilkarsprovResultat() {
     /**
      * Beregning av uføretrygden ved vilkårsprøving av halv minsteytelse.

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/reglerextend/beregning2011/Beregning2011Extension.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/reglerextend/beregning2011/Beregning2011Extension.kt
@@ -76,13 +76,13 @@ fun AvkortingsinformasjonUT.copy() =
     AvkortingsinformasjonUT().also {
         it.oifu = this.oifu
         it.oieu = this.oieu
-        it.belopsgrense = this.belopsgrense
-        it.inntektsgrense = this.inntektsgrense
+        it.fribeløp = this.fribeløp
+        it.bunnfradrag = this.bunnfradrag
         it.ugradertBruttoPerAr = this.ugradertBruttoPerAr
-        it.kompensasjonsgrad = this.kompensasjonsgrad
+        it.reduksjonsprosent = this.reduksjonsprosent
         it.utbetalingsgrad = this.utbetalingsgrad
         it.forventetInntekt = this.forventetInntekt
-        it.inntektsgrenseNesteAr = this.inntektsgrenseNesteAr
+        it.bunnfradragNesteAr = this.bunnfradragNesteAr
         it.inntektstakNesteAr = this.inntektstakNesteAr
         it.differansebelop = this.differansebelop
         it.oifuForBarnetillegg = this.oifuForBarnetillegg

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/reglerextend/beregning2011/Beregning2011Extension.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/reglerextend/beregning2011/Beregning2011Extension.kt
@@ -138,9 +138,9 @@ fun BeregningsgrunnlagYrkesskade.copy() =
 fun BeregningsInformasjon.copy() =
     BeregningsInformasjon().also {
         it.forholdstallUttak = this.forholdstallUttak
-        it.forholdstall67 = this.forholdstall67
+        it.forholdstallVedNormertPensjonsalder = this.forholdstallVedNormertPensjonsalder
         it.delingstallUttak = this.delingstallUttak
-        it.delingstall67 = this.delingstall67
+        it.delingstallVedNormertPensjonsalder = this.delingstallVedNormertPensjonsalder
         it.spt = this.spt?.let(::Sluttpoengtall)
         it.opt = this.opt?.let(::Sluttpoengtall)
         it.ypt = this.ypt?.let(::Sluttpoengtall)
@@ -174,8 +174,6 @@ fun BeregningsInformasjon.copy() =
         //--- Extra:
         it.epsMottarPensjon = this.epsMottarPensjon
         it.epsOver2G = this.epsOver2G
-        it.unclearedDelingstallUttak = this.unclearedDelingstallUttak
-        it.unclearedDelingstall67 = this.unclearedDelingstall67
     }
 
 fun BeregningsResultatAfpPrivat.copy() =

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/exception/KanIkkeBeregnesException.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/exception/KanIkkeBeregnesException.kt
@@ -1,9 +1,4 @@
 package no.nav.pensjon.simulator.core.exception
 
-import no.nav.pensjon.simulator.core.domain.regler.Merknad
-
 @Deprecated("Never thrown")
-class KanIkkeBeregnesException(
-    message: String,
-    //val merknadListe: List<Merknad> = mutableListOf()
-) : RuntimeException(message)
+class KanIkkeBeregnesException : RuntimeException()

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/exception/KanIkkeBeregnesException.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/exception/KanIkkeBeregnesException.kt
@@ -2,7 +2,8 @@ package no.nav.pensjon.simulator.core.exception
 
 import no.nav.pensjon.simulator.core.domain.regler.Merknad
 
+@Deprecated("Never thrown")
 class KanIkkeBeregnesException(
     message: String,
-    val merknadListe: List<Merknad> = mutableListOf()
+    //val merknadListe: List<Merknad> = mutableListOf()
 ) : RuntimeException(message)

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/SimulatorContextTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/SimulatorContextTest.kt
@@ -21,7 +21,6 @@ import no.nav.pensjon.simulator.core.domain.regler.vedtak.VilkarsVedtak
 import no.nav.pensjon.simulator.core.exception.RegelmotorValideringException
 import no.nav.pensjon.simulator.regel.client.GenericRegelClient
 import org.springframework.cache.caffeine.CaffeineCacheManager
-import tools.jackson.databind.json.JsonMapper
 import java.time.LocalDate
 
 class SimulatorContextTest : ShouldSpec({
@@ -453,8 +452,6 @@ class SimulatorContextTest : ShouldSpec({
 
 private val dato: LocalDate = LocalDate.of(2030, 1, 1)
 
-private val objectMapper = JsonMapper()
-
 private inline fun <K, reified T : Any> arrangeRegler(response: K): GenericRegelClient =
     mockk<GenericRegelClient>().apply {
         every {
@@ -488,6 +485,5 @@ private fun vilkarsproevingsresultat(vedtak: VilkarsVedtak) =
 private fun simulatorContext(regelmotor: GenericRegelClient) =
     SimulatorContext(
         regelService = regelmotor,
-        objectMapper = objectMapper,
         cacheManager = CaffeineCacheManager()
     )

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/SimulatorContextUtilTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/SimulatorContextUtilTest.kt
@@ -21,7 +21,6 @@ import no.nav.pensjon.simulator.core.domain.regler.grunnlag.Uttaksgrad
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.core.domain.regler.to.*
 import no.nav.pensjon.simulator.core.exception.RegelmotorValideringException
-import tools.jackson.databind.ObjectMapper
 import java.time.LocalDate
 
 class SimulatorContextUtilTest : FunSpec({
@@ -53,7 +52,6 @@ class SimulatorContextUtilTest : FunSpec({
             result = response,
             kravGjelderUfoeretrygd = false,
             spec = "",
-            objectMapper = ObjectMapper(),
             call = ""
         )
 
@@ -78,7 +76,6 @@ class SimulatorContextUtilTest : FunSpec({
             result = response,
             kravGjelderUfoeretrygd = true,
             spec = "",
-            objectMapper = ObjectMapper(),
             call = ""
         )
 
@@ -226,7 +223,6 @@ class SimulatorContextUtilTest : FunSpec({
         SimulatorContextUtil.validerResponse(
             pakkseddel = pakkseddel,
             spec = "test-spec",
-            objectMapper = ObjectMapper(),
             call = "testCall"
         )
         // Ingen unntak kastet
@@ -241,7 +237,6 @@ class SimulatorContextUtilTest : FunSpec({
             SimulatorContextUtil.validerResponse(
                 pakkseddel = pakkseddel,
                 spec = "test-spec",
-                objectMapper = ObjectMapper(),
                 call = "testCall"
             )
         }
@@ -268,7 +263,6 @@ class SimulatorContextUtilTest : FunSpec({
             SimulatorContextUtil.validerResponse(
                 pakkseddel = pakkseddel,
                 spec = request,
-                objectMapper = ObjectMapper(),
                 call = "RevurderingAlderspensjon2025"
             )
         }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/domain/regler/PakkseddelTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/domain/regler/PakkseddelTest.kt
@@ -24,10 +24,7 @@ class PakkseddelTest : ShouldSpec({
 
     context("kontrollTjenesteOk, annenTjenesteOk when no merknad") {
         should("be true") {
-            with(pakkseddel(merknadListe = emptyList())) {
-                kontrollTjenesteOk shouldBe true
-                annenTjenesteOk shouldBe true
-            }
+            pakkseddel(merknadListe = emptyList()).kontrollTjenesteOk shouldBe true
         }
     }
 
@@ -42,10 +39,7 @@ class PakkseddelTest : ShouldSpec({
                 )
             )
 
-            with(result) {
-                kontrollTjenesteOk shouldBe false
-                annenTjenesteOk shouldBe false
-            }
+            result.kontrollTjenesteOk shouldBe false
         }
     }
 })

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/domain/regler/PakkseddelTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/domain/regler/PakkseddelTest.kt
@@ -22,24 +22,22 @@ class PakkseddelTest : ShouldSpec({
         }
     }
 
-    context("kontrollTjenesteOk, annenTjenesteOk when no merknad") {
+    context("kontrollTjenesteOk when no merknad") {
         should("be true") {
             pakkseddel(merknadListe = emptyList()).kontrollTjenesteOk shouldBe true
         }
     }
 
-    context("kontrollTjenesteOk, annenTjenesteOk when merknad") {
+    context("kontrollTjenesteOk when merknad") {
         should("be false") {
-            val result = pakkseddel(
+            pakkseddel(
                 merknadListe = listOf(
                     Merknad().apply {
                         kode = null
                         argumentListe = emptyList()
                     }
                 )
-            )
-
-            result.kontrollTjenesteOk shouldBe false
+            ).kontrollTjenesteOk shouldBe false
         }
     }
 })

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutputMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/result/SimulatorOutputMapperTest.kt
@@ -543,20 +543,21 @@ class SimulatorOutputMapperTest : FunSpec({
                 brutto = 23333
             }
         }
-        val simulertAlderspensjon = SimulertAlderspensjon()
 
         val result = SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
             kravhode = kravhode,
             beregningResultat = beregningsResultat,
-            simulertAlderspensjon = simulertAlderspensjon,
+            simulertAlderspensjon = SimulertAlderspensjon(),
             foedselsdato = LocalDate.of(1970, 6, 15),
             knekkpunkt = LocalDate.of(2037, 7, 1)
         )
 
-        result.inntektspensjon shouldBe 280000
-        result.inntektspensjonPerMaaned shouldBe 23333
-        result.aarligBeloep shouldBe 400000
-        result.maanedligBeloep shouldBe 33333
+        with(result) {
+            inntektspensjon shouldBe 280000
+            inntektspensjonPerMaaned shouldBe 23333
+            aarligBeloep shouldBe 400000
+            maanedligBeloep shouldBe 33333
+        }
     }
 
     test("mapToSimulertBeregningsinformasjon should map garantipensjon") {
@@ -569,18 +570,19 @@ class SimulatorOutputMapperTest : FunSpec({
                 brutto = 10000
             }
         }
-        val simulertAlderspensjon = SimulertAlderspensjon()
 
         val result = SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
             kravhode = kravhode,
             beregningResultat = beregningsResultat,
-            simulertAlderspensjon = simulertAlderspensjon,
+            simulertAlderspensjon = SimulertAlderspensjon(),
             foedselsdato = LocalDate.of(1970, 6, 15),
             knekkpunkt = LocalDate.of(2037, 7, 1)
         )
 
-        result.garantipensjon shouldBe 120000
-        result.garantipensjonPerMaaned shouldBe 10000
+        with(result) {
+            garantipensjon shouldBe 120000
+            garantipensjonPerMaaned shouldBe 10000
+        }
     }
 
     test("mapToSimulertBeregningsinformasjon should map garantitillegg") {
@@ -592,17 +594,14 @@ class SimulatorOutputMapperTest : FunSpec({
                 bruttoPerAr = 15000.0
             }
         }
-        val simulertAlderspensjon = SimulertAlderspensjon()
 
-        val result = SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
+        SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
             kravhode = kravhode,
             beregningResultat = beregningsResultat,
-            simulertAlderspensjon = simulertAlderspensjon,
+            simulertAlderspensjon = SimulertAlderspensjon(),
             foedselsdato = LocalDate.of(1970, 6, 15),
             knekkpunkt = LocalDate.of(2037, 7, 1)
-        )
-
-        result.garantitillegg shouldBe 15000
+        ).garantitillegg shouldBe 15000
     }
 
     test("mapToSimulertBeregningsinformasjon should map grunnpensjon") {
@@ -616,19 +615,20 @@ class SimulatorOutputMapperTest : FunSpec({
                 pSats_gp = 1.0
             }
         }
-        val simulertAlderspensjon = SimulertAlderspensjon()
 
         val result = SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
             kravhode = kravhode,
             beregningResultat = beregningsResultat,
-            simulertAlderspensjon = simulertAlderspensjon,
+            simulertAlderspensjon = SimulertAlderspensjon(),
             foedselsdato = LocalDate.of(1960, 6, 15),
             knekkpunkt = LocalDate.of(2025, 7, 1)
         )
 
-        result.grunnpensjon shouldBe 118620
-        result.grunnpensjonPerMaaned shouldBe 9885
-        result.grunnpensjonsats shouldBe 1.0
+        with(result) {
+            grunnpensjon shouldBe 118620
+            grunnpensjonPerMaaned shouldBe 9885
+            grunnpensjonsats shouldBe 1.0
+        }
     }
 
     test("mapToSimulertBeregningsinformasjon should map tilleggspensjon") {
@@ -641,18 +641,19 @@ class SimulatorOutputMapperTest : FunSpec({
                 brutto = 15000
             }
         }
-        val simulertAlderspensjon = SimulertAlderspensjon()
 
         val result = SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
             kravhode = kravhode,
             beregningResultat = beregningsResultat,
-            simulertAlderspensjon = simulertAlderspensjon,
+            simulertAlderspensjon = SimulertAlderspensjon(),
             foedselsdato = LocalDate.of(1960, 6, 15),
             knekkpunkt = LocalDate.of(2025, 7, 1)
         )
 
-        result.tilleggspensjon shouldBe 180000
-        result.tilleggspensjonPerMaaned shouldBe 15000
+        with(result) {
+            tilleggspensjon shouldBe 180000
+            tilleggspensjonPerMaaned shouldBe 15000
+        }
     }
 
     test("mapToSimulertBeregningsinformasjon should map pensjonstillegg") {
@@ -660,25 +661,25 @@ class SimulatorOutputMapperTest : FunSpec({
         val beregningsResultat = createBeregningsResultatAlderspensjon2011()
         beregningsResultat.pensjonUnderUtbetaling = PensjonUnderUtbetaling().apply {
             pensjonstillegg = Pensjonstillegg().apply {
-                ytelsekomponentTypeEnum = YtelseskomponentTypeEnum.PT
                 bruttoPerAr = 50000.0
                 brutto = 4166
                 minstepensjonsnivaSats = 2.48
             }
         }
-        val simulertAlderspensjon = SimulertAlderspensjon()
 
         val result = SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
             kravhode = kravhode,
             beregningResultat = beregningsResultat,
-            simulertAlderspensjon = simulertAlderspensjon,
+            simulertAlderspensjon = SimulertAlderspensjon(),
             foedselsdato = LocalDate.of(1960, 6, 15),
             knekkpunkt = LocalDate.of(2025, 7, 1)
         )
 
-        result.pensjonstillegg shouldBe 50000
-        result.pensjonstilleggPerMaaned shouldBe 4166
-        result.minstePensjonsnivaSats shouldBe 2.48
+        with(result) {
+            pensjonstillegg shouldBe 50000
+            pensjonstilleggPerMaaned shouldBe 4166
+            minstePensjonsnivaSats shouldBe 2.48
+        }
     }
 
     test("mapToSimulertBeregningsinformasjon should map skjermingstillegg") {
@@ -691,18 +692,19 @@ class SimulatorOutputMapperTest : FunSpec({
                 ufg = 50
             }
         }
-        val simulertAlderspensjon = SimulertAlderspensjon()
 
         val result = SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
             kravhode = kravhode,
             beregningResultat = beregningsResultat,
-            simulertAlderspensjon = simulertAlderspensjon,
+            simulertAlderspensjon = SimulertAlderspensjon(),
             foedselsdato = LocalDate.of(1960, 6, 15),
             knekkpunkt = LocalDate.of(2025, 7, 1)
         )
 
-        result.skjermingstillegg shouldBe 20000
-        result.ufoereGrad shouldBe 50
+        with(result) {
+            skjermingstillegg shouldBe 20000
+            ufoereGrad shouldBe 50
+        }
     }
 
     test("mapToSimulertBeregningsinformasjon should map minstenivaatillegg") {
@@ -718,18 +720,19 @@ class SimulatorOutputMapperTest : FunSpec({
                 bruttoPerAr = 8000.0
             }
         }
-        val simulertAlderspensjon = SimulertAlderspensjon()
 
         val result = SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
             kravhode = kravhode,
             beregningResultat = beregningsResultat,
-            simulertAlderspensjon = simulertAlderspensjon,
+            simulertAlderspensjon = SimulertAlderspensjon(),
             foedselsdato = LocalDate.of(1960, 6, 15),
             knekkpunkt = LocalDate.of(2025, 7, 1)
         )
 
-        result.individueltMinstenivaaTillegg shouldBe 12000
-        result.pensjonistParMinstenivaaTillegg shouldBe 8000
+        with(result) {
+            individueltMinstenivaaTillegg shouldBe 12000
+            pensjonistParMinstenivaaTillegg shouldBe 8000
+        }
     }
 
     // =====================================================
@@ -739,13 +742,12 @@ class SimulatorOutputMapperTest : FunSpec({
     test("mapToSimulertBeregningsinformasjon should calculate startMaaned correctly") {
         val kravhode = createKravhode(RegelverkTypeEnum.N_REG_G_OPPTJ)
         val beregningsResultat = createBeregningsResultatAlderspensjon2011()
-        val simulertAlderspensjon = SimulertAlderspensjon()
 
         // Born June 15, knekkpunkt July 1 = 1 month after birth month
         val result = SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
             kravhode = kravhode,
             beregningResultat = beregningsResultat,
-            simulertAlderspensjon = simulertAlderspensjon,
+            simulertAlderspensjon = SimulertAlderspensjon(),
             foedselsdato = LocalDate.of(1960, 6, 15),
             knekkpunkt = LocalDate.of(2025, 7, 1)
         )
@@ -756,13 +758,12 @@ class SimulatorOutputMapperTest : FunSpec({
     test("mapToSimulertBeregningsinformasjon should return 12 for startMaaned when knekkpunkt is in birth month") {
         val kravhode = createKravhode(RegelverkTypeEnum.N_REG_G_OPPTJ)
         val beregningsResultat = createBeregningsResultatAlderspensjon2011()
-        val simulertAlderspensjon = SimulertAlderspensjon()
 
         // Born June 15, knekkpunkt June 1 = 0 months, should return 12
         val result = SimulatorOutputMapper.mapToSimulertBeregningsinformasjon(
             kravhode = kravhode,
             beregningResultat = beregningsResultat,
-            simulertAlderspensjon = simulertAlderspensjon,
+            simulertAlderspensjon = SimulertAlderspensjon(),
             foedselsdato = LocalDate.of(1960, 6, 15),
             knekkpunkt = LocalDate.of(2025, 6, 1)
         )

--- a/src/test/kotlin/no/nav/pensjon/simulator/orch/AlderspensjonOgPrivatAfpServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/orch/AlderspensjonOgPrivatAfpServiceTest.kt
@@ -137,11 +137,6 @@ class AlderspensjonOgPrivatAfpServiceTest : ShouldSpec({
                 .simuler(validSpec) shouldBe errorResult(ProblemType.ANNEN_KLIENTFEIL, "ugyldig enum")
         }
 
-        should("return ANNEN_KLIENTFEIL problem on KanIkkeBeregnesException") {
-            badService(simulatorException = KanIkkeBeregnesException("kan ikke beregnes"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.ANNEN_KLIENTFEIL, "kan ikke beregnes")
-        }
-
         should("return INTERN_DATA_INKONSISTENS problem on KonsistensenIGrunnlagetErFeilException") {
             val result = badService(
                 simulatorException = KonsistensenIGrunnlagetErFeilException(RuntimeException("inkonsistent"))


### PR DESCRIPTION
Oppdatert klasser kopiert fra `pensjon-regler-api` i.h.t. deres [versjon 2.0.0](https://github.com/navikt/pensjon-regler-api/releases/tag/v2.0.0).

I tillegg:

- Fjernet `objectMapper` i `SimulatorContext` (den har bare blitt brukt for debugging)
- Deprekert `KanIkkeBeregnesException` (den kastes ikke lenger)
- Litt refaktorering i `SimulatorOutputMapperTest` 