### PR TITLE
TPP-462 Sporingslogg simuler-alderspensjon-privat-afp

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/gdpr/PersonvernAdmin.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/gdpr/PersonvernAdmin.kt
@@ -1,0 +1,13 @@
+package no.nav.pensjon.simulator.gdpr
+
+/**
+ * Administrative verdier for personvern.
+ */
+object PersonvernAdmin {
+
+    /**
+     * Behandlingsnummer i Navs behandlingskatalog, ref.
+     * behandlingskatalog.nais.adeo.no/process/team/d55cc783-7850-4606-9ff6-1fc44b646c9d/91a4e540-5e39-4c10-971f-49b48f35fe11
+     */
+    const val BEHANDLINGSNUMMER = "B353" // Simulering av pensjon
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/person/client/pdl/PdlGeneralPersonClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/person/client/pdl/PdlGeneralPersonClient.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.simulator.person.client.pdl
 import com.github.benmanes.caffeine.cache.Cache
 import mu.KotlinLogging
 import no.nav.pensjon.simulator.common.client.ExternalServiceClient
+import no.nav.pensjon.simulator.gdpr.PersonvernAdmin.BEHANDLINGSNUMMER
 import no.nav.pensjon.simulator.person.Person
 import no.nav.pensjon.simulator.person.Pid
 import no.nav.pensjon.simulator.person.client.GeneralPersonClient
@@ -77,9 +78,6 @@ class PdlGeneralPersonClient(
     companion object {
         private const val RESOURCE = "graphql"
         private const val THEME = "PEN"
-
-        // https://behandlingskatalog.nais.adeo.no/process/team/d55cc783-7850-4606-9ff6-1fc44b646c9d/91a4e540-5e39-4c10-971f-49b48f35fe11
-        private const val BEHANDLINGSNUMMER = "B353"
         private val service = EgressService.PERSONDATA
 
         private fun personaliaQuery(pid: Pid) = """{

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/SporingsloggService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/SporingsloggService.kt
@@ -3,10 +3,10 @@ package no.nav.pensjon.simulator.tech.sporing
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import no.nav.pensjon.simulator.gdpr.PersonvernAdmin.BEHANDLINGSNUMMER
 import no.nav.pensjon.simulator.generelt.organisasjon.Organisasjonsnummer
 import no.nav.pensjon.simulator.generelt.organisasjon.OrganisasjonsnummerProvider
 import no.nav.pensjon.simulator.person.Pid
-import no.nav.pensjon.simulator.tech.metric.Organisasjoner
 import no.nav.pensjon.simulator.tech.security.SecurityCoroutineContext
 import no.nav.pensjon.simulator.tech.sporing.client.SporingsloggClient
 import org.springframework.stereotype.Service
@@ -28,8 +28,8 @@ class SporingsloggService(
                 Sporing(
                     pid,
                     mottaker = organisasjonsnummer,
-                    tema = "PEK",
-                    behandlingGrunnlag = "B353",
+                    tema = TEMA,
+                    behandlingGrunnlag = BEHANDLINGSNUMMER,
                     uthentingTidspunkt = LocalDateTime.now(),
                     dataForespoersel,
                     leverteData
@@ -47,13 +47,17 @@ class SporingsloggService(
                 Sporing(
                     pid,
                     mottaker = organisasjonsnummer,
-                    tema = "PEK",
-                    behandlingGrunnlag = "B353",
+                    tema = TEMA,
+                    behandlingGrunnlag = BEHANDLINGSNUMMER,
                     uthentingTidspunkt = LocalDateTime.now(),
-                    "",
+                    dataForespoersel = "",
                     leverteData
                 )
             )
         }
+    }
+
+    private companion object {
+        private const val TEMA: String = "PEK" // Pensjonskalkulator
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/web/WebConfiguration.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/sporing/web/WebConfiguration.kt
@@ -8,13 +8,17 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-open class WebConfiguration(val sporingsloggService: SporingsloggService, private val featureToggleService: FeatureToggleService) : WebMvcConfigurer {
+class WebConfiguration(
+    private val sporingsloggService: SporingsloggService,
+    private val featureToggleService: FeatureToggleService
+) : WebMvcConfigurer {
 
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(SporingInterceptor(sporingsloggService))
             .addPathPatterns(
                 "/api/v0/simuler-afp-etterfulgt-av-alderspensjon",
                 "/api/v4/simuler-alderspensjon",
+                "/api/v2/simuler-alderspensjon-privat-afp",
                 "/api/v1/simuler-folketrygdbeholdning",
                 "/api/v0/simuler-folketrygdberegnet-afp",
                 "/api/v1/tidligst-mulig-uttak"


### PR DESCRIPTION
Hovedendring (commit 1): Skrur på sporingslogging for tjenesten `simuler-alderspensjon-privat-afp` (brukes av Norsk Pensjon). Har verifisert at det logges i testmiljø.

Commit 2: Oppretter en felles konstant for behandlingsnummer.