### PR TITLE
Handle InternDataInkonsistensException in sim-ap V4

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/fra2025/beholdninger/client/PensjonOpptjeningSimulerLivsvarigOffentligAfpBeholdningsgrunnlagClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/fra2025/beholdninger/client/PensjonOpptjeningSimulerLivsvarigOffentligAfpBeholdningsgrunnlagClient.kt
@@ -61,10 +61,7 @@ class PensjonOpptjeningSimulerLivsvarigOffentligAfpBeholdningsgrunnlagClient(
     }
 
     private fun setHeaders(headers: HttpHeaders) {
-        with(EgressAccess.token(service).value) {
-            headers.setBearerAuth(this)
-            log.debug { "Token: $this" }
-        }
+        headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/samhandler/SamhandlerAlderspensjonControllerV4.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/samhandler/SamhandlerAlderspensjonControllerV4.kt
@@ -22,10 +22,10 @@ import no.nav.pensjon.simulator.tech.web.BadRequestException
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
 import no.nav.pensjon.simulator.validity.BadSpecException
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import no.nav.pensjon.simulator.validity.InternDataInkonsistensException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
 import java.time.format.DateTimeParseException
 
 /**
@@ -91,6 +91,9 @@ class SamhandlerAlderspensjonControllerV4(
         } catch (e: FeilISimuleringsgrunnlagetException) {
             log.warn { "$FUNCTION_ID_V4 feil i simuleringsgrunnlaget - ${e.message} - request: $specV4" }
             feilInfoResultV4(e)
+        } catch (e: InternDataInkonsistensException) {
+            log.warn { "$FUNCTION_ID_V4 intern datainkonsistens - ${e.message} - request: $specV4" }
+            feilInfoResultV4(e)
         } catch (e: InvalidArgumentException) {
             log.warn { "$FUNCTION_ID_V4 invalid argument - ${e.message} - request: $specV4" }
             feilInfoResultV4(e)
@@ -114,6 +117,10 @@ class SamhandlerAlderspensjonControllerV4(
             traceAid.end()
         }
     }
+
+    @ExceptionHandler(value = [Exception::class])
+    private fun handleInternalServerError(e: RuntimeException): ResponseEntity<AlderspensjonResultV4> =
+        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(feilInfoResultV4(e))
 
     override fun errorMessage() = ERROR_MESSAGE
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/PenKravClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/krav/client/pen/PenKravClient.kt
@@ -1,7 +1,6 @@
 package no.nav.pensjon.simulator.krav.client.pen
 
 import com.github.benmanes.caffeine.cache.Cache
-import mu.KotlinLogging
 import no.nav.pensjon.simulator.common.client.ExternalServiceClient
 import no.nav.pensjon.simulator.core.domain.regler.krav.Kravhode
 import no.nav.pensjon.simulator.krav.client.KravClient
@@ -22,6 +21,7 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToMono
 
 @Component
 class PenKravClient(
@@ -32,7 +32,6 @@ class PenKravClient(
     private val traceAid: TraceAid
 ) : ExternalServiceClient(retryAttempts), KravClient {
 
-    private val log = KotlinLogging.logger {}
     private val webClient = webClientBase.withBaseUrl(baseUrl)
     private val cache: Cache<Long, Kravhode> = createCache("kravhode", cacheManager)
 
@@ -51,7 +50,7 @@ class PenKravClient(
                 .headers(::setHeaders)
                 .bodyValue(PenKravSpec(kravhodeId))
                 .retrieve()
-                .bodyToMono(PenKravhode::class.java)
+                .bodyToMono<PenKravhode>()
                 .retryWhen(retryBackoffSpec(uri))
                 .block()
                 ?.let(PenKravhodeMapper::kravhode)
@@ -69,11 +68,7 @@ class PenKravClient(
     override fun toString(e: EgressException, uri: String) = "Failed calling $uri"
 
     private fun setHeaders(headers: HttpHeaders) {
-        with(EgressAccess.token(service).value) {
-            headers.setBearerAuth(this)
-            log.debug { "Token: $this" }
-        }
-
+        headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/person/client/pen/PenPersonClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/person/client/pen/PenPersonClient.kt
@@ -1,7 +1,6 @@
 package no.nav.pensjon.simulator.person.client.pen
 
 import com.github.benmanes.caffeine.cache.Cache
-import mu.KotlinLogging
 import no.nav.pensjon.simulator.common.client.ExternalServiceClient
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
 import no.nav.pensjon.simulator.person.Pid
@@ -23,6 +22,7 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToMono
 
 @Component
 class PenPersonClient(
@@ -33,7 +33,6 @@ class PenPersonClient(
     private val traceAid: TraceAid
 ) : ExternalServiceClient(retryAttempts), PersonClient {
 
-    private val log = KotlinLogging.logger {}
     private val webClient = webClientBase.withBaseUrl(baseUrl)
     private val cache: Cache<Pid, PenPerson> = createCache("person", cacheManager)
 
@@ -78,7 +77,7 @@ class PenPersonClient(
                 .headers(::setHeaders)
                 .bodyValue(PenPersonSpec(pidListe.map { it.value }))
                 .retrieve()
-                .bodyToMono(PenPersonResult::class.java)
+                .bodyToMono<PenPersonResult>()
                 .retryWhen(retryBackoffSpec(uri))
                 .block()
                 ?.let { PenPersonHistorikkMapper.fromDto(it.personerVedPid) }.orEmpty()
@@ -94,11 +93,7 @@ class PenPersonClient(
     override fun toString(e: EgressException, uri: String) = "Failed calling $uri"
 
     private fun setHeaders(headers: HttpHeaders) {
-        with(EgressAccess.token(service).value) {
-            headers.setBearerAuth(this)
-            log.debug { "Token: $this" }
-        }
-
+        headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/sak/client/pen/PenSakClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/sak/client/pen/PenSakClient.kt
@@ -1,7 +1,6 @@
 package no.nav.pensjon.simulator.sak.client.pen
 
 import com.github.benmanes.caffeine.cache.Cache
-import mu.KotlinLogging
 import no.nav.pensjon.simulator.common.client.ExternalServiceClient
 import no.nav.pensjon.simulator.core.virkning.FoersteVirkningDatoCombo
 import no.nav.pensjon.simulator.person.Pid
@@ -23,6 +22,7 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToMono
 
 @Component
 class PenSakClient(
@@ -33,7 +33,6 @@ class PenSakClient(
     private val traceAid: TraceAid
 ) : ExternalServiceClient(retryAttempts), SakClient {
 
-    private val log = KotlinLogging.logger {}
     private val webClient = webClientBase.withBaseUrl(baseUrl)
     private val cache: Cache<Pid, FoersteVirkningDatoCombo> = createCache("personVirkningDato", cacheManager)
 
@@ -52,7 +51,7 @@ class PenSakClient(
                 .headers(::setHeaders)
                 .bodyValue(PenSakSpec(pid.value))
                 .retrieve()
-                .bodyToMono(PenVirkningsdatoResult::class.java)
+                .bodyToMono<PenVirkningsdatoResult>()
                 .retryWhen(retryBackoffSpec(uri))
                 .block()
                 ?.let(PenVirkningsdatoResultMapper::fromDto)
@@ -69,11 +68,7 @@ class PenSakClient(
     override fun toString(e: EgressException, uri: String) = "Failed calling $uri"
 
     private fun setHeaders(headers: HttpHeaders) {
-        with(EgressAccess.token(service).value) {
-            headers.setBearerAuth(this)
-            log.debug { "Token: $this" }
-        }
-
+        headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/fra2025/service/klp/KlpTjenestepensjonClientFra2025.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/fra2025/service/klp/KlpTjenestepensjonClientFra2025.kt
@@ -41,6 +41,7 @@ class KlpTjenestepensjonClientFra2025(
     private val sammenligner: SammenlignAFPService,
     private val isDevelopment: () -> Boolean = { EnvironmentUtil.isDevelopment() },
 ) : ExternalServiceClient(retryAttempts), TjenestepensjonFra2025Client {
+
     override val service = service()
     private val log = KotlinLogging.logger {}
     private val webClient = webClientBase.withBaseUrl(baseUrl)
@@ -95,11 +96,7 @@ class KlpTjenestepensjonClientFra2025(
                 .also { sammenligner.sammenlignOgLoggAfp(spec, it.utbetalingsperioder) })
 
     private fun setHeaders(headers: HttpHeaders) {
-        with(EgressAccess.token(service).value) {
-            headers.setBearerAuth(this)
-            log.debug { "Token: $this" }
-        }
-
+        headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/fra2025/service/spk/SpkTjenestepensjonClientFra2025.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/fra2025/service/spk/SpkTjenestepensjonClientFra2025.kt
@@ -94,11 +94,7 @@ class SpkTjenestepensjonClientFra2025(
         )
 
     private fun setHeaders(headers: HttpHeaders) {
-        with(EgressAccess.token(service).value) {
-            headers.setBearerAuth(this)
-            log.debug { "Token: $this" }
-        }
-
+        headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/tpregisteret/TpregisteretClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tpregisteret/TpregisteretClient.kt
@@ -39,7 +39,7 @@ class TpregisteretClient(
                 .bodyValue(pid.value)
                 .headers(::setHeaders)
                 .retrieve()
-                .bodyToMono(BrukerTilknyttetTpLeverandoerResponse::class.java)
+                .bodyToMono<BrukerTilknyttetTpLeverandoerResponse>()
                 .block()
             response?.forhold ?: logAndReturnFalse("Tom responsebody fra ${service.shortName}", organisasjonsnummer)
         } catch (e: WebClientRequestException) {
@@ -56,7 +56,7 @@ class TpregisteretClient(
     }
 
     fun findAlleTpForhold(pid: Pid): List<TpForhold> =
-         webClient.get()
+        webClient.get()
             .uri(FORHOLD_PATH)
             .headers { setHeaders(it); it["fnr"] = pid.value }
             .exchangeToMono(::handleAlleTpForholdResponse)
@@ -64,11 +64,11 @@ class TpregisteretClient(
             .orEmpty()
 
     fun findTssId(tpId: String): String? =
-         try {
+        try {
             webClient.get()
                 .uri("$TSS_PATH$tpId")
                 .retrieve()
-                .bodyToMono(String::class.java)
+                .bodyToMono<String>()
                 .block()
         } catch (_: WebClientResponseException.NotFound) {
             null
@@ -106,11 +106,7 @@ class TpregisteretClient(
     override fun toString(e: EgressException, uri: String) = "Failed calling $uri"
 
     private fun setHeaders(headers: HttpHeaders) {
-        with(EgressAccess.token(service).value) {
-            headers.setBearerAuth(this)
-            log.debug { "Token: $this" }
-        }
-
+        headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/ufoere/client/pen/PenUfoeretrygdUtbetalingClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/ufoere/client/pen/PenUfoeretrygdUtbetalingClient.kt
@@ -1,7 +1,6 @@
 package no.nav.pensjon.simulator.ufoere.client.pen
 
 import com.github.benmanes.caffeine.cache.Cache
-import mu.KotlinLogging
 import no.nav.pensjon.simulator.common.client.ExternalServiceClient
 import no.nav.pensjon.simulator.core.domain.regler.beregning2011.UtbetalingsgradUT
 import no.nav.pensjon.simulator.tech.cache.CacheConfigurator.createCache
@@ -21,6 +20,7 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToMono
 
 @Component
 class PenUfoeretrygdUtbetalingClient(
@@ -31,7 +31,6 @@ class PenUfoeretrygdUtbetalingClient(
     private val traceAid: TraceAid
 ) : ExternalServiceClient(retryAttempts), UfoeretrygdUtbetalingClient {
 
-    private val log = KotlinLogging.logger {}
     private val webClient = webClientBase.withBaseUrl(baseUrl)
     private val cache: Cache<Long, List<UtbetalingsgradUT>> = createCache("utbetalingsgrader", cacheManager)
 
@@ -50,7 +49,7 @@ class PenUfoeretrygdUtbetalingClient(
                 .headers(::setHeaders)
                 .bodyValue(PenUfoeretrygdUtbetalingSpec(penPersonId))
                 .retrieve()
-                .bodyToMono(PenUfoeretrygdUtbetalingResult::class.java)
+                .bodyToMono<PenUfoeretrygdUtbetalingResult>()
                 .retryWhen(retryBackoffSpec(uri))
                 .block()
                 ?.utbetalingsgradListe.orEmpty()
@@ -67,11 +66,7 @@ class PenUfoeretrygdUtbetalingClient(
     override fun toString(e: EgressException, uri: String) = "Failed calling $uri"
 
     private fun setHeaders(headers: HttpHeaders) {
-        with(EgressAccess.token(service).value) {
-            headers.setBearerAuth(this)
-            log.debug { "Token: $this" }
-        }
-
+        headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/vedtak/client/pen/PenVedtakClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/vedtak/client/pen/PenVedtakClient.kt
@@ -1,7 +1,6 @@
 package no.nav.pensjon.simulator.vedtak.client.pen
 
 import com.github.benmanes.caffeine.cache.Cache
-import mu.KotlinLogging
 import no.nav.pensjon.simulator.common.client.ExternalServiceClient
 import no.nav.pensjon.simulator.core.domain.regler.enum.SakTypeEnum
 import no.nav.pensjon.simulator.person.Pid
@@ -24,6 +23,7 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToMono
 import java.time.LocalDate
 
 @Component
@@ -35,7 +35,6 @@ class PenVedtakClient(
     private val traceAid: TraceAid
 ) : ExternalServiceClient(retryAttempts), VedtakClient {
 
-    private val log = KotlinLogging.logger {}
     private val webClient = webClientBase.withBaseUrl(baseUrl)
 
     private val datoCache: Cache<PenVedtakSpecV1, PenVedtakResultV1> =
@@ -67,7 +66,7 @@ class PenVedtakClient(
                 .headers(::setHeaders)
                 .bodyValue(spec)
                 .retrieve()
-                .bodyToMono(PenVedtakResultV1::class.java)
+                .bodyToMono<PenVedtakResultV1>()
                 .retryWhen(retryBackoffSpec(uri))
                 .block()
                 ?: PenVedtakResultV1(dato = null)
@@ -90,7 +89,7 @@ class PenVedtakClient(
                 .headers(::setHeaders)
                 .bodyValue(spec)
                 .retrieve()
-                .bodyToMono(VedtakStatus::class.java)
+                .bodyToMono<VedtakStatus>()
                 .retryWhen(retryBackoffSpec(uri))
                 .block()
                 ?: VedtakStatus(harGjeldendeVedtak = false, harGjenlevenderettighet = false)
@@ -106,11 +105,7 @@ class PenVedtakClient(
     override fun toString(e: EgressException, uri: String) = "Failed calling $uri"
 
     private fun setHeaders(headers: HttpHeaders) {
-        with(EgressAccess.token(service).value) {
-            headers.setBearerAuth(this)
-            log.debug { "Token: $this" }
-        }
-
+        headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/ytelse/client/pen/PenYtelseClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/ytelse/client/pen/PenYtelseClient.kt
@@ -1,7 +1,6 @@
 package no.nav.pensjon.simulator.ytelse.client.pen
 
 import com.github.benmanes.caffeine.cache.Cache
-import mu.KotlinLogging
 import no.nav.pensjon.simulator.common.client.ExternalServiceClient
 import no.nav.pensjon.simulator.tech.cache.CacheConfigurator.createCache
 import no.nav.pensjon.simulator.tech.security.egress.EgressAccess
@@ -36,7 +35,6 @@ class PenYtelseClient(
     private val traceAid: TraceAid
 ) : ExternalServiceClient(retryAttempts), YtelseClient {
 
-    private val log = KotlinLogging.logger {}
     private val webClient = webClientBase.withBaseUrl(baseUrl)
     private val cache: Cache<LoependeYtelserSpec, LoependeYtelserResult> = createCache("loependeYtelser", cacheManager)
 
@@ -74,11 +72,7 @@ class PenYtelseClient(
     override fun toString(e: EgressException, uri: String) = "Failed calling $uri"
 
     private fun setHeaders(headers: HttpHeaders) {
-        with(EgressAccess.token(service).value) {
-            headers.setBearerAuth(this)
-            log.debug { "Token: $this" }
-        }
-
+        headers.setBearerAuth(EgressAccess.token(service).value)
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.main.banner-mode=off
-spring.web.error.include-message=always
+spring.web.error.include-message=never
 
 spring.flyway.default-schema=pensjonssimulator
 spring.flyway.url=${psdb.jdbc.url}

--- a/src/test/kotlin/no/nav/pensjon/simulator/common/api/ControllerBaseTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/common/api/ControllerBaseTest.kt
@@ -21,7 +21,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
-/* TODO restore tests
+
 class ControllerBaseTest : ShouldSpec({
 
     val pid = Pid("12906498357")
@@ -71,7 +71,7 @@ class ControllerBaseTest : ShouldSpec({
             controller.testVerifiserAtBrukerTilknyttetTpLeverandoer(pid)
         }
 
-        should("kaste exception med årsak når personen ikke er tilknyttet tjenestepensjonsleverandør") {
+        should("kaste exception med ikke-sensitiv årsak når personen ikke er tilknyttet tjenestepensjonsleverandør") {
             val controller = TestController(
                 traceAid = mockk<TraceAid>().apply { every { callId() } returns "123-124" },
                 organisasjonsnummerProvider = mockk(relaxed = true),
@@ -92,10 +92,7 @@ class ControllerBaseTest : ShouldSpec({
     context("timed (no argument)") {
         should("returnere resultatet fra funksjonen") {
             val controller = SimpleTestController(mockk(relaxed = true))
-
-            val result = controller.testTimed({ "result" }, "testFunction")
-
-            result shouldBe "result"
+            controller.testTimed({ "result" }, "testFunction") shouldBe "result"
         }
 
         should("kalle funksjonen nøyaktig én gang") {
@@ -109,10 +106,7 @@ class ControllerBaseTest : ShouldSpec({
 
         should("håndtere funksjoner som returnerer null") {
             val controller = SimpleTestController(mockk(relaxed = true))
-
-            val result = controller.testTimed<String?>({ null }, "testFunction")
-
-            result shouldBe null
+            controller.testTimed<String?>({ null }, "testFunction") shouldBe null
         }
     }
 
@@ -120,9 +114,11 @@ class ControllerBaseTest : ShouldSpec({
         should("returnere resultatet fra funksjonen med argument") {
             val controller = SimpleTestController(mockk(relaxed = true))
 
-            val result = controller.testTimedWithArg({ x: Int -> x * 2 }, 5, "testFunction")
-
-            result shouldBe 10
+            controller.testTimedWithArg(
+                function = { x: Int -> x * 2 },
+                argument = 5,
+                functionName = "testFunction"
+            ) shouldBe 10
         }
 
         should("sende argumentet til funksjonen") {
@@ -146,8 +142,10 @@ class ControllerBaseTest : ShouldSpec({
                 controller.testHandle<String>(egressException)
             }
 
-            exception.statusCode shouldBe HttpStatus.INTERNAL_SERVER_ERROR
-            exception.reason shouldContain "test-call-id"
+            with(exception) {
+                statusCode shouldBe HttpStatus.INTERNAL_SERVER_ERROR
+                reason shouldContain "test-call-id"
+            }
         }
 
         should("kaste SERVICE_UNAVAILABLE for server error") {
@@ -156,11 +154,9 @@ class ControllerBaseTest : ShouldSpec({
             val controller = SimpleTestController(traceAid)
             val egressException = EgressException("Server error", statusCode = HttpStatus.INTERNAL_SERVER_ERROR)
 
-            val exception = shouldThrow<ResponseStatusException> {
+            shouldThrow<ResponseStatusException> {
                 controller.testHandle<String>(egressException)
-            }
-
-            exception.statusCode shouldBe HttpStatus.SERVICE_UNAVAILABLE
+            }.statusCode shouldBe HttpStatus.SERVICE_UNAVAILABLE
         }
 
         should("kaste SERVICE_UNAVAILABLE for 5xx errors") {
@@ -169,11 +165,9 @@ class ControllerBaseTest : ShouldSpec({
             val controller = SimpleTestController(traceAid)
             val egressException = EgressException("Bad gateway", statusCode = HttpStatus.BAD_GATEWAY)
 
-            val exception = shouldThrow<ResponseStatusException> {
+            shouldThrow<ResponseStatusException> {
                 controller.testHandle<String>(egressException)
-            }
-
-            exception.statusCode shouldBe HttpStatus.SERVICE_UNAVAILABLE
+            }.statusCode shouldBe HttpStatus.SERVICE_UNAVAILABLE
         }
     }
 
@@ -188,9 +182,10 @@ class ControllerBaseTest : ShouldSpec({
                 controller.testBadRequest<String>(runtimeException)
             }
 
-            exception.statusCode shouldBe HttpStatus.BAD_REQUEST
-            exception.reason shouldContain "bad-request-call-id"
-            exception.reason shouldContain "Invalid input"
+            with(exception) {
+                statusCode shouldBe HttpStatus.BAD_REQUEST
+                reason shouldBe "Call ID: bad-request-call-id | Error: Test error | Details: RuntimeException"
+            }
         }
 
         should("håndtere nestede exceptions") {
@@ -200,33 +195,25 @@ class ControllerBaseTest : ShouldSpec({
             val cause = IllegalArgumentException("Root cause")
             val runtimeException = RuntimeException("Outer exception", cause)
 
-            val exception = shouldThrow<ResponseStatusException> {
+            shouldThrow<ResponseStatusException> {
                 controller.testBadRequest<String>(runtimeException)
-            }
-
-            exception.reason shouldContain "Outer exception"
-            exception.reason shouldContain "Root cause"
+            }.reason shouldBe "Call ID: call-id | Error: Test error | Details: RuntimeException | Cause: IllegalArgumentException"
         }
     }
 
     context("extractMessageRecursively") {
-        should("returnere exception message") {
-            val exception = RuntimeException("Simple error")
-
-            val result = SimpleTestController.testExtractMessageRecursively(exception)
-
-            result shouldBe "Simple error"
+        should("ikke returnere mulig sensitiv exception message") {
+            SimpleTestController.testExtractMessageRecursively(
+                e = RuntimeException("Simple error")
+            ) shouldBe "RuntimeException"
         }
 
-        should("inkludere cause message") {
+        should("ikke inkludere mulig sensitiv årsak") {
             val cause = IllegalArgumentException("Root cause")
-            val exception = RuntimeException("Outer error", cause)
 
-            val result = SimpleTestController.testExtractMessageRecursively(exception)
-
-            result shouldContain "Outer error"
-            result shouldContain "Cause:"
-            result shouldContain "Root cause"
+            SimpleTestController.testExtractMessageRecursively(
+                e = RuntimeException("Outer error", cause)
+            ) shouldBe "RuntimeException | Cause: IllegalArgumentException"
         }
 
         should("håndtere flere nivåer av causes") {
@@ -234,19 +221,12 @@ class ControllerBaseTest : ShouldSpec({
             val middleCause = IllegalArgumentException("Middle", rootCause)
             val exception = RuntimeException("Top", middleCause)
 
-            val result = SimpleTestController.testExtractMessageRecursively(exception)
-
-            result shouldContain "Top"
-            result shouldContain "Middle"
-            result shouldContain "Root"
+            SimpleTestController.testExtractMessageRecursively(exception) shouldBe
+                    "RuntimeException | Cause: IllegalArgumentException | Cause: IllegalStateException"
         }
 
         should("bruke class name når message er null") {
-            val exception = RuntimeException()
-
-            val result = SimpleTestController.testExtractMessageRecursively(exception)
-
-            result shouldContain "RuntimeException"
+            SimpleTestController.testExtractMessageRecursively(e = RuntimeException()) shouldBe "RuntimeException"
         }
     }
 })
@@ -295,6 +275,7 @@ private class SimpleTestController(traceAid: TraceAid) : ControllerBase(traceAid
     fun <R> testTimed(function: () -> R, functionName: String): R = timed(function, functionName)
     fun <A, R> testTimedWithArg(function: (A) -> R, argument: A, functionName: String): R =
         timed(function, argument, functionName)
+
     fun <T> testHandle(e: EgressException): T? = handle(e)
     fun <T> testBadRequest(e: RuntimeException): T = badRequest(e)
 
@@ -302,4 +283,3 @@ private class SimpleTestController(traceAid: TraceAid) : ControllerBase(traceAid
         fun testExtractMessageRecursively(e: Throwable): String = extractMessageRecursively(e)
     }
 }
-*/

--- a/src/test/kotlin/no/nav/pensjon/simulator/orch/AlderspensjonOgPrivatAfpServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/orch/AlderspensjonOgPrivatAfpServiceTest.kt
@@ -22,7 +22,6 @@ import org.springframework.http.HttpStatus
 import java.time.LocalDate
 import java.time.format.DateTimeParseException
 
-/* TODO restore tests
 class AlderspensjonOgPrivatAfpServiceTest : ShouldSpec({
 
     context("happy path") {
@@ -81,7 +80,7 @@ class AlderspensjonOgPrivatAfpServiceTest : ShouldSpec({
 
             goodService.simuler(spec) shouldBe errorResult(
                 problemType = ProblemType.UGYLDIG_UTTAKSDATO,
-                beskrivelse = "Dato for første uttak (2023-01-01) er for tidlig"
+                beskrivelse = "Ukjent feil - BadSpecException"
             )
         }
 
@@ -90,7 +89,7 @@ class AlderspensjonOgPrivatAfpServiceTest : ShouldSpec({
 
             goodService.simuler(spec) shouldBe errorResult(
                 problemType = ProblemType.UGYLDIG_UTTAKSDATO,
-                beskrivelse = "Dato for første uttak mangler"
+                beskrivelse = "Ukjent feil - BadSpecException"
             )
         }
 
@@ -107,7 +106,7 @@ class AlderspensjonOgPrivatAfpServiceTest : ShouldSpec({
 
             goodService.simuler(spec) shouldBe errorResult(
                 problemType = ProblemType.UGYLDIG_INNTEKT,
-                beskrivelse = "En fremtidig inntekt har negativt beløp"
+                beskrivelse = "Ukjent feil - BadSpecException"
             )
         }
     }
@@ -115,27 +114,47 @@ class AlderspensjonOgPrivatAfpServiceTest : ShouldSpec({
     context("ukategorisert klientfeil") {
         should("return ANNEN_KLIENTFEIL problem on BadRequestException") {
             badService(simulatorException = BadRequestException("bad request"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.ANNEN_KLIENTFEIL, "bad request")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.ANNEN_KLIENTFEIL,
+                        beskrivelse = "Ukjent feil - BadRequestException"
+                    )
         }
 
         should("return ANNEN_KLIENTFEIL problem on DateTimeParseException") {
             badService(simulatorException = DateTimeParseException("parse error", "text", 0))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.ANNEN_KLIENTFEIL, "parse error")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.ANNEN_KLIENTFEIL,
+                        beskrivelse = "Ukjent feil - DateTimeParseException"
+                    )
         }
 
         should("return ANNEN_KLIENTFEIL problem on FeilISimuleringsgrunnlagetException") {
             badService(simulatorException = FeilISimuleringsgrunnlagetException("feil i grunnlag"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.ANNEN_KLIENTFEIL, "feil i grunnlag")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.ANNEN_KLIENTFEIL,
+                        beskrivelse = "Ukjent feil - FeilISimuleringsgrunnlagetException"
+                    )
         }
 
         should("return ANNEN_KLIENTFEIL problem on InvalidArgumentException") {
             badService(simulatorException = InvalidArgumentException("ugyldig argument"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.ANNEN_KLIENTFEIL, "ugyldig argument")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.ANNEN_KLIENTFEIL,
+                        beskrivelse = "Ukjent feil - InvalidArgumentException"
+                    )
         }
 
         should("return ANNEN_KLIENTFEIL problem on InvalidEnumValueException") {
             badService(simulatorException = InvalidEnumValueException("ugyldig enum"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.ANNEN_KLIENTFEIL, "ugyldig enum")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.ANNEN_KLIENTFEIL,
+                        beskrivelse = "Ukjent feil - InvalidEnumValueException"
+                    )
         }
 
         should("return INTERN_DATA_INKONSISTENS problem on KonsistensenIGrunnlagetErFeilException") {
@@ -151,51 +170,82 @@ class AlderspensjonOgPrivatAfpServiceTest : ShouldSpec({
 
         should("return ANNEN_KLIENTFEIL problem on PersonForUngException") {
             badService(simulatorException = PersonForUngException("for ung"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.ANNEN_KLIENTFEIL, "for ung")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.ANNEN_KLIENTFEIL,
+                        beskrivelse = "Ukjent feil - PersonForUngException"
+                    )
         }
 
         should("return ANNEN_KLIENTFEIL problem on RegelmotorValideringException") {
             badService(simulatorException = RegelmotorValideringException("validering feilet"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.ANNEN_KLIENTFEIL, "validering feilet")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.ANNEN_KLIENTFEIL,
+                        beskrivelse = "Ukjent feil - RegelmotorValideringException"
+                    )
         }
     }
 
     context("serverfeil") {
         should("return ANNEN_SERVERFEIL problem on EgressException due to error in application acting as client") {
             badService(simulatorException = EgressException("egress error", statusCode = HttpStatus.BAD_REQUEST))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.ANNEN_SERVERFEIL, "egress error")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.ANNEN_SERVERFEIL,
+                        beskrivelse = "Ukjent feil - EgressException"
+                    )
         }
 
         should("return TREDJEPARTSFEIL problem on EgressException due to error in remote server") {
             badService(
                 simulatorException = EgressException(
-                    "egress error",
+                    message = "egress error",
                     statusCode = HttpStatus.INTERNAL_SERVER_ERROR
                 )
-            )
-                .simuler(validSpec) shouldBe errorResult(ProblemType.TREDJEPARTSFEIL, "egress error")
+            ).simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.TREDJEPARTSFEIL,
+                        beskrivelse = "Ukjent feil - EgressException"
+                    )
         }
 
         should("return IMPLEMENTASJONSFEIL problem on ImplementationUnrecoverableException") {
             badService(simulatorException = ImplementationUnrecoverableException("implementation error"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.IMPLEMENTASJONSFEIL, "implementation error")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.IMPLEMENTASJONSFEIL,
+                        beskrivelse = "Ukjent feil - ImplementationUnrecoverableException"
+                    )
         }
 
         should("return IMPLEMENTASJONSFEIL problem on ImplementationUnrecoverableException") {
             badService(simulatorException = InternDataInkonsistensException("data error"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.INTERN_DATA_INKONSISTENS, "data error")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.INTERN_DATA_INKONSISTENS,
+                        beskrivelse = "Ukjent feil - InternDataInkonsistensException"
+                    )
         }
     }
 
     context("kategorisert feilsituasjon") {
         should("return PERSON_FOR_HOEY_ALDER problem on PersonForGammelException") {
             badService(simulatorException = PersonForGammelException("for gammel"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.PERSON_FOR_HOEY_ALDER, "for gammel")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.PERSON_FOR_HOEY_ALDER,
+                        beskrivelse = "Ukjent feil - PersonForGammelException"
+                    )
         }
 
         should("return UTILSTREKKELIG_OPPTJENING problem on UtilstrekkeligOpptjeningException") {
             badService(simulatorException = UtilstrekkeligOpptjeningException("for lav opptjening"))
-                .simuler(validSpec) shouldBe errorResult(ProblemType.UTILSTREKKELIG_OPPTJENING, "for lav opptjening")
+                .simuler(validSpec) shouldBe
+                    errorResult(
+                        problemType = ProblemType.UTILSTREKKELIG_OPPTJENING,
+                        beskrivelse = "Ukjent feil - UtilstrekkeligOpptjeningException"
+                    )
         }
 
         should("return UTILSTREKKELIG_TRYGDETID problem on UtilstrekkeligTrygdetidException") {
@@ -204,7 +254,7 @@ class AlderspensjonOgPrivatAfpServiceTest : ShouldSpec({
             with(result) {
                 suksess shouldBe false
                 problem?.type shouldBe ProblemType.UTILSTREKKELIG_TRYGDETID
-                problem?.beskrivelse shouldBe "Utilstrekkelig trygdetid"
+                problem?.beskrivelse shouldBe "Ukjent feil - UtilstrekkeligTrygdetidException"
             }
         }
     }
@@ -270,4 +320,3 @@ private fun errorResult(problemType: ProblemType, beskrivelse: String) =
         harLoependePrivatAfp = false,
         problem = Problem(problemType, beskrivelse)
     )
-*/

--- a/src/test/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/TjenestepensjonSimuleringPre2025FacadeTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/TjenestepensjonSimuleringPre2025FacadeTest.kt
@@ -12,11 +12,10 @@ import no.nav.pensjon.simulator.testutil.TestObjects.simuleringSpec
 import no.nav.pensjon.simulator.validity.Problem
 import no.nav.pensjon.simulator.validity.ProblemType
 
-/* TODO restore tests
 class TjenestepensjonSimuleringPre2025FacadeTest : ShouldSpec({
 
     context("AFP avslått uten oppgitt årsak") {
-        should("gi resultat med 'annen klientfeil' og problembeskrivelse") {
+        should("gi resultat med 'annen klientfeil' og ikke-sensitiv problembeskrivelse") {
             TjenestepensjonSimuleringPre2025Facade(
                 beregningService = arrangeAvslag(aarsak = null), // uten oppgitt årsak
                 tjenestepensjonSimulator = mockk()
@@ -24,28 +23,37 @@ class TjenestepensjonSimuleringPre2025FacadeTest : ShouldSpec({
                     SimulerOffentligTjenestepensjonResult(
                         tpnr = "",
                         navnOrdning = "",
-                        problem = Problem(type = ProblemType.ANNEN_KLIENTFEIL, beskrivelse = AVSLAGSBESKRIVELSE)
+                        problem = Problem(
+                            type = ProblemType.ANNEN_KLIENTFEIL,
+                            beskrivelse = "Ukjent feil - Pre2025OffentligAfpAvslaattException"
+                        )
                     )
         }
     }
 
     context("AFP avslått med oppgitt årsak") {
-        should("gi resultat med tilsvarende problemtype og problembeskrivelse") {
+        should("gi resultat med tilsvarende problemtype og ikke-sensitiv problembeskrivelse") {
             TjenestepensjonSimuleringPre2025Facade(
                 beregningService = arrangeAvslag(aarsak = TidsbegrensetOffentligAfpAvslagAarsak.FOR_LAV_ALDER),
                 tjenestepensjonSimulator = mockk()
-            ).simuler(simuleringSpec, stillingsprosentSpec)
-                .problem shouldBe Problem(type = ProblemType.PERSON_FOR_LAV_ALDER, beskrivelse = AVSLAGSBESKRIVELSE)
+            ).simuler(simuleringSpec, stillingsprosentSpec).problem shouldBe
+                    Problem(
+                        type = ProblemType.PERSON_FOR_LAV_ALDER,
+                        beskrivelse = "Ukjent feil - Pre2025OffentligAfpAvslaattException"
+                    )
         }
     }
 
     context("utilstrekkelig opptjening") {
-        should("gi resultat med 'utilstrekkelig opptjening' og problembeskrivelse") {
+        should("gi resultat med 'utilstrekkelig opptjening' og ikke-sensitiv problembeskrivelse") {
             TjenestepensjonSimuleringPre2025Facade(
                 beregningService = arrangeProblem(e = UtilstrekkeligOpptjeningException(message = "10 kroner")),
                 tjenestepensjonSimulator = mockk()
-            ).simuler(simuleringSpec, stillingsprosentSpec)
-                .problem shouldBe Problem(type = ProblemType.UTILSTREKKELIG_OPPTJENING, beskrivelse = "10 kroner")
+            ).simuler(simuleringSpec, stillingsprosentSpec).problem shouldBe
+                    Problem(
+                        type = ProblemType.UTILSTREKKELIG_OPPTJENING,
+                        beskrivelse = "Ukjent feil - UtilstrekkeligOpptjeningException"
+                    )
         }
     }
 
@@ -56,13 +64,16 @@ class TjenestepensjonSimuleringPre2025FacadeTest : ShouldSpec({
                     e = KonsistensenIGrunnlagetErFeilException(e = MatchException(null, null))
                 ),
                 tjenestepensjonSimulator = mockk()
-            ).simuler(simuleringSpec, stillingsprosentSpec)
-                .problem shouldBe Problem(type = ProblemType.ANNEN_KLIENTFEIL, beskrivelse = "java.lang.MatchException")
+            ).simuler(simuleringSpec, stillingsprosentSpec).problem shouldBe
+                    Problem(
+                        type = ProblemType.ANNEN_KLIENTFEIL,
+                        beskrivelse = "Ukjent feil - KonsistensenIGrunnlagetErFeilException"
+                    )
         }
     }
 })
 
-private const val AVSLAGSBESKRIVELSE = "AFP avslått"
+private const val SENSITIV_INFO = "noe sensitivt"
 
 private val stillingsprosentSpec =
     StillingsprosentSpec(
@@ -74,7 +85,7 @@ private fun arrangeAvslag(
     aarsak: TidsbegrensetOffentligAfpAvslagAarsak?
 ): TjenestepensjonSimuleringPre2025SpecBeregningService =
     arrangeProblem(
-        e = Pre2025OffentligAfpAvslaattException(message = AVSLAGSBESKRIVELSE, aarsak)
+        e = Pre2025OffentligAfpAvslaattException(message = SENSITIV_INFO, aarsak)
     )
 
 private fun arrangeProblem(e: Exception): TjenestepensjonSimuleringPre2025SpecBeregningService =
@@ -83,4 +94,3 @@ private fun arrangeProblem(e: Exception): TjenestepensjonSimuleringPre2025SpecBe
             kompletterMedAlderspensjonsberegning(any(), any())
         } throws e
     }
-*/


### PR DESCRIPTION
Endringer:

- Handle `InternDataInkonsistensException` in sim-ap V4
- Add `ExceptionHandler` in sim-ap V4
- Set `spring.web.error.include-message=never`
- Restore unit tests after hotfix
- Remove debug logging of JWT