### PR TITLE
TPP-500 Use consumer ID in regler calls

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContext.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/core/SimulatorContext.kt
@@ -41,9 +41,7 @@ class SimulatorContext(
             regelService.makeRegelCall(
                 request = spec,
                 responseClass = BeregnAlderspensjon2011ForsteUttakResponse::class.java,
-                serviceName = "beregnAlderspensjon2011ForsteUttak",
-                map = null,
-                sakId = sakId?.toString()
+                serviceName = "beregnAlderspensjon2011ForsteUttak"
             )
 
         validerResponse(response.pakkseddel, spec, "beregnAlderspensjon2011FoersteUttak")
@@ -63,9 +61,7 @@ class SimulatorContext(
             regelService.makeRegelCall(
                 request = spec,
                 responseClass = BeregnAlderspensjon2016ForsteUttakResponse::class.java,
-                serviceName = "beregnAlderspensjon2016ForsteUttak",
-                map = null,
-                sakId = sakId?.toString()
+                serviceName = "beregnAlderspensjon2016ForsteUttak"
             )
 
         validerResponse(response.pakkseddel, spec, "beregnAlderspensjon2016FoersteUttak")
@@ -85,9 +81,7 @@ class SimulatorContext(
             regelService.makeRegelCall(
                 request = spec,
                 responseClass = BeregnAlderspensjon2025ForsteUttakResponse::class.java,
-                serviceName = "beregnAlderspensjon2025ForsteUttak",
-                map = null,
-                sakId = sakId?.toString()
+                serviceName = "beregnAlderspensjon2025ForsteUttak"
             )
 
         validerResponse(response.pakkseddel, spec, "beregnAlderspensjon2025FoersteUttak")
@@ -116,9 +110,7 @@ class SimulatorContext(
                 personOpptjeningsgrunnlagListe = inputList.toMutableList()
             },
             responseClass = BeregnPoengtallBatchResponse::class.java,
-            serviceName = "beregnPoengtallBatch",
-            map = null,
-            sakId = null
+            serviceName = "beregnPoengtallBatch"
         )
 
         val outputList = response.personOpptjeningsgrunnlagListe
@@ -134,9 +126,7 @@ class SimulatorContext(
             regelService.makeRegelCall(
                 request = spec,
                 responseClass = RevurderingAlderspensjon2011Response::class.java,
-                serviceName = "revurderingAlderspensjon2011",
-                map = null,
-                sakId = sakId?.toString()
+                serviceName = "revurderingAlderspensjon2011"
             )
 
         validerResponse(response.pakkseddel, spec, "revurderingAlderspensjon2011")
@@ -151,9 +141,7 @@ class SimulatorContext(
             regelService.makeRegelCall(
                 request = spec,
                 responseClass = RevurderingAlderspensjon2016Response::class.java,
-                serviceName = "revurderingAlderspensjon2016",
-                map = null,
-                sakId = sakId?.toString()
+                serviceName = "revurderingAlderspensjon2016"
             )
 
         validerResponse(response.pakkseddel, spec, "revurderingAlderspensjon2016")
@@ -168,9 +156,7 @@ class SimulatorContext(
             regelService.makeRegelCall(
                 request = spec,
                 responseClass = RevurderingAlderspensjon2025Response::class.java,
-                serviceName = "revurderingAlderspensjon2025",
-                map = null,
-                sakId = sakId?.toString()
+                serviceName = "revurderingAlderspensjon2025"
             )
 
         validerResponse(response.pakkseddel, spec, "revurderingAlderspensjon2025")
@@ -183,9 +169,7 @@ class SimulatorContext(
             regelService.makeRegelCall(
                 request = spec,
                 responseClass = SimuleringResponse::class.java,
-                serviceName,
-                map = null,
-                sakId = null
+                serviceName
             )
 
         return validerOgFerdigstillResponse(response) ?: throw RuntimeException("Simuleringsresultat is null")
@@ -197,9 +181,7 @@ class SimulatorContext(
             regelService.makeRegelCall(
                 request = spec,
                 responseClass = SimuleringResponse::class.java,
-                serviceName = "simulerAFP",
-                map = null,
-                sakId = null
+                serviceName = "simulerAFP"
             )
 
         validerResponse(response.pakkseddel)
@@ -212,9 +194,7 @@ class SimulatorContext(
             regelService.makeRegelCall(
                 request = spec,
                 responseClass = SimuleringResponse::class.java,
-                serviceName = "simulerVilkarsprovAFP",
-                map = null,
-                sakId = null
+                serviceName = "simulerVilkarsprovAFP"
             )
 
         validerResponse(response.pakkseddel)
@@ -231,9 +211,7 @@ class SimulatorContext(
             regelService.makeRegelCall(
                 request = spec,
                 responseClass = VilkarsprovResponse::class.java,
-                serviceName = "vilkarsprovAlderspensjonOver67",
-                map = null,
-                sakId = sakId?.toString()
+                serviceName = "vilkarsprovAlderspensjonOver67"
             )
 
         validerResponse(response.pakkseddel, spec, "vilkaarsproevUbetingetAlderspensjon")
@@ -250,9 +228,7 @@ class SimulatorContext(
         val response: VilkarsprovResponse = regelService.makeRegelCall(
             request = spec,
             responseClass = VilkarsprovResponse::class.java,
-            serviceName = "vilkarsprovAlderspensjon2011",
-            map = null,
-            sakId = sakId?.toString()
+            serviceName = "vilkarsprovAlderspensjon2011"
         )
 
         validerResponse(response.pakkseddel, spec, "vilkarsprovAlderspensjon2011")
@@ -269,9 +245,7 @@ class SimulatorContext(
         val response: VilkarsprovResponse = regelService.makeRegelCall(
             request = spec,
             responseClass = VilkarsprovResponse::class.java,
-            serviceName = "vilkarsprovAlderspensjon2016",
-            map = null,
-            sakId = sakId?.toString()
+            serviceName = "vilkarsprovAlderspensjon2016"
         )
 
         validerResponse(response.pakkseddel, spec, "vilkarsprovAlderspensjon2016")
@@ -288,9 +262,7 @@ class SimulatorContext(
         val response: VilkarsprovResponse = regelService.makeRegelCall(
             request = spec,
             responseClass = VilkarsprovResponse::class.java,
-            serviceName = "vilkarsprovAlderspensjon2025",
-            map = null,
-            sakId = sakId?.toString()
+            serviceName = "vilkarsprovAlderspensjon2025"
         )
 
         validerResponse(response.pakkseddel, spec, "vilkaarsproevAlderspensjon2025")
@@ -303,9 +275,7 @@ class SimulatorContext(
         val response: BeregnAfpPrivatResponse = regelService.makeRegelCall(
             request = spec,
             responseClass = BeregnAfpPrivatResponse::class.java,
-            serviceName = "beregnAfpPrivat",
-            map = null,
-            sakId = sakId?.toString()
+            serviceName = "beregnAfpPrivat"
         )
 
         validerResponse(response.pakkseddel)
@@ -322,9 +292,7 @@ class SimulatorContext(
         val response: TrygdetidResponse = regelService.makeRegelCall(
             request = spec,
             responseClass = TrygdetidResponse::class.java,
-            serviceName = "fastsettTrygdetid",
-            map = null,
-            sakId = sakId?.toString()
+            serviceName = "fastsettTrygdetid"
         )
 
         validerOgFerdigstillResponse(response, kravIsUfoeretrygd, spec, "fastsettTrygdetid")
@@ -350,9 +318,7 @@ class SimulatorContext(
             regelService.makeRegelCall<BeregnPensjonsBeholdningResponse, BeregnPensjonsBeholdningRequest>(
                 request = request,
                 responseClass = BeregnPensjonsBeholdningResponse::class.java,
-                serviceName = "beregnPensjonsBeholdning",
-                map = null,
-                sakId = null
+                serviceName = "beregnPensjonsBeholdning"
             ).also {
                 validerResponse(it.pakkseddel)
                 finishOpptjeningInit(it.beholdninger)
@@ -369,9 +335,7 @@ class SimulatorContext(
         regelService.makeRegelCall(
             request,
             responseClass = HentDelingstallResponse::class.java,
-            serviceName = "delingstall",
-            map = null,
-            sakId = null
+            serviceName = "delingstall"
         )
 
     private fun fetchFreshGrunnbeloep(dato: LocalDate): SatsResponse =
@@ -381,9 +345,7 @@ class SimulatorContext(
                 tomLd = dato
             },
             responseClass = SatsResponse::class.java,
-            serviceName = "hentGrunnbelopListe",
-            map = null,
-            sakId = null
+            serviceName = "hentGrunnbelopListe"
         )
 
     // TODO: May be unnecessary, since this is done in PersonDetalj.finishInit

--- a/src/main/kotlin/no/nav/pensjon/simulator/person/FoedselsnummerUtil.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/person/FoedselsnummerUtil.kt
@@ -3,6 +3,9 @@ package no.nav.pensjon.simulator.person
 object FoedselsnummerUtil {
     private val FOEDSELSNUMMER_REGEX = """[0-9]{2}([0-9]{4})[0-9]{5}""".toRegex()
 
-    fun redact(value: String) =
-        FOEDSELSNUMMER_REGEX.replace(value, "**$1*****")
+    /**
+     * Redakterer fødselsnummer slik at bare de 4 tallene som representerer måned og år forblir synlige.
+     */
+    fun redact(value: String?) =
+        value?.let { FOEDSELSNUMMER_REGEX.replace(it, "**$1*****") }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/regel/client/GenericRegelClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/regel/client/GenericRegelClient.kt
@@ -1,13 +1,10 @@
 package no.nav.pensjon.simulator.regel.client
 
-// PensjonReglerConsumerService
 interface GenericRegelClient {
-    // regelServiceApi
+
     fun <K, T : Any> makeRegelCall(
         request: T,
         responseClass: Class<*>,
-        serviceName: String,
-        map: Map<String, Any>?,
-        sakId: String?
+        serviceName: String
     ): K
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/regel/client/pensjonregler/PensjonReglerGenericRegelClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/regel/client/pensjonregler/PensjonReglerGenericRegelClient.kt
@@ -60,8 +60,7 @@ class PensjonReglerGenericRegelClient(
         return requireNonNull(objectMapper.readValue(requireNonNull(responseBody), responseClass) as T)
     }
 
-    private fun setHeaders(headers: HttpHeaders, sakId: String? = null) {
-        sakId?.let { headers["sakId"] = it }
+    private fun setHeaders(headers: HttpHeaders) {
         headers.contentType = MediaType.APPLICATION_JSON
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
         headers[CustomHttpHeaders.CONSUMER_ID] = "pensjonssimulator"

--- a/src/main/kotlin/no/nav/pensjon/simulator/regel/client/pensjonregler/PensjonReglerGenericRegelClient.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/regel/client/pensjonregler/PensjonReglerGenericRegelClient.kt
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.bodyToMono
 import tools.jackson.databind.json.JsonMapper
 import java.util.Objects.requireNonNull
 
@@ -25,28 +26,22 @@ class PensjonReglerGenericRegelClient(
 ) : ExternalServiceClient(retryAttempts), GenericRegelClient {
     private val webClient = webClientBase.withBaseUrl(baseUrl)
 
-    // regelServiceApi
     override fun <K, T : Any> makeRegelCall(
         request: T,
         responseClass: Class<*>,
-        serviceName: String,
-        map: Map<String, Any>?,
-        sakId: String?
+        serviceName: String
     ): K {
         return try {
-            callPensjonRegler(serviceName, request, responseClass, map, sakId)
+            callPensjonRegler(serviceName, request, responseClass)
         } catch (e: Exception) {
             throw ImplementationUnrecoverableException("Request failed to pensjon-regler", e)
         }
     }
 
-    // pensjonReglerRest
     private fun <T> callPensjonRegler(
         serviceName: String,
         request: Any,
-        responseClass: Class<*>,
-        extra: Map<String, Any>?,
-        sakId: String?
+        responseClass: Class<*>
     ): T {
         val uri = "$BASE_PATH/$serviceName"
 
@@ -58,18 +53,18 @@ class PensjonReglerGenericRegelClient(
             .headers(::setHeaders)
             .bodyValue(request)
             .retrieve()
-            .bodyToMono(String::class.java)
+            .bodyToMono<String>()
             .retryWhen(retryBackoffSpec(uri))
             .block()
 
         return requireNonNull(objectMapper.readValue(requireNonNull(responseBody), responseClass) as T)
     }
 
-    // makeHttpHeaders
     private fun setHeaders(headers: HttpHeaders, sakId: String? = null) {
         sakId?.let { headers["sakId"] = it }
         headers.contentType = MediaType.APPLICATION_JSON
         headers[CustomHttpHeaders.CALL_ID] = traceAid.callId()
+        headers[CustomHttpHeaders.CONSUMER_ID] = "pensjonssimulator"
     }
 
     override fun toString(e: EgressException, uri: String) = "Failed calling $uri"

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/json/JsonMapperExtension.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/json/JsonMapperExtension.kt
@@ -5,7 +5,7 @@ import tools.jackson.databind.json.JsonMapper
 
 fun JsonMapper.writeValueAsRedactedString(value: Any): String =
     try {
-        FoedselsnummerUtil.redact(this.writeValueAsString(value))
+        FoedselsnummerUtil.redact(this.writeValueAsString(value)) ?: ""
     } catch (_: Exception) {
         // should not fail the request
         "Failed to redact value"

--- a/src/main/kotlin/no/nav/pensjon/simulator/tech/web/CustomHttpHeaders.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tech/web/CustomHttpHeaders.kt
@@ -4,6 +4,7 @@ object CustomHttpHeaders {
     const val ANNEN_PERSON_ID = "annenPid"
     const val BEHANDLINGSNUMMER = "behandlingsnummer"
     const val CALL_ID = "Nav-Call-Id"
+    const val CONSUMER_ID = "Nav-Consumer-Id"
     const val EXTERNAL_REQUEST_ID = "x-request-id"
     const val PERSON_ID = "pid"
     const val PID = "fnr" // fødselsnummer

--- a/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/fra2025/service/klp/KlpMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/fra2025/service/klp/KlpMapper.kt
@@ -1,24 +1,17 @@
 package no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.klp
 
-import mu.KotlinLogging
 import no.nav.pensjon.simulator.tech.security.egress.config.EgressService
 import no.nav.pensjon.simulator.tjenestepensjon.fra2025.domain.Ordning
 import no.nav.pensjon.simulator.tjenestepensjon.fra2025.domain.SimulertTjenestepensjon
 import no.nav.pensjon.simulator.tjenestepensjon.fra2025.domain.Utbetalingsperiode
 import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.OffentligTjenestepensjonFra2025SimuleringSpec
 import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.TjenestepensjonInntektSpec
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.klp.acl.FremtidigInntekt
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.klp.acl.KlpSimulerTjenestepensjonRequest
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.klp.acl.KlpSimulerTjenestepensjonResponse
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.klp.acl.KlpTjenestepensjonYtelseType
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.klp.acl.Utbetaling
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.klp.acl.Uttak
+import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.klp.acl.*
 import java.time.LocalDate
 
 object KlpMapper {
 
     private const val ANNEN_TP_ORDNING_BURDE_SIMULERE = "IKKE_SISTE_ORDNING"
-    private val log = KotlinLogging.logger {}
 
     fun toRequestDto(spec: OffentligTjenestepensjonFra2025SimuleringSpec) =
         KlpSimulerTjenestepensjonRequest(
@@ -33,9 +26,8 @@ object KlpMapper {
     fun fromResponseDto(
         response: KlpSimulerTjenestepensjonResponse,
         request: KlpSimulerTjenestepensjonRequest? = null
-    ): SimulertTjenestepensjon {
-        log.info { "Mapping response from KLP $response" }
-        return SimulertTjenestepensjon(
+    ) =
+        SimulertTjenestepensjon(
             tpLeverandoer = EgressService.KLP.description,
             ordningsListe = response.inkludertOrdningListe.map { Ordning(tpNummer = it.tpnr) },
             utbetalingsperioder = response.utbetalingsListe.map(::utbetalingsperiode),
@@ -44,7 +36,6 @@ object KlpMapper {
             erSisteOrdning = response.arsakIngenUtbetaling.none { it.statusKode == ANNEN_TP_ORDNING_BURDE_SIMULERE },
             serviceData = listOf("Request: ${request?.toString()}", "Response: $response")
         )
-    }
 
     private fun heltUttakAlleYtelser(fom: LocalDate) =
         Uttak(
@@ -55,11 +46,7 @@ object KlpMapper {
 
     private fun inntekter(spec: OffentligTjenestepensjonFra2025SimuleringSpec): MutableList<FremtidigInntekt> {
         val inntektListe = mutableListOf(naaverendeInntekt(aarligInntekt = spec.sisteInntekt))
-
-        inntektListe.addAll(
-            spec.fremtidigeInntekter.map(::inntekt)
-        )
-
+        inntektListe.addAll(spec.fremtidigeInntekter.map(::inntekt))
         return inntektListe
     }
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/fra2025/service/spk/SpkMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/fra2025/service/spk/SpkMapper.kt
@@ -1,23 +1,15 @@
 package no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.spk
 
-import mu.KotlinLogging
 import no.nav.pensjon.simulator.tech.security.egress.config.EgressService
 import no.nav.pensjon.simulator.tjenestepensjon.fra2025.domain.Ordning
 import no.nav.pensjon.simulator.tjenestepensjon.fra2025.domain.SimulertTjenestepensjon
 import no.nav.pensjon.simulator.tjenestepensjon.fra2025.domain.Utbetalingsperiode
 import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.OffentligTjenestepensjonFra2025SimuleringSpec
 import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.TjenestepensjonInntektSpec
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.spk.acl.Delytelse
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.spk.acl.FremtidigInntekt
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.spk.acl.SpkSimulerTjenestepensjonRequest
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.spk.acl.SpkSimulerTjenestepensjonResponse
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.spk.acl.SpkTjenestepensjonYtelseType
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.spk.acl.Utbetaling
-import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.spk.acl.Uttak
+import no.nav.pensjon.simulator.tjenestepensjon.fra2025.service.spk.acl.*
 import java.time.LocalDate
 
 object SpkMapper {
-    private val log = KotlinLogging.logger {}
 
     fun toRequestDto(spec: OffentligTjenestepensjonFra2025SimuleringSpec) =
         SpkSimulerTjenestepensjonRequest(
@@ -32,9 +24,8 @@ object SpkMapper {
     fun fromResponseDto(
         response: SpkSimulerTjenestepensjonResponse,
         request: SpkSimulerTjenestepensjonRequest? = null
-    ): SimulertTjenestepensjon {
-        log.info { "Mapping response from SPK $response" }
-        return SimulertTjenestepensjon(
+    ) =
+        SimulertTjenestepensjon(
             tpLeverandoer = EgressService.SPK.description,
             ordningsListe = response.inkludertOrdningListe.map { Ordning(tpNummer = it.tpnr) },
             utbetalingsperioder = response.utbetalingListe.flatMap(::utbetalingsperioder),
@@ -45,17 +36,14 @@ object SpkMapper {
             erSisteOrdning = response.aarsakIngenUtbetaling.none { it.statusKode == "IKKE_SISTE_ORDNING" }, //TODO enum
             serviceData = listOf("Request: ${request?.toString()}", "Response: $response")
         )
-    }
 
     /**
      * Inntekter f.o.m. fjorårets første dag til siste 'f.o.m.'-dato i listen over fremtidige inntekter.
      */
     private fun inntekter(spec: OffentligTjenestepensjonFra2025SimuleringSpec): List<FremtidigInntekt> {
-        val fremtidigeInntekter: MutableList<FremtidigInntekt> =
-            mutableListOf(naaverendeInntekt(aarligInntekt = spec.sisteInntekt))
-
-        fremtidigeInntekter.addAll(spec.fremtidigeInntekter.map(::inntekt))
-        return fremtidigeInntekter
+        val inntektListe = mutableListOf(naaverendeInntekt(aarligInntekt = spec.sisteInntekt))
+        inntektListe.addAll(spec.fremtidigeInntekter.map(::inntekt))
+        return inntektListe
     }
 
     private fun naaverendeInntekt(aarligInntekt: Int) =
@@ -64,7 +52,7 @@ object SpkMapper {
             aarligInntekt = aarligInntekt
         )
 
-    private fun inntekt(spec: TjenestepensjonInntektSpec): FremtidigInntekt =
+    private fun inntekt(spec: TjenestepensjonInntektSpec) =
         FremtidigInntekt(
             fraOgMedDato = spec.fom,
             aarligInntekt = spec.aarligInntekt

--- a/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/fra2025/service/spk/SpkTjenestepensjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/fra2025/service/spk/SpkTjenestepensjonService.kt
@@ -51,7 +51,6 @@ class SpkTjenestepensjonService(
                 Result.failure(exception = TomSimuleringFraTpOrdningException(tpOrdning = client.service.shortName))
 
             else -> Result.success(value = filtrertTjenestepensjon(tpNummer, pensjon, foedselsdato))
-                .also { logAfp(utbetalingsliste = pensjon.utbetalingsperioder) }
         }
 
     private fun filtrertTjenestepensjon(
@@ -61,7 +60,7 @@ class SpkTjenestepensjonService(
     ) =
         SimulertTjenestepensjonMedMaanedsUtbetalinger(
             tpLeverandoer = client.service,
-            tpNummer = tpNummer,
+            tpNummer,
             ordningsListe = pensjon.ordningsListe,
             utbetalingsperioder = grupperMedDatoFra(
                 utbetalingsliste = pensjon.utbetalingsperioder.filterNot(::ekskludert),
@@ -76,14 +75,6 @@ class SpkTjenestepensjonService(
             log.warn { it }
             Result.failure(TjenestepensjonSimuleringException(it, client.service.shortName))
         }
-
-    private fun logAfp(utbetalingsliste: List<Utbetalingsperiode>) {
-        val afp = utbetalingsliste.filter { it.ytelseType == TjenestepensjonYtelseType.OFFENTLIG_AFP.kode }
-
-        if (afp.isNotEmpty()) {
-            log.info { "AFP fra ${client.service.shortName}: $afp" }
-        }
-    }
 
     private companion object {
 

--- a/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/stillingsprosent/SpkStillingsprosentService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/tjenestepensjon/pre2025/stillingsprosent/SpkStillingsprosentService.kt
@@ -1,28 +1,23 @@
 package no.nav.pensjon.simulator.tjenestepensjon.pre2025.stillingsprosent
 
 import mu.KotlinLogging
+import no.nav.pensjon.simulator.person.FoedselsnummerUtil.redact
 import no.nav.pensjon.simulator.person.Pid
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.tjenestepensjon.pre2025.stillingsprosent.client.StillingsprosentClient
 import no.nav.pensjon.simulator.tpregisteret.TpOrdning
 import org.springframework.stereotype.Service
-import kotlin.system.measureTimeMillis
 
 @Service
 class SpkStillingsprosentService(private val client: StillingsprosentClient) {
 
     private val log = KotlinLogging.logger {}
 
-    fun getStillingsprosentListe(pid: Pid, tpOrdning: TpOrdning): List<Stillingsprosent> {
-        var stillingsprosentListe: List<Stillingsprosent> = emptyList()
-
+    fun getStillingsprosentListe(pid: Pid, tpOrdning: TpOrdning): List<Stillingsprosent> =
         try {
-            val elapsed = measureTimeMillis { stillingsprosentListe = client.getStillingsprosenter(pid, tpOrdning) }
-            log.info { "Executed call to stillingsprosenter in: $elapsed ms $stillingsprosentListe" }
+            client.getStillingsprosenter(pid, tpOrdning)
         } catch (e: EgressException) {
-            log.warn { "Failed to fetch stillingsprosenter: ${e.message}" }
+            log.warn { "Failed to fetch stillingsprosenter: ${redact(e.message)}" }
+            emptyList()
         }
-
-        return stillingsprosentListe
-    }
 }

--- a/src/test/kotlin/no/nav/pensjon/simulator/core/SimulatorContextTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/core/SimulatorContextTest.kt
@@ -411,7 +411,7 @@ class SimulatorContextTest : ShouldSpec({
             // Regelservice skal kun kalles én gang pga. caching
             verify(exactly = 1) {
                 regelmotor.makeRegelCall<SatsResponse, HentGrunnbelopListeRequest>(
-                    any(), any(), eq("hentGrunnbelopListe"), any(), any()
+                    any(), any(), eq("hentGrunnbelopListe")
                 )
             }
         }
@@ -456,7 +456,7 @@ private inline fun <K, reified T : Any> arrangeRegler(response: K): GenericRegel
     mockk<GenericRegelClient>().apply {
         every {
             makeRegelCall<K, T>(
-                any(), any(), any(), any(), any()
+                any(), any(), any()
             )
         } returns response
     }
@@ -465,7 +465,7 @@ private inline fun <K, reified T : Any> arrangeRegler(serviceName: String, respo
     mockk<GenericRegelClient>().apply {
         every {
             makeRegelCall<K, T>(
-                any(), any(), eq(serviceName), any(), any()
+                any(), any(), eq(serviceName)
             )
         } returns response
     }

--- a/src/test/kotlin/no/nav/pensjon/simulator/person/FoedselsnummerUtilTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/person/FoedselsnummerUtilTest.kt
@@ -1,0 +1,11 @@
+package no.nav.pensjon.simulator.person
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+
+class FoedselsnummerUtilTest : ShouldSpec({
+
+    should("redaktere fødselsnummer slik at bare de 4 tallene som representerer måned og år forblir synlige") {
+        FoedselsnummerUtil.redact("15126512345") shouldBe "**1265*****"
+    }
+})


### PR DESCRIPTION
Hovedendring (commit 1):
- Angir consumer-ID i kall til pensjon-regler
- Fjerner ubrukte funksjonsargumenter (`map` og `sakId`)

Commit 2:
- Reduserer mengden av info-logging
- Redakterer exception-message før den logges (i `SpkStillingsprosentService`)
- Litt opprydding i kode

Commit 3 (etter copilot-review):
- Fjerner ubrukt funksjonsargument (`sakId`)