### PR TITLE
Update e2e test responses for new satstabell

### DIFF
--- a/end-to-end-test/src/main/resources/afp-etterfulgt-av-alder-response.json
+++ b/end-to-end-test/src/main/resources/afp-etterfulgt-av-alder-response.json
@@ -3,27 +3,27 @@
   "aarsakListeIkkeSuksess": [],
   "folketrygdberegnetAfp": {
     "fraOgMedDato": "2028-01-01",
-    "beregnetTidligereInntekt": 905000,
+    "beregnetTidligereInntekt": 950000,
     "sisteLignetInntektBrukt": false,
     "sisteLignetInntektAar": null,
-    "afpGrad": 84,
+    "afpGrad": 85,
     "afpAvkortetTil70Prosent": false,
     "grunnpensjon": {
-      "maanedligUtbetaling": 9111,
-      "grunnbeloep": 130160,
+      "maanedligUtbetaling": 9672,
+      "grunnbeloep": 136549,
       "grunnpensjonsats": 1.0,
       "trygdetid": 40
     },
     "tilleggspensjon": {
-      "maanedligUtbetaling": 22593,
-      "grunnbeloep": 130160,
+      "maanedligUtbetaling": 23984,
+      "grunnbeloep": 136549,
       "sluttpoengTall": 5.76,
       "antallPoengaarTilOgMed1991": 14,
       "antallPoengaarFraOgMed1992": 26
     },
     "saertillegg": null,
-    "maanedligAfpTillegg": 1428,
-    "sumMaanedligUtbetaling": 33132
+    "maanedligAfpTillegg": 1445,
+    "sumMaanedligUtbetaling": 35101
   },
   "alderspensjonFraFolketrygden": [
     {
@@ -31,36 +31,36 @@
       "andelKapittel19": 0.2,
       "alderspensjonKapittel19": {
         "grunnpensjon": {
-          "maanedligUtbetaling": 1946,
-          "grunnbeloep": 130160,
+          "maanedligUtbetaling": 2041,
+          "grunnbeloep": 136549,
           "grunnpensjonsats": 1.0,
           "trygdetid": 40
         },
         "tilleggspensjon": {
-          "maanedligUtbetaling": 4824,
-          "grunnbeloep": 130160,
+          "maanedligUtbetaling": 5061,
+          "grunnbeloep": 136549,
           "sluttpoengTall": 5.76,
           "antallPoengaarTilOgMed1991": 14,
           "antallPoengaarFraOgMed1992": 26
         },
         "pensjonstillegg": {
           "maanedligUtbetaling": 0,
-          "minstepensjonsnivaaSats": 279933.0
+          "minstepensjonsnivaaSats": 293062.0
         }
       },
       "andelKapittel20": 0.8,
       "alderspensjonKapittel20": {
         "inntektspensjon": {
-          "maanedligUtbetaling": 32983,
-          "pensjonsbeholdningForUttak": 7920817
+          "maanedligUtbetaling": 34588,
+          "pensjonsbeholdningForUttak": 8306213
         },
         "garantipensjon": {
           "maanedligUtbetaling": 0,
-          "garantipensjonsbeholdningForUttak": -2455541,
+          "garantipensjonsbeholdningForUttak": -2581840,
           "trygdetid": 40
         }
       },
-      "sumMaanedligUtbetaling": 39753
+      "sumMaanedligUtbetaling": 41690
     },
     {
       "fraOgMedDato": "2029-01-01",
@@ -68,7 +68,7 @@
       "alderspensjonKapittel19": null,
       "andelKapittel20": 0.8,
       "alderspensjonKapittel20": null,
-      "sumMaanedligUtbetaling": 40225
+      "sumMaanedligUtbetaling": 42162
     }
   ]
 }

--- a/end-to-end-test/src/main/resources/simuler-alderspensjon-v3-response.json
+++ b/end-to-end-test/src/main/resources/simuler-alderspensjon-v3-response.json
@@ -1,28 +1,368 @@
 {
-  "afpPrivatBeholdningVedUttak": 98252,
+  "pensjonsperioder": [
+    {
+      "arligUtbetaling": 59910,
+      "datoFom": "2028-11-01"
+    },
+    {
+      "arligUtbetaling": 71892,
+      "datoFom": "2029-11-01"
+    },
+    {
+      "arligUtbetaling": 388932,
+      "datoFom": "2030-11-01"
+    },
+    {
+      "arligUtbetaling": 391182,
+      "datoFom": "2031-11-01"
+    },
+    {
+      "arligUtbetaling": 393560,
+      "datoFom": "2032-11-01"
+    },
+    {
+      "arligUtbetaling": 396090,
+      "datoFom": "2033-11-01"
+    },
+    {
+      "arligUtbetaling": 398786,
+      "datoFom": "2034-11-01"
+    },
+    {
+      "arligUtbetaling": 401660,
+      "datoFom": "2035-11-01"
+    },
+    {
+      "arligUtbetaling": 404744,
+      "datoFom": "2036-11-01"
+    },
+    {
+      "arligUtbetaling": 408034,
+      "datoFom": "2037-11-01"
+    },
+    {
+      "arligUtbetaling": 411358,
+      "datoFom": "2038-11-01"
+    },
+    {
+      "arligUtbetaling": 411912,
+      "datoFom": "2039-11-01"
+    }
+  ],
+  "simuleringsdataListe": [
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 0.0,
+      "delingstallUttak": 0.0,
+      "datoFom": "2029-11-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 0.0,
+      "delingstallUttak": 0.0,
+      "datoFom": "2030-01-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 1.063,
+      "delingstallUttak": 15.28,
+      "datoFom": "2030-11-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 1.054,
+      "delingstallUttak": 15.14,
+      "datoFom": "2031-01-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 0.998,
+      "delingstallUttak": 14.34,
+      "datoFom": "2032-01-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 0.943,
+      "delingstallUttak": 13.55,
+      "datoFom": "2033-01-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 0.888,
+      "delingstallUttak": 12.76,
+      "datoFom": "2034-01-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 0.834,
+      "delingstallUttak": 11.98,
+      "datoFom": "2035-01-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 0.78,
+      "delingstallUttak": 11.2,
+      "datoFom": "2036-01-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 0.727,
+      "delingstallUttak": 10.44,
+      "datoFom": "2037-01-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 0.683,
+      "delingstallUttak": 9.81,
+      "datoFom": "2038-01-01"
+    },
+    {
+      "poengArTom1991": 12,
+      "poengArFom1992": 28,
+      "sluttpoengtall": 4.46,
+      "anvendtTrygdetid": 40,
+      "basisgp": 122894.1,
+      "basistp": 261264.66365999996,
+      "basispt": -149693.57465999993,
+      "forholdstallUttak": 0.683,
+      "delingstallUttak": 9.81,
+      "datoFom": "2039-01-01"
+    }
+  ],
+  "pensjonsbeholdningsperioder": [
+    {
+      "pensjonsbeholdning": 6076709.43496694,
+      "garantipensjonsbeholdning": -1086346.347973553,
+      "datoFom": "2029-01-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6076709.43496694,
+      "garantipensjonsbeholdning": -1086346.347973553,
+      "garantitilleggsbeholdning": -1816969.8990202737,
+      "datoFom": "2029-11-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6076709.43496694,
+      "garantipensjonsbeholdning": -1086346.347973553,
+      "garantitilleggsbeholdning": -1816969.8990202737,
+      "datoFom": "2030-11-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6112909.43496694,
+      "garantipensjonsbeholdning": -1115306.347973553,
+      "garantitilleggsbeholdning": -1849549.899020274,
+      "datoFom": "2031-01-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6149109.253966941,
+      "garantipensjonsbeholdning": -1144266.203173553,
+      "garantitilleggsbeholdning": -1882129.7361202745,
+      "datoFom": "2032-01-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6185309.253966941,
+      "garantipensjonsbeholdning": -1173226.203173553,
+      "garantitilleggsbeholdning": -1914709.7361202738,
+      "datoFom": "2033-01-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6221509.253966941,
+      "garantipensjonsbeholdning": -1202186.203173553,
+      "garantitilleggsbeholdning": -1947289.736120274,
+      "datoFom": "2034-01-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6257709.253966941,
+      "garantipensjonsbeholdning": -1231146.203173553,
+      "garantitilleggsbeholdning": -1979869.7361202743,
+      "datoFom": "2035-01-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6293909.253966941,
+      "garantipensjonsbeholdning": -1260106.203173553,
+      "garantitilleggsbeholdning": -2012449.7361202745,
+      "datoFom": "2036-01-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6330109.253966941,
+      "garantipensjonsbeholdning": -1289066.203173553,
+      "garantitilleggsbeholdning": -2045029.7361202748,
+      "datoFom": "2037-01-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6366309.253966941,
+      "garantipensjonsbeholdning": -1318026.203173553,
+      "garantitilleggsbeholdning": -2077609.736120274,
+      "datoFom": "2038-01-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    },
+    {
+      "pensjonsbeholdning": 6402509.253966941,
+      "garantipensjonsbeholdning": -1346986.203173553,
+      "garantitilleggsbeholdning": -2110189.7361202743,
+      "datoFom": "2039-01-01",
+      "garantipensjonsniva": {
+        "belop": 234765.0,
+        "satsType": "ORDINAER",
+        "sats": 234765.0,
+        "tt_anv": 40
+      }
+    }
+  ],
   "alderspensjonFraFolketrygden": [
     {
       "datoFom": "2029-01-01",
       "delytelser": [
         {
-          "belop": 2009,
-          "pensjonstype": "GP"
+          "pensjonstype": "GP",
+          "belop": 2107
         },
         {
-          "belop": 4271,
-          "pensjonstype": "TP"
+          "pensjonstype": "TP",
+          "belop": 4481
         },
         {
-          "belop": -2439,
-          "pensjonstype": "PT"
+          "pensjonstype": "PT",
+          "belop": -2567
         },
         {
-          "belop": 62245,
-          "pensjonstype": "IP"
+          "pensjonstype": "IP",
+          "belop": 65301
         },
         {
-          "belop": -11046,
-          "pensjonstype": "GAP"
+          "pensjonstype": "GAP",
+          "belop": -11674
         }
       ],
       "uttaksgrad": 20
@@ -31,375 +371,35 @@
       "datoFom": "2030-11-01",
       "delytelser": [
         {
-          "belop": 10825,
-          "pensjonstype": "GP"
+          "pensjonstype": "GP",
+          "belop": 11356
         },
         {
-          "belop": 23014,
-          "pensjonstype": "TP"
+          "pensjonstype": "TP",
+          "belop": 24143
         },
         {
-          "belop": -13143,
-          "pensjonstype": "PT"
+          "pensjonstype": "PT",
+          "belop": -13833
         },
         {
-          "belop": -230568,
-          "pensjonstype": "MIN_NIVA_TILL_INDV"
+          "pensjonstype": "MIN_NIVA_TILL_INDV",
+          "belop": -242419
         },
         {
-          "belop": 335181,
-          "pensjonstype": "IP"
+          "pensjonstype": "IP",
+          "belop": 351639
         },
         {
-          "belop": -59483,
-          "pensjonstype": "GAP"
+          "pensjonstype": "GAP",
+          "belop": -62863
         }
       ],
       "uttaksgrad": 100
     }
   ],
-  "harTidligereUttak": false,
   "harUttak": false,
-  "pensjonsbeholdningsperioder": [
-    {
-      "datoFom": "2029-01-01",
-      "garantipensjonsbeholdning": -1027937.8829754586,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "pensjonsbeholdning": 5792307.153719322
-    },
-    {
-      "datoFom": "2029-11-01",
-      "garantipensjonsbeholdning": -1027937.8829754586,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -1731884.7196728606,
-      "pensjonsbeholdning": 5792307.153719322
-    },
-    {
-      "datoFom": "2030-11-01",
-      "garantipensjonsbeholdning": -1027937.8829754586,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -1731884.7196728606,
-      "pensjonsbeholdning": 5792307.153719322
-    },
-    {
-      "datoFom": "2031-01-01",
-      "garantipensjonsbeholdning": -1056897.8829754586,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -1764464.7196728599,
-      "pensjonsbeholdning": 5828507.153719322
-    },
-    {
-      "datoFom": "2032-01-01",
-      "garantipensjonsbeholdning": -1085857.7381754587,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -1797044.5567728605,
-      "pensjonsbeholdning": 5864706.972719322
-    },
-    {
-      "datoFom": "2033-01-01",
-      "garantipensjonsbeholdning": -1114817.7381754587,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -1829624.5567728598,
-      "pensjonsbeholdning": 5900906.972719322
-    },
-    {
-      "datoFom": "2034-01-01",
-      "garantipensjonsbeholdning": -1143777.7381754587,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -1862204.55677286,
-      "pensjonsbeholdning": 5937106.972719322
-    },
-    {
-      "datoFom": "2035-01-01",
-      "garantipensjonsbeholdning": -1172737.7381754587,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -1894784.5567728602,
-      "pensjonsbeholdning": 5973306.972719322
-    },
-    {
-      "datoFom": "2036-01-01",
-      "garantipensjonsbeholdning": -1201697.7381754587,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -1927364.5567728605,
-      "pensjonsbeholdning": 6009506.972719322
-    },
-    {
-      "datoFom": "2037-01-01",
-      "garantipensjonsbeholdning": -1230657.7381754587,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -1959944.5567728598,
-      "pensjonsbeholdning": 6045706.972719322
-    },
-    {
-      "datoFom": "2038-01-01",
-      "garantipensjonsbeholdning": -1259617.7381754587,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -1992524.55677286,
-      "pensjonsbeholdning": 6081906.972719322
-    },
-    {
-      "datoFom": "2039-01-01",
-      "garantipensjonsbeholdning": -1288577.7381754587,
-      "garantipensjonsniva": {
-        "belop": 224248.0,
-        "sats": 224248.0,
-        "satsType": "ORDINAER",
-        "tt_anv": 40
-      },
-      "garantitilleggsbeholdning": -2025104.5567728602,
-      "pensjonsbeholdning": 6118106.972719322
-    }
-  ],
-  "pensjonsperioder": [
-    {
-      "arligUtbetaling": 57100,
-      "datoFom": "2028-11-01"
-    },
-    {
-      "arligUtbetaling": 68520,
-      "datoFom": "2029-11-01"
-    },
-    {
-      "arligUtbetaling": 370814,
-      "datoFom": "2030-11-01"
-    },
-    {
-      "arligUtbetaling": 373062,
-      "datoFom": "2031-11-01"
-    },
-    {
-      "arligUtbetaling": 375450,
-      "datoFom": "2032-11-01"
-    },
-    {
-      "arligUtbetaling": 377982,
-      "datoFom": "2033-11-01"
-    },
-    {
-      "arligUtbetaling": 380668,
-      "datoFom": "2034-11-01"
-    },
-    {
-      "arligUtbetaling": 383550,
-      "datoFom": "2035-11-01"
-    },
-    {
-      "arligUtbetaling": 386636,
-      "datoFom": "2036-11-01"
-    },
-    {
-      "arligUtbetaling": 389916,
-      "datoFom": "2037-11-01"
-    },
-    {
-      "arligUtbetaling": 393238,
-      "datoFom": "2038-11-01"
-    },
-    {
-      "arligUtbetaling": 393792,
-      "datoFom": "2039-11-01"
-    }
-  ],
-  "simuleringsdataListe": [
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2029-11-01",
-      "delingstallUttak": 0.0,
-      "forholdstallUttak": 0.0,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2030-01-01",
-      "delingstallUttak": 0.0,
-      "forholdstallUttak": 0.0,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2030-11-01",
-      "delingstallUttak": 15.28,
-      "forholdstallUttak": 1.063,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2031-01-01",
-      "delingstallUttak": 15.14,
-      "forholdstallUttak": 1.054,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2032-01-01",
-      "delingstallUttak": 14.34,
-      "forholdstallUttak": 0.998,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2033-01-01",
-      "delingstallUttak": 13.55,
-      "forholdstallUttak": 0.943,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2034-01-01",
-      "delingstallUttak": 12.76,
-      "forholdstallUttak": 0.888,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2035-01-01",
-      "delingstallUttak": 11.98,
-      "forholdstallUttak": 0.834,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2036-01-01",
-      "delingstallUttak": 11.2,
-      "forholdstallUttak": 0.78,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2037-01-01",
-      "delingstallUttak": 10.44,
-      "forholdstallUttak": 0.727,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2038-01-01",
-      "delingstallUttak": 9.81,
-      "forholdstallUttak": 0.683,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    },
-    {
-      "anvendtTrygdetid": 40,
-      "basisgp": 117144.0,
-      "basispt": -142223.1984,
-      "basistp": 249040.3344,
-      "datoFom": "2039-01-01",
-      "delingstallUttak": 9.81,
-      "forholdstallUttak": 0.683,
-      "poengArFom1992": 28,
-      "poengArTom1991": 12,
-      "sluttpoengtall": 4.46
-    }
-  ],
+  "harTidligereUttak": false,
+  "afpPrivatBeholdningVedUttak": 103076,
   "sisteGyldigeOpptjeningsAr": 2024
 }

--- a/end-to-end-test/src/main/resources/simuler-alderspensjon-v4-response.json
+++ b/end-to-end-test/src/main/resources/simuler-alderspensjon-v4-response.json
@@ -7,11 +7,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 46393
+          "belop": 48691
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 2889
+          "belop": 2926
         }
       ],
       "uttaksgrad": 20
@@ -21,11 +21,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 46393
+          "belop": 48691
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 2889
+          "belop": 2926
         }
       ],
       "uttaksgrad": 20
@@ -35,11 +35,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 46393
+          "belop": 48691
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 2889
+          "belop": 2926
         }
       ],
       "uttaksgrad": 20
@@ -49,11 +49,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 46393
+          "belop": 48691
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 2889
+          "belop": 2926
         }
       ],
       "uttaksgrad": 20
@@ -63,11 +63,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 46393
+          "belop": 48691
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 2889
+          "belop": 2926
         }
       ],
       "uttaksgrad": 20
@@ -77,11 +77,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 275686
+          "belop": 288735
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 6602
+          "belop": 6816
         }
       ],
       "uttaksgrad": 100
@@ -91,11 +91,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 275686
+          "belop": 288735
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 6602
+          "belop": 6816
         }
       ],
       "uttaksgrad": 100
@@ -105,11 +105,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 275686
+          "belop": 288735
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 6602
+          "belop": 6816
         }
       ],
       "uttaksgrad": 100
@@ -119,11 +119,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 275686
+          "belop": 288735
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 6602
+          "belop": 6816
         }
       ],
       "uttaksgrad": 100
@@ -133,11 +133,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 275686
+          "belop": 288735
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 6602
+          "belop": 6816
         }
       ],
       "uttaksgrad": 100
@@ -147,11 +147,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 275686
+          "belop": 288735
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 6602
+          "belop": 6816
         }
       ],
       "uttaksgrad": 100
@@ -161,11 +161,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 275686
+          "belop": 288735
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 6602
+          "belop": 6816
         }
       ],
       "uttaksgrad": 100
@@ -175,11 +175,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 275686
+          "belop": 288735
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 6602
+          "belop": 6816
         }
       ],
       "uttaksgrad": 100
@@ -189,11 +189,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 275686
+          "belop": 288735
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 6602
+          "belop": 6816
         }
       ],
       "uttaksgrad": 100
@@ -203,11 +203,11 @@
       "delytelseListe": [
         {
           "pensjonsType": "inntektsPensjon",
-          "belop": 275686
+          "belop": 288735
         },
         {
           "pensjonsType": "garantiPensjon",
-          "belop": 6602
+          "belop": 6816
         }
       ],
       "uttaksgrad": 100

--- a/end-to-end-test/src/main/resources/simuler-folketrygdbeholdning-response.json
+++ b/end-to-end-test/src/main/resources/simuler-folketrygdbeholdning-response.json
@@ -1,37 +1,37 @@
 {
   "pensjonsBeholdningsPeriodeListe": [
     {
-      "pensjonsBeholdning": 5023522,
-      "garantiPensjonsBeholdning": 457172,
+      "pensjonsBeholdning": 5053370,
+      "garantiPensjonsBeholdning": 643212,
       "garantitilleggsbeholdning": 0,
       "garantiPensjonsNiva": {
-        "belop": 224248,
+        "belop": 234765,
         "satsType": "ORDINAER",
-        "sats": 224248,
+        "sats": 234765,
         "anvendtTrygdetid": 40
       },
       "fraOgMedDato": "2068-02-01"
     },
     {
-      "pensjonsBeholdning": 5132122,
-      "garantiPensjonsBeholdning": 370292,
+      "pensjonsBeholdning": 5161970,
+      "garantiPensjonsBeholdning": 556332,
       "garantitilleggsbeholdning": 0,
       "garantiPensjonsNiva": {
-        "belop": 224248,
+        "belop": 234765,
         "satsType": "ORDINAER",
-        "sats": 224248,
+        "sats": 234765,
         "anvendtTrygdetid": 40
       },
       "fraOgMedDato": "2069-01-01"
     },
     {
-      "pensjonsBeholdning": 5141172,
-      "garantiPensjonsBeholdning": 363052,
+      "pensjonsBeholdning": 5171020,
+      "garantiPensjonsBeholdning": 549092,
       "garantitilleggsbeholdning": 0,
       "garantiPensjonsNiva": {
-        "belop": 224248,
+        "belop": 234765,
         "satsType": "ORDINAER",
-        "sats": 224248,
+        "sats": 234765,
         "anvendtTrygdetid": 40
       },
       "fraOgMedDato": "2070-01-01"

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/ServiceRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/ServiceRequest.kt
@@ -8,5 +8,5 @@ abstract class ServiceRequest {
      * Satsstabell som skal benyttes ved beregning.
      * Kun lest av pensjon-regler i test miljø.
      */
-    var satstabell: String? = "PROD_20250701"
+    var satstabell: String? = "PROD_20260701"
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/ServiceRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/domain/regler/to/ServiceRequest.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.simulator.core.domain.regler.to
 
-// 2026-04-23 + default satstabell
+// Copied from pensjon-regler-api v2.0.0 2026-06-08
+// plus given value for satstabell to make end-to-end tests stable
 abstract class ServiceRequest {
 
     /**


### PR DESCRIPTION
Oppdaterte responser for end-to-end-tester (integrasjonstester) etter G-regulering.
Angir ny satstabell (gjelder kun test) etter G-regulering.
(Angivelse av satstabell gir mer stabile end-to-end-tester.)