### PR TITLE
TPP-462 Sporingslogg simuler-alderspensjon-privat-afp

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/folketrygdberegnet/api/direct/TpoFolketrygdberegnetAfpController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/folketrygdberegnet/api/direct/TpoFolketrygdberegnetAfpController.kt
@@ -23,6 +23,7 @@ import no.nav.pensjon.simulator.tech.validation.InvalidEnumValueException
 import no.nav.pensjon.simulator.tech.web.BadRequestException
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.validity.BadSpecException
+import no.nav.pensjon.simulator.validity.InternDataInkonsistensException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -92,6 +93,9 @@ class TpoFolketrygdberegnetAfpController(
         } catch (e: ImplementationUnrecoverableException) {
             log.error(e) { "$FUNCTION_ID unrecoverable error - request - $specV0" }
             throw e
+        } catch (e: InternDataInkonsistensException) {
+            log.error(e) { "$FUNCTION_ID intern datainkonsistens - request - $specV0" }
+            throw e
         } catch (e: InvalidArgumentException) {
             log.warn(e) { "$FUNCTION_ID invalid argument - request - $specV0" }
             throw e
@@ -154,7 +158,9 @@ class TpoFolketrygdberegnetAfpController(
 
     @ExceptionHandler(
         value = [
-            ImplementationUnrecoverableException::class
+            ImplementationUnrecoverableException::class,
+            InternDataInkonsistensException::class,
+            Exception::class
         ]
     )
     fun handleInternalServerError(e: RuntimeException): ResponseEntity<TpoSimuleringErrorDto> =

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/folketrygdberegnet/api/direct/TpoFolketrygdberegnetAfpController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/folketrygdberegnet/api/direct/TpoFolketrygdberegnetAfpController.kt
@@ -127,7 +127,8 @@ class TpoFolketrygdberegnetAfpController(
             log.info(e) { "$FUNCTION_ID utilstrekkelig trygdetid - request - $specV0" }
             throw e
         } catch (e: EgressException) {
-            handle(e)!!
+            log.error(e) { "$FUNCTION_ID error calling backside service - request - $specV0" }
+            throw e
         } finally {
             traceAid.end()
         }
@@ -140,17 +141,7 @@ class TpoFolketrygdberegnetAfpController(
             BadRequestException::class,
             BadSpecException::class,
             DateTimeParseException::class,
-            FeilISimuleringsgrunnlagetException::class,
-            InvalidArgumentException::class,
-            InvalidEnumValueException::class,
-            KanIkkeBeregnesException::class,
-            KonsistensenIGrunnlagetErFeilException::class,
-            PersonForGammelException::class,
-            PersonForUngException::class,
-            Pre2025OffentligAfpAvslaattException::class,
-            RegelmotorValideringException::class,
-            UtilstrekkeligOpptjeningException::class,
-            UtilstrekkeligTrygdetidException::class
+            InvalidEnumValueException::class
         ]
     )
     private fun handleBadRequest(e: RuntimeException): ResponseEntity<TpoSimuleringErrorDto> =
@@ -158,8 +149,25 @@ class TpoFolketrygdberegnetAfpController(
 
     @ExceptionHandler(
         value = [
+            PersonForGammelException::class,
+            PersonForUngException::class,
+            Pre2025OffentligAfpAvslaattException::class,
+            UtilstrekkeligOpptjeningException::class,
+            UtilstrekkeligTrygdetidException::class
+        ]
+    )
+    private fun handleUnprocessableEntity(e: RuntimeException): ResponseEntity<TpoSimuleringErrorDto> =
+        ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(errorDto(e))
+
+    @ExceptionHandler(
+        value = [
+            FeilISimuleringsgrunnlagetException::class,
             ImplementationUnrecoverableException::class,
             InternDataInkonsistensException::class,
+            InvalidArgumentException::class,
+            KonsistensenIGrunnlagetErFeilException::class,
+            RegelmotorValideringException::class,
+            EgressException::class,
             Exception::class
         ]
     )
@@ -172,7 +180,7 @@ class TpoFolketrygdberegnetAfpController(
 
         private fun errorDto(e: RuntimeException) =
             TpoSimuleringErrorDto(
-                feil = e.javaClass.simpleName
+                feil = e.javaClass.simpleName // no sensitive data here
             )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/api/TpoAfpEtterfulgtAvAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/api/TpoAfpEtterfulgtAvAlderspensjonController.kt
@@ -26,6 +26,7 @@ import no.nav.pensjon.simulator.tech.trace.TraceAid
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
 import no.nav.pensjon.simulator.validity.BadSpecException
+import no.nav.pensjon.simulator.validity.InternDataInkonsistensException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -94,6 +95,9 @@ class TpoAfpEtterfulgtAvAlderspensjonController(
         } catch (e: ImplementationUnrecoverableException) {
             log.error(e) { "$FUNCTION_ID unrecoverable error - request - $specV0" }
             throw e
+        } catch (e: InternDataInkonsistensException) {
+            log.error(e) { "$FUNCTION_ID intern datainkonsistens - request - $specV0" }
+            throw e
         } catch (e: KonsistensenIGrunnlagetErFeilException) {
             log.warn(e) { "$FUNCTION_ID inkonsistent grunnlag - request - $specV0" }
             tomResponsMedAarsak(AarsakIkkeSuccessV0.FEIL_I_GRUNNLAG)
@@ -129,7 +133,9 @@ class TpoAfpEtterfulgtAvAlderspensjonController(
     @ExceptionHandler(
         value = [
             RegelmotorValideringException::class,
-            ImplementationUnrecoverableException::class
+            ImplementationUnrecoverableException::class,
+            InternDataInkonsistensException::class,
+            Exception::class
         ]
     )
     fun handleInternalServerError(e: RuntimeException): ResponseEntity<TpoSimuleringErrorDto> =

--- a/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/api/TpoAfpEtterfulgtAvAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/afp/offentlig/pre2025/api/TpoAfpEtterfulgtAvAlderspensjonController.kt
@@ -23,6 +23,8 @@ import no.nav.pensjon.simulator.person.Pid
 import no.nav.pensjon.simulator.statistikk.StatistikkService
 import no.nav.pensjon.simulator.tech.sporing.web.SporingInterceptor
 import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.tech.validation.InvalidEnumValueException
+import no.nav.pensjon.simulator.tech.web.BadRequestException
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
 import no.nav.pensjon.simulator.validity.BadSpecException
@@ -30,6 +32,7 @@ import no.nav.pensjon.simulator.validity.InternDataInkonsistensException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.time.format.DateTimeParseException
 
 /**
  * REST-controller for simulering av "gammel" (pre-2025) offentlig AFP etterfulgt av alderspensjon (kapittel 19).
@@ -120,28 +123,52 @@ class TpoAfpEtterfulgtAvAlderspensjonController(
             log.info(e) { "$FUNCTION_ID utilstrekkelig trygdetid - request - $specV0" }
             tomResponsMedAarsak(AarsakIkkeSuccessV0.UTILSTREKKELIG_TRYGDETID)
         } catch (e: EgressException) {
-            handle(e)!!
+            log.error(e) { "$FUNCTION_ID error calling backside service - request - $specV0" }
+            throw e
         } finally {
             traceAid.end()
         }
     }
 
-    @ExceptionHandler(value = [BadSpecException::class])
-    private fun handleBadRequest(e: RuntimeException): ResponseEntity<TpoSimuleringErrorDto> =
-        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorDto(e.message!!))
+    override fun errorMessage() = ERROR_MESSAGE
 
     @ExceptionHandler(
         value = [
-            RegelmotorValideringException::class,
+            BadRequestException::class,
+            BadSpecException::class,
+            DateTimeParseException::class,
+            InvalidEnumValueException::class
+        ]
+    )
+    private fun handleBadRequest(e: RuntimeException): ResponseEntity<TpoSimuleringErrorDto> =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorDto(e))
+
+    @ExceptionHandler(
+        value = [
+            PersonForGammelException::class,
+            PersonForUngException::class,
+            Pre2025OffentligAfpAvslaattException::class,
+            UtilstrekkeligOpptjeningException::class,
+            UtilstrekkeligTrygdetidException::class
+        ]
+    )
+    private fun handleUnprocessableEntity(e: RuntimeException): ResponseEntity<TpoSimuleringErrorDto> =
+        ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(errorDto(e))
+
+    @ExceptionHandler(
+        value = [
+            FeilISimuleringsgrunnlagetException::class,
             ImplementationUnrecoverableException::class,
             InternDataInkonsistensException::class,
+            InvalidArgumentException::class,
+            KonsistensenIGrunnlagetErFeilException::class,
+            RegelmotorValideringException::class,
+            EgressException::class,
             Exception::class
         ]
     )
     fun handleInternalServerError(e: RuntimeException): ResponseEntity<TpoSimuleringErrorDto> =
         ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorDto(e))
-
-    override fun errorMessage() = ERROR_MESSAGE
 
     /**
      * Ref. PEN JsonErrorEntityBuilder.createErrorEntity
@@ -153,9 +180,8 @@ class TpoAfpEtterfulgtAvAlderspensjonController(
         private const val FUNCTION_ID = "afp-etterf-av-ap-tpo-v0"
 
         private fun errorDto(e: RuntimeException) =
-            TpoSimuleringErrorDto(feil = e.javaClass.simpleName)
-
-        private fun errorDto(error: String) =
-            TpoSimuleringErrorDto(feil = ERROR_MESSAGE) // no sensitive data here
+            TpoSimuleringErrorDto(
+                feil = e.javaClass.simpleName // no sensitive data here
+            )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/api/BeholdningController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/api/BeholdningController.kt
@@ -20,6 +20,7 @@ import no.nav.pensjon.simulator.generelt.organisasjon.OrganisasjonsnummerProvide
 import no.nav.pensjon.simulator.statistikk.StatistikkService
 import no.nav.pensjon.simulator.tech.sporing.web.SporingInterceptor
 import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.tech.validation.InvalidEnumValueException
 import no.nav.pensjon.simulator.tech.web.BadRequestException
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
@@ -28,6 +29,7 @@ import no.nav.pensjon.simulator.validity.InternDataInkonsistensException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.time.format.DateTimeParseException
 
 @RestController
 @RequestMapping("api")
@@ -113,35 +115,47 @@ class BeholdningController(
             log.info(e) { "$FUNCTION_ID utilstrekkelig trygdetid - request - $specV1" }
             throw e // delegate handling to ExceptionHandler to avoid returning ResponseEntity<Any>
         } catch (e: EgressException) {
-            handle(e)!!
+            log.error(e) { "$FUNCTION_ID error calling backside service - request - $specV1" }
+            throw e
         } finally {
             traceAid.end()
         }
     }
 
+    override fun errorMessage() = ERROR_MESSAGE
+
     @ExceptionHandler(
         value = [
             BadRequestException::class,
             BadSpecException::class,
-            FeilISimuleringsgrunnlagetException::class,
-            InvalidArgumentException::class,
-            KanIkkeBeregnesException::class,
-            KonsistensenIGrunnlagetErFeilException::class,
-            PersonForGammelException::class,
-            PersonForUngException::class,
-            Pre2025OffentligAfpAvslaattException::class,
-            RegelmotorValideringException::class,
-            UtilstrekkeligOpptjeningException::class,
-            UtilstrekkeligTrygdetidException::class
+            DateTimeParseException::class,
+            InvalidEnumValueException::class
         ]
     )
-    fun handleBadRequest(e: RuntimeException): ResponseEntity<FolketrygdBeholdningErrorV1> =
+    private fun handleBadRequest(e: RuntimeException): ResponseEntity<FolketrygdBeholdningErrorV1> =
         ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorV1(e))
 
     @ExceptionHandler(
         value = [
+            PersonForGammelException::class,
+            PersonForUngException::class,
+            Pre2025OffentligAfpAvslaattException::class,
+            UtilstrekkeligOpptjeningException::class,
+            UtilstrekkeligTrygdetidException::class
+        ]
+    )
+    private fun handleUnprocessableEntity(e: RuntimeException): ResponseEntity<FolketrygdBeholdningErrorV1> =
+        ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(errorV1(e))
+
+    @ExceptionHandler(
+        value = [
+            FeilISimuleringsgrunnlagetException::class,
             ImplementationUnrecoverableException::class,
             InternDataInkonsistensException::class,
+            InvalidArgumentException::class,
+            KonsistensenIGrunnlagetErFeilException::class,
+            RegelmotorValideringException::class,
+            EgressException::class,
             Exception::class
         ]
     )
@@ -150,10 +164,8 @@ class BeholdningController(
 
     fun errorV1(e: RuntimeException) =
         FolketrygdBeholdningErrorV1(
-            beskrivelse = ERROR_MESSAGE // no sensitive data here
+            beskrivelse = e.javaClass.simpleName // no sensitive data here
         )
-
-    override fun errorMessage() = ERROR_MESSAGE
 
     data class FolketrygdBeholdningErrorV1(
         val beskrivelse: String

--- a/src/main/kotlin/no/nav/pensjon/simulator/beholdning/api/BeholdningController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/beholdning/api/BeholdningController.kt
@@ -24,6 +24,7 @@ import no.nav.pensjon.simulator.tech.web.BadRequestException
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
 import no.nav.pensjon.simulator.validity.BadSpecException
+import no.nav.pensjon.simulator.validity.InternDataInkonsistensException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -81,6 +82,9 @@ class BeholdningController(
         } catch (e: ImplementationUnrecoverableException) {
             log.error(e) { "$FUNCTION_ID unrecoverable error - request - $specV1" }
             throw e // delegate handling to ExceptionHandler to avoid returning ResponseEntity<Any>
+        } catch (e: InternDataInkonsistensException) {
+            log.warn(e) { "$FUNCTION_ID intern datainkonsistens - request - $specV1" }
+            throw e // delegate handling to ExceptionHandler to avoid returning ResponseEntity<Any>
         } catch (e: InvalidArgumentException) {
             log.warn(e) { "$FUNCTION_ID invalid argument - request - $specV1" }
             throw e // delegate handling to ExceptionHandler to avoid returning ResponseEntity<Any>
@@ -136,7 +140,9 @@ class BeholdningController(
 
     @ExceptionHandler(
         value = [
-            ImplementationUnrecoverableException::class
+            ImplementationUnrecoverableException::class,
+            InternDataInkonsistensException::class,
+            Exception::class
         ]
     )
     fun handleInternalServerError(e: RuntimeException): ResponseEntity<FolketrygdBeholdningErrorV1> =

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/web/WebConfiguration.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/web/WebConfiguration.kt
@@ -8,13 +8,17 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-open class WebConfiguration(val sporingsloggService: SporingsloggService, private val featureToggleService: FeatureToggleService) : WebMvcConfigurer {
+class WebConfiguration(
+    private val sporingsloggService: SporingsloggService,
+    private val featureToggleService: FeatureToggleService
+) : WebMvcConfigurer {
 
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(SporingInterceptor(sporingsloggService))
             .addPathPatterns(
                 "/api/v0/simuler-afp-etterfulgt-av-alderspensjon",
                 "/api/v4/simuler-alderspensjon",
+                "/api/v2/simuler-alderspensjon-privat-afp",
                 "/api/v1/simuler-folketrygdbeholdning",
                 "/api/v0/simuler-folketrygdberegnet-afp",
                 "/api/v1/tidligst-mulig-uttak"


### PR DESCRIPTION
Hovedendring (commit 1): Skrur på sporingslogging for tjenesten `simuler-alderspensjon-privat-afp` (brukes av Norsk Pensjon).

Commit 2: Eksplisitt håndtering av `InternDataInkonsistensException` i API-ene for eksterne samhandlere. Det gjør at feilhåndteringen kontrolleres av vår kode, ikke av Spring-rammeverket. (Del av TPP-478)