### PR TITLE
TPP-478 Handle malformed JSON in TMU endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>${okhttp3.version}</version>
@@ -313,6 +318,12 @@
             <groupId>io.mockk</groupId>
             <artifactId>mockk-jvm</artifactId>
             <version>1.14.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.ninja-squad</groupId>
+            <artifactId>springmockk</artifactId>
+            <version>5.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/NavAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/NavAlderspensjonController.kt
@@ -141,7 +141,7 @@ class NavAlderspensjonController(
                 opptjeningGrunnlagListe = emptyList(),
                 error = NavSimuleringErrorV3(
                     exception = e.javaClass.simpleName,
-                    message = extractMessageRecursively(e)
+                    message = extractExceptionNames(e)
                 )
             )
     }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/NavAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/NavAlderspensjonController.kt
@@ -22,6 +22,7 @@ import no.nav.pensjon.simulator.tech.trace.TraceAid
 import no.nav.pensjon.simulator.tech.validation.InvalidEnumValueException
 import no.nav.pensjon.simulator.tech.web.BadRequestException
 import no.nav.pensjon.simulator.tech.web.EgressException
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractExceptionNames
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/NavViaPenAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/NavViaPenAlderspensjonController.kt
@@ -105,10 +105,10 @@ class NavViaPenAlderspensjonController(
             log.warn(e) { "$AP_FUNCTION_ID bad request - $specV2" }
             throw e // delegate handling to ExceptionHandler to avoid returning ResponseEntity<Any>
         } catch (e: BadSpecException) {
-            log.warn { "$AP_FUNCTION_ID bad spec - ${extractMessageRecursively(e)} - $specV2" } // not log.warn(e)
+            log.warn { "$AP_FUNCTION_ID bad spec - ${extractExceptionNames(e)} - $specV2" } // not log.warn(e)
             throw e
         } catch (e: DateTimeParseException) {
-            log.warn { "$AP_FUNCTION_ID feil datoformat (forventet yyyy-mm-dd) - ${extractMessageRecursively(e)} - request: $specV2" }
+            log.warn { "$AP_FUNCTION_ID feil datoformat (forventet yyyy-mm-dd) - ${extractExceptionNames(e)} - request: $specV2" }
             throw e
         } catch (e: FeilISimuleringsgrunnlagetException) {
             log.warn(e) { "$AP_FUNCTION_ID feil i simuleringsgrunnlaget - request - $specV2" }
@@ -200,10 +200,10 @@ class NavViaPenAlderspensjonController(
             log.warn(e) { "$TP_FUNCTION_ID bad request - $specV2" }
             throw e // delegate handling to ExceptionHandler to avoid returning ResponseEntity<Any>
         } catch (e: BadSpecException) {
-            log.warn { "$TP_FUNCTION_ID bad spec - ${extractMessageRecursively(e)} - $specV2" } // not log.warn(e)
+            log.warn { "$TP_FUNCTION_ID bad spec - ${extractExceptionNames(e)} - $specV2" } // not log.warn(e)
             throw e
         } catch (e: DateTimeParseException) {
-            log.warn { "$TP_FUNCTION_ID feil datoformat (forventet yyyy-mm-dd) - ${extractMessageRecursively(e)} - request: $specV2" }
+            log.warn { "$TP_FUNCTION_ID feil datoformat (forventet yyyy-mm-dd) - ${extractExceptionNames(e)} - request: $specV2" }
             throw e
         } catch (e: FeilISimuleringsgrunnlagetException) {
             log.warn(e) { "$TP_FUNCTION_ID feil i simuleringsgrunnlaget - request - $specV2" }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/NavViaPenAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/viapen/NavViaPenAlderspensjonController.kt
@@ -33,6 +33,7 @@ import no.nav.pensjon.simulator.tech.validation.InvalidEnumValueException
 import no.nav.pensjon.simulator.tech.web.BadRequestException
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.validity.BadSpecException
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractExceptionNames
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/samhandler/SamhandlerAlderspensjonControllerV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/samhandler/SamhandlerAlderspensjonControllerV3.kt
@@ -97,10 +97,10 @@ class SamhandlerAlderspensjonControllerV3(
             log.warn(e) { "$FUNCTION_ID_V3 bad request - $specV3" }
             throw e // delegate handling to ExceptionHandler to avoid returning ResponseEntity<Any>
         } catch (e: BadSpecException) {
-            log.warn { "$FUNCTION_ID_V3 bad spec - ${extractMessageRecursively(e)} - $specV3" } // not log.warn(e)
+            log.warn { "$FUNCTION_ID_V3 bad spec - ${extractExceptionNames(e)} - $specV3" } // not log.warn(e)
             throw e
         } catch (e: DateTimeParseException) {
-            log.warn { "$FUNCTION_ID_V3 feil datoformat (forventet yyyy-mm-dd) - ${extractMessageRecursively(e)} - request: $specV3" }
+            log.warn { "$FUNCTION_ID_V3 feil datoformat (forventet yyyy-mm-dd) - ${extractExceptionNames(e)} - request: $specV3" }
             throw e
         } catch (e: FeilISimuleringsgrunnlagetException) {
             log.warn(e) { "$FUNCTION_ID_V3 feil i simuleringsgrunnlaget - request - $specV3" }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/samhandler/SamhandlerAlderspensjonControllerV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/samhandler/SamhandlerAlderspensjonControllerV3.kt
@@ -22,6 +22,7 @@ import no.nav.pensjon.simulator.tech.web.BadRequestException
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
 import no.nav.pensjon.simulator.validity.BadSpecException
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractExceptionNames
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/viapen/TpoViaPenAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/viapen/TpoViaPenAlderspensjonController.kt
@@ -22,6 +22,7 @@ import no.nav.pensjon.simulator.tech.validation.InvalidEnumValueException
 import no.nav.pensjon.simulator.tech.web.BadRequestException
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.validity.BadSpecException
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractExceptionNames
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/viapen/TpoViaPenAlderspensjonController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/tpo/viapen/TpoViaPenAlderspensjonController.kt
@@ -77,10 +77,10 @@ class TpoViaPenAlderspensjonController(
             log.warn(e) { "$FUNCTION_ID_V1 bad request - $specV1" }
             throw e // delegate handling to ExceptionHandler to avoid returning ResponseEntity<Any>
         } catch (e: BadSpecException) {
-            log.warn { "$FUNCTION_ID_V1 bad spec - ${extractMessageRecursively(e)} - $specV1" } // not log.warn(e)
+            log.warn { "$FUNCTION_ID_V1 bad spec - ${extractExceptionNames(e)} - $specV1" } // not log.warn(e)
             throw e // delegate handling to ExceptionHandler to avoid returning ResponseEntity<Any>
         } catch (e: DateTimeParseException) {
-            log.warn { "$FUNCTION_ID_V1 feil datoformat (forventet yyyy-mm-dd) - ${extractMessageRecursively(e)} - request: $specV1" }
+            log.warn { "$FUNCTION_ID_V1 feil datoformat (forventet yyyy-mm-dd) - ${extractExceptionNames(e)} - request: $specV1" }
             throw e
         } catch (e: FeilISimuleringsgrunnlagetException) {
             log.warn(e) { "$FUNCTION_ID_V1 feil i simuleringsgrunnlaget - request - $specV1" }

--- a/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v1/PensjonForNavController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v1/PensjonForNavController.kt
@@ -21,6 +21,7 @@ import no.nav.pensjon.simulator.tech.json.writeValueAsRedactedString
 import no.nav.pensjon.simulator.tech.trace.TraceAid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.annotation.*
 import tools.jackson.databind.json.JsonMapper
 
@@ -97,18 +98,26 @@ class PensjonForNavController(
 
     override fun errorMessage() = ERROR_MESSAGE
 
+    @ExceptionHandler(value = [HttpMessageNotReadableException::class])
+    private fun handleMalformedRequest(e: Exception): ResponseEntity<SimuleringResultDto> =
+        with(ProblemTypeDto.ANNEN_KLIENTFEIL) {
+            log.warn(e) { "$FUNCTION_ID - request not readable - ${extractUnsafeMessages(e)}" }
+            ResponseEntity.status(this.httpStatus).body(problem(type = this, beskrivelse = extractSafeMessage(e)))
+        }
+
     @ExceptionHandler(value = [Exception::class])
-    private fun internalError(e: Exception): ResponseEntity<SimuleringResultDto> =
+    private fun handleInternalError(e: Exception): ResponseEntity<SimuleringResultDto> =
         with(ProblemTypeDto.ANNEN_SERVERFEIL) {
-            ResponseEntity.status(this.httpStatus).body(problem(e, type = this))
+            log.error(e) { "$FUNCTION_ID - unknown error - ${extractUnsafeMessages(e)}" }
+            ResponseEntity.status(this.httpStatus).body(problem(type = this, beskrivelse = extractExceptionNames(e)))
         }
 
     private companion object {
         private const val TJENESTE = "intern simulering av pensjon"
         private const val ERROR_MESSAGE = "feil ved $TJENESTE"
-        private const val FUNCTION_ID = "int-pen" // Nav-intern simulering av pensjon
+        private const val FUNCTION_ID = "int-pen-v1" // Nav-intern simulering av pensjon
 
-        private fun problem(e: Exception, type: ProblemTypeDto) =
+        private fun problem(type: ProblemTypeDto, beskrivelse: String) =
             SimuleringResultDto(
                 alderspensjonListe = emptyList(),
                 alderspensjonMaanedsbeloep = null,
@@ -118,7 +127,7 @@ class PensjonForNavController(
                 vilkaarsproevingsresultat = VilkaarsproevingsresultatDto(erInnvilget = false, alternativ = null),
                 primaerTrygdetid = null,
                 pensjonsgivendeInntektListe = emptyList(),
-                problem = ProblemDto(kode = type, beskrivelse = extractMessageRecursively(e))
+                problem = ProblemDto(kode = type, beskrivelse)
             )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v1/PensjonForNavController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v1/PensjonForNavController.kt
@@ -19,6 +19,9 @@ import no.nav.pensjon.simulator.api.nav.v1.acl.result.VilkaarsproevingsresultatD
 import no.nav.pensjon.simulator.statistikk.StatistikkService
 import no.nav.pensjon.simulator.tech.json.writeValueAsRedactedString
 import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractExceptionNames
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractSafeMessage
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractUnsafeMessages
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException

--- a/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/PensjonForNavV2Controller.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/PensjonForNavV2Controller.kt
@@ -19,6 +19,9 @@ import no.nav.pensjon.simulator.api.nav.v2.acl.result.VilkaarsproevingsresultatD
 import no.nav.pensjon.simulator.statistikk.StatistikkService
 import no.nav.pensjon.simulator.tech.json.writeValueAsRedactedString
 import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractExceptionNames
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractSafeMessage
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractUnsafeMessages
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException

--- a/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/PensjonForNavV2Controller.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/PensjonForNavV2Controller.kt
@@ -21,6 +21,7 @@ import no.nav.pensjon.simulator.tech.json.writeValueAsRedactedString
 import no.nav.pensjon.simulator.tech.trace.TraceAid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.annotation.*
 import tools.jackson.databind.json.JsonMapper
 
@@ -97,18 +98,26 @@ class PensjonForNavV2Controller(
 
     override fun errorMessage() = ERROR_MESSAGE
 
+    @ExceptionHandler(value = [HttpMessageNotReadableException::class])
+    private fun handleMalformedRequest(e: Exception): ResponseEntity<SimuleringResultDto> =
+        with(ProblemTypeDto.ANNEN_KLIENTFEIL) {
+            log.warn(e) { "$FUNCTION_ID - request not readable - ${extractUnsafeMessages(e)}" }
+            ResponseEntity.status(this.httpStatus).body(problem(type = this, beskrivelse = extractSafeMessage(e)))
+        }
+
     @ExceptionHandler(value = [Exception::class])
-    private fun internalError(e: Exception): ResponseEntity<SimuleringResultDto> =
+    private fun handleInternalError(e: Exception): ResponseEntity<SimuleringResultDto> =
         with(ProblemTypeDto.ANNEN_SERVERFEIL) {
-            ResponseEntity.status(this.httpStatus).body(problem(e, type = this))
+            log.error(e) { "$FUNCTION_ID - unknown error - ${extractUnsafeMessages(e)}" }
+            ResponseEntity.status(this.httpStatus).body(problem(type = this, beskrivelse = extractExceptionNames(e)))
         }
 
     private companion object {
         private const val TJENESTE = "intern simulering av pensjon"
         private const val ERROR_MESSAGE = "feil ved $TJENESTE"
-        private const val FUNCTION_ID = "int-pen" // Nav-intern simulering av pensjon
+        private const val FUNCTION_ID = "int-pen-v2" // Nav-intern simulering av pensjon
 
-        private fun problem(e: Exception, type: ProblemTypeDto) =
+        private fun problem(type: ProblemTypeDto, beskrivelse: String) =
             SimuleringResultDto(
                 alderspensjonListe = emptyList(),
                 alderspensjonMaanedsbeloep = null,
@@ -119,7 +128,7 @@ class PensjonForNavV2Controller(
                 vilkaarsproevingsresultat = VilkaarsproevingsresultatDto(erInnvilget = false, alternativ = null),
                 primaerTrygdetid = null,
                 pensjonsgivendeInntektListe = emptyList(),
-                problem = ProblemDto(kode = type, beskrivelse = extractMessageRecursively(e))
+                problem = ProblemDto(kode = type, beskrivelse)
             )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/common/api/ControllerBase.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/common/api/ControllerBase.kt
@@ -12,12 +12,11 @@ import no.nav.pensjon.simulator.tech.metric.Organisasjoner
 import no.nav.pensjon.simulator.tech.trace.TraceAid
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractExceptionNames
 import org.intellij.lang.annotations.Language
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
-import tools.jackson.databind.exc.MismatchedInputException
 import java.lang.System.currentTimeMillis
-import java.time.format.DateTimeParseException
 
 abstract class ControllerBase(
     private val traceAid: TraceAid,
@@ -167,33 +166,5 @@ abstract class ControllerBase(
     "message": "En feil inntraff",
     "path": "/api/ressurs"
 }"""
-
-        fun extractExceptionNames(e: Throwable): String =
-            StringBuilder(e.javaClass.simpleName).apply {
-                e.cause?.let { append(" | Cause: ").append(extractExceptionNames(it)) }
-            }.toString()
-
-        fun extractSafeMessage(e: Throwable): String =
-            (if (safeExceptions.any { it.isInstance(e) }) e.message else e.cause?.let(::extractSafeMessage))
-                ?: e.javaClass.simpleName
-
-        /**
-         * NB: Use with caution, since 'message' may contain sensitive information.
-         * Should only be used for internal logging purposes, not for user-facing messages.
-         */
-        fun extractUnsafeMessages(e: Throwable): String =
-            StringBuilder(e.message ?: e.javaClass.simpleName).apply {
-                e.cause?.let { append(" | Cause: ").append(extractUnsafeMessages(it)) }
-            }.toString()
-
-        /**
-         * Exception types whose messages are considered never to contain sensitive information
-         * and are therefore safe to expose to external clients.
-         */
-        private val safeExceptions = setOf(
-            DateTimeParseException::class.java,
-            MismatchedInputException::class.java,
-            NullPointerException::class.java
-        )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/common/api/ControllerBase.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/common/api/ControllerBase.kt
@@ -3,18 +3,19 @@ package no.nav.pensjon.simulator.common.api
 import mu.KotlinLogging
 import no.nav.pensjon.simulator.core.domain.regler.enum.SimuleringTypeEnum
 import no.nav.pensjon.simulator.generelt.organisasjon.Organisasjonsnummer
-import no.nav.pensjon.simulator.person.Pid
-import no.nav.pensjon.simulator.tech.metric.Metrics
-import no.nav.pensjon.simulator.tech.metric.Organisasjoner
 import no.nav.pensjon.simulator.generelt.organisasjon.OrganisasjonsnummerProvider
+import no.nav.pensjon.simulator.person.Pid
 import no.nav.pensjon.simulator.statistikk.SimuleringHendelse
 import no.nav.pensjon.simulator.statistikk.StatistikkService
+import no.nav.pensjon.simulator.tech.metric.Metrics
+import no.nav.pensjon.simulator.tech.metric.Organisasjoner
 import no.nav.pensjon.simulator.tech.trace.TraceAid
 import no.nav.pensjon.simulator.tech.web.EgressException
 import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
 import org.intellij.lang.annotations.Language
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
+import tools.jackson.databind.exc.MismatchedInputException
 import java.lang.System.currentTimeMillis
 import java.time.format.DateTimeParseException
 
@@ -173,7 +174,7 @@ abstract class ControllerBase(
             }.toString()
 
         fun extractSafeMessage(e: Throwable): String =
-            (if (safeExceptions.contains(e::class.java)) e.message else e.cause?.let(::extractSafeMessage))
+            (if (safeExceptions.any { it.isInstance(e) }) e.message else e.cause?.let(::extractSafeMessage))
                 ?: e.javaClass.simpleName
 
         /**
@@ -191,6 +192,7 @@ abstract class ControllerBase(
          */
         private val safeExceptions = setOf(
             DateTimeParseException::class.java,
+            MismatchedInputException::class.java,
             NullPointerException::class.java
         )
     }

--- a/src/main/kotlin/no/nav/pensjon/simulator/common/api/ControllerBase.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/common/api/ControllerBase.kt
@@ -16,6 +16,7 @@ import org.intellij.lang.annotations.Language
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 import java.lang.System.currentTimeMillis
+import java.time.format.DateTimeParseException
 
 abstract class ControllerBase(
     private val traceAid: TraceAid,
@@ -60,7 +61,7 @@ abstract class ControllerBase(
             handleExternalError<T>(e)
 
     protected fun <T> badRequest(e: RuntimeException): T {
-        val message = extractMessageRecursively(e)
+        val message = extractExceptionNames(e)
         log.info { "Bad request - $message" } // no error, so the stacktrace is not logged
 
         throw ResponseStatusException(
@@ -132,7 +133,7 @@ abstract class ControllerBase(
 
         throw ResponseStatusException(
             HttpStatus.INTERNAL_SERVER_ERROR,
-            "Call ID: ${traceAid.callId()} | Error: ${errorMessage()} | Details: ${extractMessageRecursively(e)}",
+            "Call ID: ${traceAid.callId()} | Error: ${errorMessage()} | Details: ${extractExceptionNames(e)}",
             e
         )
     }
@@ -145,13 +146,13 @@ abstract class ControllerBase(
     private fun <T> serviceUnavailable(e: EgressException): T {
         throw ResponseStatusException(
             HttpStatus.SERVICE_UNAVAILABLE,
-            "Call ID: ${traceAid.callId()} | Error: ${errorMessage()} | Details: ${extractMessageRecursively(e)}",
+            "Call ID: ${traceAid.callId()} | Error: ${errorMessage()} | Details: ${extractExceptionNames(e)}",
             e
         )
     }
 
     private fun logError(e: EgressException, category: String) {
-        log.error { "$category ${errorMessage()} : ${extractMessageRecursively(e)}" }
+        log.error { "$category ${errorMessage()} : ${extractExceptionNames(e)}" }
     }
 
     protected companion object {
@@ -166,9 +167,31 @@ abstract class ControllerBase(
     "path": "/api/ressurs"
 }"""
 
-        fun extractMessageRecursively(e: Throwable): String =
+        fun extractExceptionNames(e: Throwable): String =
             StringBuilder(e.javaClass.simpleName).apply {
-                e.cause?.let { append(" | Cause: ").append(extractMessageRecursively(it)) }
+                e.cause?.let { append(" | Cause: ").append(extractExceptionNames(it)) }
             }.toString()
+
+        fun extractSafeMessage(e: Throwable): String =
+            (if (safeExceptions.contains(e::class.java)) e.message else e.cause?.let(::extractSafeMessage))
+                ?: e.javaClass.simpleName
+
+        /**
+         * NB: Use with caution, since 'message' may contain sensitive information.
+         * Should only be used for internal logging purposes, not for user-facing messages.
+         */
+        fun extractUnsafeMessages(e: Throwable): String =
+            StringBuilder(e.message ?: e.javaClass.simpleName).apply {
+                e.cause?.let { append(" | Cause: ").append(extractUnsafeMessages(it)) }
+            }.toString()
+
+        /**
+         * Exception types whose messages are considered never to contain sensitive information
+         * and are therefore safe to expose to external clients.
+         */
+        private val safeExceptions = setOf(
+            DateTimeParseException::class.java,
+            NullPointerException::class.java
+        )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/generelt/organisasjon/Organisasjonsnummer.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/generelt/organisasjon/Organisasjonsnummer.kt
@@ -3,8 +3,7 @@ package no.nav.pensjon.simulator.generelt.organisasjon
 /**
  * Representerer organisasjonsnummer (no.wikipedia.org/wiki/Organisasjonsnummer)
  */
-@JvmInline
-value class Organisasjonsnummer(val value: String) {
+data class Organisasjonsnummer(val value: String) {
 
     init {
         require(value.length == REQUIRED_LENGTH) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/uttak/UttakService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/uttak/UttakService.kt
@@ -100,7 +100,7 @@ class UttakService(
             TidligstMuligUttak(
                 uttaksdato = null,
                 uttaksgrad = Uttaksgrad.NULL,
-                problem = Problem(type, beskrivelse = "Ukjent feil - ${e.javaClass.simpleName}")
+                problem = Problem(type, beskrivelse = e.javaClass.simpleName)
             )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/uttak/api/UttakController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/uttak/api/UttakController.kt
@@ -18,6 +18,8 @@ import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
 import no.nav.pensjon.simulator.uttak.UttakService
 import no.nav.pensjon.simulator.uttak.api.acl.*
 import no.nav.pensjon.simulator.uttak.api.acl.UttakResultMapperV1.resultV1
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractSafeMessage
+import no.nav.pensjon.simulator.validity.IngressErrorHandler.extractUnsafeMessages
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException

--- a/src/main/kotlin/no/nav/pensjon/simulator/uttak/api/UttakController.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/uttak/api/UttakController.kt
@@ -20,6 +20,7 @@ import no.nav.pensjon.simulator.uttak.api.acl.*
 import no.nav.pensjon.simulator.uttak.api.acl.UttakResultMapperV1.resultV1
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import tools.jackson.databind.json.JsonMapper
@@ -113,22 +114,29 @@ class UttakController(
 
     override fun errorMessage() = ERROR_MESSAGE
 
+    @ExceptionHandler(value = [HttpMessageNotReadableException::class])
+    private fun handleMalformedRequest(e: Exception): ResponseEntity<TidligstMuligUttakResultV1> =
+        with(TidligstMuligUttakFeilTypeV1.ANNEN_KLIENTFEIL) {
+            log.warn(e) { "$FUNCTION_ID - request not readable - ${extractUnsafeMessages(e)}" }
+            ResponseEntity.status(this.httpStatus).body(problem(type = this, beskrivelse = extractSafeMessage(e)))
+        }
+
     @ExceptionHandler(value = [Exception::class])
-    private fun internalError(e: Exception): ResponseEntity<TidligstMuligUttakResultV1> =
-        ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(problem(e))
+    private fun handleInternalError(e: Exception): ResponseEntity<TidligstMuligUttakResultV1> =
+        with(TidligstMuligUttakFeilTypeV1.TEKNISK_FEIL) {
+            log.error(e) { "$FUNCTION_ID - unknown error - ${extractUnsafeMessages(e)}" }
+            ResponseEntity.status(this.httpStatus).body(problem(type = this, beskrivelse = e.javaClass.simpleName))
+        }
 
     private companion object {
         private const val TJENESTE = "simulering for TMU"
         private const val ERROR_MESSAGE = "feil ved $TJENESTE"
         private const val FUNCTION_ID = "tmu"
 
-        private fun problem(e: Exception) =
+        private fun problem(type: TidligstMuligUttakFeilTypeV1, beskrivelse: String) =
             TidligstMuligUttakResultV1(
                 tidligstMuligeUttakstidspunktListe = emptyList(),
-                feil = TidligstMuligUttakFeilV1(
-                    type = TidligstMuligUttakFeilTypeV1.TEKNISK_FEIL,
-                    beskrivelse = e.javaClass.simpleName
-                )
+                feil = TidligstMuligUttakFeilV1(type, beskrivelse)
             )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/validity/IngressErrorHandler.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/validity/IngressErrorHandler.kt
@@ -1,0 +1,49 @@
+package no.nav.pensjon.simulator.validity
+
+import tools.jackson.databind.exc.MismatchedInputException
+import java.time.format.DateTimeParseException
+
+object IngressErrorHandler {
+
+    fun extractExceptionNames(e: Throwable): String =
+        StringBuilder(e.javaClass.simpleName).apply {
+            e.cause?.let { append(" | Cause: ").append(extractExceptionNames(it)) }
+        }.toString()
+
+    fun extractSafeMessage(e: Throwable): String =
+        when {
+            e is NullPointerException -> e.message?.let(::strip)
+            safeExceptions.any { it.isInstance(e) } -> e.message
+            else -> e.cause?.let(::extractSafeMessage)
+        } ?: e.javaClass.simpleName
+
+    /**
+     * NB: Use with caution, since 'message' may contain sensitive information.
+     * Should only be used for internal logging purposes, not for user-facing messages.
+     */
+    fun extractUnsafeMessages(e: Throwable): String =
+        StringBuilder(e.message ?: e.javaClass.simpleName).apply {
+            e.cause?.let { append(" | Cause: ").append(extractUnsafeMessages(it)) }
+        }.toString()
+
+    /**
+     * Kotlin null-check NPEs include internal method/class names; strip down to just the parameter name.
+     */
+    private fun strip(message: String): String =
+        Regex("""parameter ([A-Za-z0-9_]+)\b""")
+            .find(message)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.let { "Missing required parameter: $it" }
+            ?: message
+
+    /**
+     * Exception types whose messages are considered never to contain sensitive information
+     * and are therefore safe to expose to external clients.
+     */
+    private val safeExceptions = setOf(
+        DateTimeParseException::class.java,
+        MismatchedInputException::class.java,
+        NullPointerException::class.java
+    )
+}

--- a/src/test/kotlin/no/nav/pensjon/simulator/api/nav/v2/PensjonForNavV2ControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/api/nav/v2/PensjonForNavV2ControllerTest.kt
@@ -1,0 +1,355 @@
+package no.nav.pensjon.simulator.api.nav.v2
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.ShouldSpec
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.verify
+import no.nav.pensjon.simulator.alder.Alder
+import no.nav.pensjon.simulator.alderspensjon.alternativ.*
+import no.nav.pensjon.simulator.api.nav.v2.acl.spec.SimuleringSpecMapperForNavV2
+import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
+import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.opptjening.OpptjeningGrunnlag
+import no.nav.pensjon.simulator.statistikk.StatistikkService
+import no.nav.pensjon.simulator.tech.sporing.SporingsloggService
+import no.nav.pensjon.simulator.tech.toggle.FeatureToggleService
+import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.testutil.TestObjects
+import no.nav.pensjon.simulator.testutil.TestObjects.emptyKnekkpunkter
+import no.nav.pensjon.simulator.trygdetid.Trygdetid
+import org.intellij.lang.annotations.Language
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
+
+@WebMvcTest(PensjonForNavV2Controller::class)
+class PensjonForNavV2ControllerTest : ShouldSpec() {
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @MockkBean
+    private lateinit var sporingsloggService: SporingsloggService
+
+    @MockkBean
+    private lateinit var feature: FeatureToggleService
+
+    @MockkBean(relaxed = true)
+    private lateinit var traceAid: TraceAid
+
+    @MockkBean
+    private lateinit var simuleringSpecMapper: SimuleringSpecMapperForNavV2
+
+    @MockkBean
+    private lateinit var simuleringFacade: SimuleringFacade
+
+    @MockkBean(relaxed = true)
+    private lateinit var statistikkService: StatistikkService
+
+    init {
+        beforeSpec {
+            every { feature.isEnabled(any()) } returns false // vedlikeholdsmodus deaktivert
+            every { sporingsloggService.log(any(), any(), any()) } returns Unit
+            every { simuleringSpecMapper.fromDto(any()) } returns TestObjects.simuleringSpec
+            every { statistikkService.takeSnapshotIfNeeded() } returns Unit
+            every { traceAid.begin() } returns Unit
+        }
+
+        context("request OK") {
+            should("simulere pensjon") {
+                every {
+                    simuleringFacade.simulerAlderspensjon(any(), any())
+                } returns pensjonMedAlternativ
+
+                mvc.perform(
+                    post(URL)
+                        .with(csrf())
+                        .content(requestBody())
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                    .andExpect(status().isOk())
+                    .andExpect(content().json(OK_RESPONSE_BODY))
+
+                verify { sporingsloggService wasNot Called } // not called in Nav context
+            }
+        }
+
+        context("bad request - bad enum value in JSON") {
+            should("return status 'bad request' and descriptive body") {
+                mvc.perform(
+                    post(URL)
+                        .with(csrf())
+                        .content(requestBody(grad = "TI_PROSENT")) // invalid value
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().json(ERROR_RESPONSE_BODY))
+            }
+        }
+    }
+
+    private companion object {
+
+        private const val URL = "/api/nav/v2/simuler-pensjon"
+
+        @Language("json")
+        private fun requestBody(grad: String = "FEMTI_PROSENT") = """{
+    "simuleringstype": "ALDERSPENSJON_MED_TIDSBEGRENSET_OFFENTLIG_AFP",
+    "pid": "29416429438",
+    "sivilstatus": "UGIFT",
+    "sisteInntekt": 763215,
+    "gradertUttak": {
+        "grad": "$grad",
+        "uttakFomAlder": {
+            "aar": 65,
+            "maaneder": 3
+        },
+        "aarligInntekt": 333000
+    },
+    "heltUttak": {
+        "uttakFomAlder": {
+            "aar": 66,
+            "maaneder": 3
+        },
+        "aarligInntekt": 0,
+        "inntektTomAlder": {
+            "aar": 69,
+            "maaneder": 6
+        }
+    },
+    "utenlandsperiodeListe": [],
+    "eps": {
+        "levende": {
+            "harPensjon": false,
+            "harInntektOver2G": false
+        }
+    },
+    "offentligAfp": {
+        "harInntektMaanedenFoerUttak": false,
+        "afpOrdning": "KOMMUNAL",
+        "innvilgetLivsvarigAfp": null
+    }
+}""".trimIndent()
+
+        @Language("json")
+        private const val OK_RESPONSE_BODY = """{
+  "alderspensjonListe": [{
+    "alderAar": 65,
+    "beloep": 123,
+    "inntektspensjon": 234,
+    "delingstall": 1.2,
+    "pensjonsbeholdningFoerUttak": 456,
+    "sluttpoengtall": 5.6,
+    "poengaarFoer92": 10,
+    "poengaarEtter91": 20,
+    "forholdstall": 0.8,
+    "grunnpensjon": 567,
+    "tilleggspensjon": 678,
+    "pensjonstillegg": 789,
+    "skjermingstillegg": 890,
+    "kapittel19Pensjon": {
+      "andelsbroek": 0.3,
+      "trygdetidAntallAar": 30,
+      "basispensjon": 321,
+      "restpensjon": 876,
+      "gjenlevendetillegg": 321,
+      "minstePensjonsnivaaSats": 0.9
+    },
+    "kapittel20Pensjon": {
+      "andelsbroek": 0.7,
+      "trygdetidAntallAar": 40,
+      "garantipensjon": {
+        "aarligBeloep": 345,
+        "maanedligBeloep": null,
+        "sats": 1.1
+      },
+      "garantitillegg": 432
+    }
+  }],
+  "alderspensjonMaanedsbeloep": {
+    "gradertUttakBeloep": 678,
+    "heltUttakBeloep": 0
+  },
+  "maanedligAlderspensjonForKnekkpunkter": {},
+  "livsvarigOffentligAfpListe": [{
+    "alderAar": 63,
+    "beloep": 901,
+    "maanedligBeloep": 100
+  }],
+  "tidsbegrensetOffentligAfp": {
+    "alderAar": 62,
+    "totaltAfpBeloep": 890,
+    "tidligereArbeidsinntekt": 123,
+    "grunnbeloep": 456,
+    "sluttpoengtall": 7.8,
+    "trygdetid": 30,
+    "poengaarTom1991": 10,
+    "poengaarFom1992": 20,
+    "grunnpensjon": 567,
+    "tilleggspensjon": 678,
+    "afpTillegg": 789,
+    "saertillegg": 890,
+    "afpGrad": 80,
+    "erAvkortet": false
+  },
+  "privatAfpListe": [{
+    "alderAar": 66,
+    "beloep": 789,
+    "kompensasjonstillegg": 123,
+    "kronetillegg": 5,
+    "livsvarig": 93,
+    "maanedligBeloep": 100
+  }],
+  "primaerTrygdetid": {
+    "antallAar": 39,
+    "erUtilstrekkelig": false
+  },
+  "vilkaarsproevingsresultat": {
+    "erInnvilget": false,
+    "alternativ": {
+      "gradertUttakAlder": {
+        "aar": 66,
+        "maaneder": 2
+      },
+      "uttaksgrad": "TJUE_PROSENT",
+      "heltUttakAlder": {
+        "aar": 67,
+        "maaneder": 0
+      }
+    }
+  },
+  "pensjonsgivendeInntektListe": [{
+    "aarstall": 1999,
+    "beloep": 1002
+  }]
+}"""
+
+        @Language("json")
+        private const val ERROR_RESPONSE_BODY = """{
+  "alderspensjonListe": [],
+  "livsvarigOffentligAfpListe": [],
+  "privatAfpListe": [],
+  "vilkaarsproevingsresultat": {
+    "erInnvilget": false
+  },
+  "pensjonsgivendeInntektListe": [],
+  "problem": {
+    "kode": "ANNEN_KLIENTFEIL",
+    "beskrivelse": "Cannot deserialize value of type `no.nav.pensjon.simulator.api.nav.v2.acl.UttaksgradDto` from String \"TI_PROSENT\": not one of the values accepted for Enum class: [FOERTI_PROSENT, SEKSTI_PROSENT, NULL, FEMTI_PROSENT, HUNDRE_PROSENT, AATTI_PROSENT, TJUE_PROSENT]\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); byte offset: #194] (through reference chain: no.nav.pensjon.simulator.api.nav.v2.acl.spec.SimuleringSpecDto[\"gradertUttak\"]->no.nav.pensjon.simulator.api.nav.v2.acl.spec.GradertUttakSpecDto[\"grad\"])"
+  }
+}"""
+
+        private val pensjonMedAlternativ =
+            SimulertPensjonEllerAlternativ(
+                pensjon = SimulertPensjon(
+                    alderspensjon = listOf(
+                        SimulertAarligAlderspensjon(
+                            alderAar = 65,
+                            beloep = 123,
+                            inntektspensjon = 234,
+                            garantipensjon = SimulertGarantipensjon(aarligBeloep = 345, sats = 1.1),
+                            garantitillegg = 432,
+                            delingstall = 1.2,
+                            pensjonBeholdningFoerUttak = 456,
+                            andelsbroekKap19 = 0.3,
+                            andelsbroekKap20 = 0.7,
+                            sluttpoengtall = 5.6,
+                            trygdetidKap19 = 30,
+                            trygdetidKap20 = 40,
+                            poengaarFoer92 = 10,
+                            poengaarEtter91 = 20,
+                            forholdstall = 0.8,
+                            basispensjon = 321,
+                            grunnpensjon = 567,
+                            tilleggspensjon = 678,
+                            restpensjon = 876,
+                            pensjonstillegg = 789,
+                            skjermingstillegg = 890,
+                            kapittel19Gjenlevendetillegg = 321,
+                            minstePensjonsnivaaSats = 0.9
+                        )
+                    ),
+                    maanedligAlderspensjonForKnekkpunkter = emptyKnekkpunkter,
+                    alderspensjonFraFolketrygden = listOf(
+                        SimulertAlderspensjonFraFolketrygden(
+                            datoFom = LocalDate.of(2021, 1, 1),
+                            delytelseListe = listOf(
+                                SimulertDelytelse(type = YtelseskomponentTypeEnum.GAP, beloep = 567)
+                            ),
+                            uttakGrad = 50, // => gradert
+                            maanedligBeloep = 678 // skal mappes til gradertUttakBeloep
+                        )
+                    ),
+                    privatAfp = listOf(
+                        SimulertPrivatAfp(
+                            alderAar = 66,
+                            beloep = 789,
+                            kompensasjonstillegg = 123,
+                            kronetillegg = 5,
+                            livsvarig = 93,
+                            maanedligBeloep = 100
+                        )
+                    ),
+                    pre2025OffentligAfp = SimulertPre2025OffentligAfp(
+                        alderAar = 62,
+                        totaltAfpBeloep = 890,
+                        tidligereArbeidsinntekt = 123,
+                        grunnbeloep = 456,
+                        sluttpoengtall = 7.8,
+                        trygdetid = 30,
+                        poengaarTom1991 = 10,
+                        poengaarFom1992 = 20,
+                        grunnpensjon = 567,
+                        tilleggspensjon = 678,
+                        afpTillegg = 789,
+                        saertillegg = 890,
+                        afpGrad = 80,
+                        afpAvkortetTil70Prosent = false
+                    ),
+                    livsvarigOffentligAfp = listOf(
+                        SimulertLivsvarigOffentligAfp(
+                            alderAar = 63,
+                            beloep = 901,
+                            maanedligBeloep = 100
+                        )
+                    ),
+                    pensjonBeholdningPeriodeListe = listOf(
+                        SimulertPensjonBeholdningPeriode(
+                            pensjonBeholdning = 2.3,
+                            garantipensjonBeholdning = 3.4,
+                            garantitilleggBeholdning = 4.5,
+                            datoFom = LocalDate.of(2022, 2, 1),
+                            garantipensjonNivaa = SimulertGarantipensjonNivaa(
+                                beloep = 5.6,
+                                satsType = "sats1",
+                                sats = 6.7,
+                                anvendtTrygdetid = 40
+                            )
+                        )
+                    ),
+                    harUttak = true,
+                    primaerTrygdetid = Trygdetid(kapittel19 = 0, kapittel20 = 39),
+                    opptjeningGrunnlagListe = listOf(OpptjeningGrunnlag(aar = 1999, pensjonsgivendeInntekt = 1002))
+                ),
+                alternativ = SimulertAlternativ(
+                    gradertUttakAlder = SimulertUttakAlder(
+                        alder = Alder(aar = 66, maaneder = 2),
+                        uttakDato = LocalDate.of(2023, 3, 1),
+                    ),
+                    uttakGrad = UttakGradKode.P_20,
+                    heltUttakAlder = SimulertUttakAlder(
+                        alder = Alder(aar = 67, maaneder = 0),
+                        uttakDato = LocalDate.of(2024, 1, 1),
+                    ),
+                    resultStatus = SimulatorResultStatus.GOOD
+                )
+            )
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/simulator/common/api/ControllerBaseTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/common/api/ControllerBaseTest.kt
@@ -21,6 +21,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
+import java.time.format.DateTimeParseException
 
 class ControllerBaseTest : ShouldSpec({
 
@@ -201,9 +202,9 @@ class ControllerBaseTest : ShouldSpec({
         }
     }
 
-    context("extractMessageRecursively") {
+    context("extractExceptionNames") {
         should("ikke returnere mulig sensitiv exception message") {
-            SimpleTestController.testExtractMessageRecursively(
+            SimpleTestController.testExtractExceptionNames(
                 e = RuntimeException("Simple error")
             ) shouldBe "RuntimeException"
         }
@@ -211,7 +212,7 @@ class ControllerBaseTest : ShouldSpec({
         should("ikke inkludere mulig sensitiv årsak") {
             val cause = IllegalArgumentException("Root cause")
 
-            SimpleTestController.testExtractMessageRecursively(
+            SimpleTestController.testExtractExceptionNames(
                 e = RuntimeException("Outer error", cause)
             ) shouldBe "RuntimeException | Cause: IllegalArgumentException"
         }
@@ -221,12 +222,45 @@ class ControllerBaseTest : ShouldSpec({
             val middleCause = IllegalArgumentException("Middle", rootCause)
             val exception = RuntimeException("Top", middleCause)
 
-            SimpleTestController.testExtractMessageRecursively(exception) shouldBe
+            SimpleTestController.testExtractExceptionNames(exception) shouldBe
                     "RuntimeException | Cause: IllegalArgumentException | Cause: IllegalStateException"
         }
 
         should("bruke class name når message er null") {
-            SimpleTestController.testExtractMessageRecursively(e = RuntimeException()) shouldBe "RuntimeException"
+            SimpleTestController.testExtractExceptionNames(e = RuntimeException()) shouldBe "RuntimeException"
+        }
+    }
+
+    context("extractUnsafeMessages") {
+        should("håndtere flere nivåer av causes") {
+            val rootCause = IllegalStateException("Root")
+            val middleCause = IllegalArgumentException("Middle", rootCause)
+            val exception = RuntimeException("Top", middleCause)
+
+            SimpleTestController.testExtractUnsafeMessages(exception) shouldBe "Top | Cause: Middle | Cause: Root"
+        }
+
+        should("bruke class name når message er null") {
+            val rootCause = NumberFormatException()
+            val exception = IllegalArgumentException(null, rootCause)
+
+            SimpleTestController.testExtractUnsafeMessages(exception) shouldBe "IllegalArgumentException | Cause: NumberFormatException"
+        }
+    }
+
+    context("extractSafeMessage") {
+        should("betrakte DateTimeParseException som sikker") {
+            val exception = DateTimeParseException("Oops", "2023.01.01", 4)
+
+            SimpleTestController.testExtractSafeMessage(exception) shouldBe "Oops"
+        }
+
+        should("betrakte NullPointerException som sikker og håndtere flere nivåer av causes") {
+            val rootCause = NullPointerException("Root")
+            val middleCause = IllegalArgumentException("Middle", rootCause)
+            val exception = RuntimeException("Top", middleCause)
+
+            SimpleTestController.testExtractSafeMessage(exception) shouldBe "Root"
         }
     }
 })
@@ -280,6 +314,8 @@ private class SimpleTestController(traceAid: TraceAid) : ControllerBase(traceAid
     fun <T> testBadRequest(e: RuntimeException): T = badRequest(e)
 
     companion object {
-        fun testExtractMessageRecursively(e: Throwable): String = extractMessageRecursively(e)
+        fun testExtractExceptionNames(e: Throwable): String = extractExceptionNames(e)
+        fun testExtractUnsafeMessages(e: Throwable): String = extractUnsafeMessages(e)
+        fun testExtractSafeMessage(e: Throwable): String = extractSafeMessage(e)
     }
 }

--- a/src/test/kotlin/no/nav/pensjon/simulator/common/api/ControllerBaseTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/common/api/ControllerBaseTest.kt
@@ -21,7 +21,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
-import java.time.format.DateTimeParseException
 
 class ControllerBaseTest : ShouldSpec({
 
@@ -201,68 +200,6 @@ class ControllerBaseTest : ShouldSpec({
             }.reason shouldBe "Call ID: call-id | Error: Test error | Details: RuntimeException | Cause: IllegalArgumentException"
         }
     }
-
-    context("extractExceptionNames") {
-        should("ikke returnere mulig sensitiv exception message") {
-            SimpleTestController.testExtractExceptionNames(
-                e = RuntimeException("Simple error")
-            ) shouldBe "RuntimeException"
-        }
-
-        should("ikke inkludere mulig sensitiv årsak") {
-            val cause = IllegalArgumentException("Root cause")
-
-            SimpleTestController.testExtractExceptionNames(
-                e = RuntimeException("Outer error", cause)
-            ) shouldBe "RuntimeException | Cause: IllegalArgumentException"
-        }
-
-        should("håndtere flere nivåer av causes") {
-            val rootCause = IllegalStateException("Root")
-            val middleCause = IllegalArgumentException("Middle", rootCause)
-            val exception = RuntimeException("Top", middleCause)
-
-            SimpleTestController.testExtractExceptionNames(exception) shouldBe
-                    "RuntimeException | Cause: IllegalArgumentException | Cause: IllegalStateException"
-        }
-
-        should("bruke class name når message er null") {
-            SimpleTestController.testExtractExceptionNames(e = RuntimeException()) shouldBe "RuntimeException"
-        }
-    }
-
-    context("extractUnsafeMessages") {
-        should("håndtere flere nivåer av causes") {
-            val rootCause = IllegalStateException("Root")
-            val middleCause = IllegalArgumentException("Middle", rootCause)
-            val exception = RuntimeException("Top", middleCause)
-
-            SimpleTestController.testExtractUnsafeMessages(exception) shouldBe "Top | Cause: Middle | Cause: Root"
-        }
-
-        should("bruke class name når message er null") {
-            val rootCause = NumberFormatException()
-            val exception = IllegalArgumentException(null, rootCause)
-
-            SimpleTestController.testExtractUnsafeMessages(exception) shouldBe "IllegalArgumentException | Cause: NumberFormatException"
-        }
-    }
-
-    context("extractSafeMessage") {
-        should("betrakte DateTimeParseException som sikker") {
-            val exception = DateTimeParseException("Oops", "2023.01.01", 4)
-
-            SimpleTestController.testExtractSafeMessage(exception) shouldBe "Oops"
-        }
-
-        should("betrakte NullPointerException som sikker og håndtere flere nivåer av causes") {
-            val rootCause = NullPointerException("Root")
-            val middleCause = IllegalArgumentException("Middle", rootCause)
-            val exception = RuntimeException("Top", middleCause)
-
-            SimpleTestController.testExtractSafeMessage(exception) shouldBe "Root"
-        }
-    }
 })
 
 /**
@@ -312,10 +249,4 @@ private class SimpleTestController(traceAid: TraceAid) : ControllerBase(traceAid
 
     fun <T> testHandle(e: EgressException): T? = handle(e)
     fun <T> testBadRequest(e: RuntimeException): T = badRequest(e)
-
-    companion object {
-        fun testExtractExceptionNames(e: Throwable): String = extractExceptionNames(e)
-        fun testExtractUnsafeMessages(e: Throwable): String = extractUnsafeMessages(e)
-        fun testExtractSafeMessage(e: Throwable): String = extractSafeMessage(e)
-    }
 }

--- a/src/test/kotlin/no/nav/pensjon/simulator/uttak/api/UttakControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/uttak/api/UttakControllerTest.kt
@@ -131,10 +131,10 @@ class UttakControllerTest : ShouldSpec() {
                     .andExpect(
                         content().json(
                             """{
-  "tidligstMuligeUttakstidspunktListe" : [],
-  "feil" : {
-    "type" : "ANNEN_KLIENTFEIL",
-    "beskrivelse" : "Text '2030.02.01' could not be parsed at index 4"
+  "tidligstMuligeUttakstidspunktListe": [],
+  "feil": {
+    "type": "ANNEN_KLIENTFEIL",
+    "beskrivelse": "Cannot deserialize value of type `java.time.LocalDate` from String \"2030.02.01\": Failed to deserialize `java.time.LocalDate` (with format 'Value(YearOfEra,4,19,EXCEEDS_PAD)'-'Value(MonthOfYear,2)'-'Value(DayOfMonth,2)'): (java.time.format.DateTimeParseException) Text '2030.02.01' could not be parsed at index 4\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); byte offset: #117] (through reference chain: no.nav.pensjon.simulator.uttak.api.acl.TidligstMuligUttakSpecV1[\"heltUttakFraOgMedDato\"])"
   }
 }"""
                         )

--- a/src/test/kotlin/no/nav/pensjon/simulator/uttak/api/UttakControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/uttak/api/UttakControllerTest.kt
@@ -1,0 +1,206 @@
+package no.nav.pensjon.simulator.uttak.api
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.ShouldSpec
+import io.mockk.every
+import no.nav.pensjon.simulator.generelt.organisasjon.Organisasjonsnummer
+import no.nav.pensjon.simulator.generelt.organisasjon.OrganisasjonsnummerProvider
+import no.nav.pensjon.simulator.statistikk.StatistikkService
+import no.nav.pensjon.simulator.tech.sporing.SporingsloggService
+import no.nav.pensjon.simulator.tech.toggle.FeatureToggleService
+import no.nav.pensjon.simulator.tech.trace.TraceAid
+import no.nav.pensjon.simulator.testutil.TestObjects
+import no.nav.pensjon.simulator.tjenestepensjon.TilknytningService
+import no.nav.pensjon.simulator.uttak.TidligstMuligUttak
+import no.nav.pensjon.simulator.uttak.UttakService
+import no.nav.pensjon.simulator.uttak.Uttaksgrad
+import no.nav.pensjon.simulator.uttak.api.acl.UttakSpecMapperV1
+import org.intellij.lang.annotations.Language
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
+
+@WebMvcTest(UttakController::class)
+class UttakControllerTest : ShouldSpec() {
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @MockkBean
+    private lateinit var sporingsloggService: SporingsloggService
+
+    @MockkBean
+    private lateinit var feature: FeatureToggleService
+
+    @MockkBean(relaxed = true)
+    private lateinit var traceAid: TraceAid
+
+    @MockkBean
+    private lateinit var uttakSpecMapper: UttakSpecMapperV1
+
+    @MockkBean
+    private lateinit var uttakService: UttakService
+
+    @MockkBean(relaxed = true)
+    private lateinit var statistikkService: StatistikkService
+
+    @MockkBean
+    private lateinit var organisasjonsnummerProvider: OrganisasjonsnummerProvider
+
+    @MockkBean
+    private lateinit var tilknytningService: TilknytningService
+
+    init {
+        beforeSpec {
+            every { feature.isEnabled(any()) } returns false // vedlikeholdsmodus deaktivert
+            every { sporingsloggService.log(any(), any(), any()) } returns Unit
+            every { organisasjonsnummerProvider.provideOrganisasjonsnummer() } returns Organisasjonsnummer("123456789")
+            every { uttakSpecMapper.fromSpecV1(any()) } returns TestObjects.simuleringSpec
+            every { statistikkService.takeSnapshotIfNeeded() } returns Unit
+            every { tilknytningService.erPersonTilknyttetTjenestepensjonsordning(any(), any()) } returns true
+            every { traceAid.begin() } returns Unit
+        }
+
+        context("request OK") {
+            should("simulere tidligst mulig uttak") {
+                every { uttakService.finnTidligstMuligUttak(any()) } returns TidligstMuligUttak(
+                    uttaksdato = LocalDate.of(2033, 3, 1),
+                    uttaksgrad = Uttaksgrad.FEMTI_PROSENT,
+                    problem = null
+                )
+
+                mvc.perform(
+                    post(URL)
+                        .with(csrf())
+                        .content(okRequestBody())
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                    .andExpect(status().isOk())
+                    .andExpect(
+                        content().json(
+                            """{
+  "tidligstMuligeUttakstidspunktListe" : [ {
+    "uttaksgrad" : 50,
+    "tidligstMuligeUttaksdato" : "2033-03-01"
+  } ],
+  "feil" : null
+}"""
+                        )
+                    )
+            }
+        }
+
+        context("bad request - missing parameter in JSON") {
+            should("return status 'bad request' and descriptive body") {
+                mvc.perform(
+                    post(URL)
+                        .with(csrf())
+                        .content(bodyWithMissingPersonId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(
+                        content().json(
+                            """{
+  "tidligstMuligeUttakstidspunktListe" : [],
+  "feil" : {
+    "type" : "ANNEN_KLIENTFEIL",
+    "beskrivelse" : "Parameter specified as non-null is null: method no.nav.pensjon.simulator.uttak.api.acl.TidligstMuligUttakSpecV1.<init>, parameter personId"
+  }
+}"""
+                        )
+                    )
+            }
+        }
+
+        context("bad request - malformed date") {
+            should("return status 'bad request' and descriptive body") {
+                mvc.perform(
+                    post(URL)
+                        .with(csrf())
+                        .content(bodyWithBadDate())
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                    .andExpect(status().isBadRequest())
+                    .andExpect(
+                        content().json(
+                            """{
+  "tidligstMuligeUttakstidspunktListe" : [],
+  "feil" : {
+    "type" : "ANNEN_KLIENTFEIL",
+    "beskrivelse" : "Text '2030.02.01' could not be parsed at index 4"
+  }
+}"""
+                        )
+                    )
+            }
+        }
+    }
+
+    private companion object {
+
+        private const val URL = "/api/v1/tidligst-mulig-uttak"
+
+        @Language("json")
+        private fun okRequestBody() = """{
+    "personId": "02816396649",
+    "fodselsdato": "1963-01-02",
+    "uttaksgrad": 50,
+    "heltUttakFraOgMedDato": "2030-02-01",
+    "rettTilAfpOffentligDato": "2025-02-01",
+    "fremtidigInntektListe": [
+        {
+            "arligInntekt": 637000,
+            "fraOgMedDato": "2023-01-01"
+        },
+        {
+            "arligInntekt": 0,
+            "fraOgMedDato": "2030-02-01"
+        }
+    ]
+}""".trimIndent()
+
+        @Language("json")
+        private fun bodyWithMissingPersonId() = """{
+    "fodselsdato": "1963-01-02",
+    "uttaksgrad": 50,
+    "heltUttakFraOgMedDato": "2030-02-01",
+    "rettTilAfpOffentligDato": "2025-02-01",
+    "fremtidigInntektListe": [
+        {
+            "arligInntekt": 637000,
+            "fraOgMedDato": "2023-01-01"
+        },
+        {
+            "arligInntekt": 0,
+            "fraOgMedDato": "2030-02-01"
+        }
+    ]
+}""".trimIndent()
+
+        @Language("json")
+        private fun bodyWithBadDate() = """{
+    "personId": "02816396649",
+    "fodselsdato": "1963-01-02",
+    "uttaksgrad": 50,
+    "heltUttakFraOgMedDato": "2030.02.01",
+    "rettTilAfpOffentligDato": "2025-02-01",
+    "fremtidigInntektListe": [
+        {
+            "arligInntekt": 637000,
+            "fraOgMedDato": "2023-01-01"
+        },
+        {
+            "arligInntekt": 0,
+            "fraOgMedDato": "2030-02-01"
+        }
+    ]
+}""".trimIndent()
+    }
+}

--- a/src/test/kotlin/no/nav/pensjon/simulator/uttak/api/UttakControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/uttak/api/UttakControllerTest.kt
@@ -15,14 +15,17 @@ import no.nav.pensjon.simulator.uttak.TidligstMuligUttak
 import no.nav.pensjon.simulator.uttak.UttakService
 import no.nav.pensjon.simulator.uttak.Uttaksgrad
 import no.nav.pensjon.simulator.uttak.api.acl.UttakSpecMapperV1
+import org.hamcrest.Matchers.containsString
 import org.intellij.lang.annotations.Language
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDate
 
@@ -78,7 +81,7 @@ class UttakControllerTest : ShouldSpec() {
                 mvc.perform(
                     post(URL)
                         .with(csrf())
-                        .content(okRequestBody())
+                        .content(OK_REQUEST_BODY)
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                     .andExpect(status().isOk())
@@ -101,21 +104,11 @@ class UttakControllerTest : ShouldSpec() {
                 mvc.perform(
                     post(URL)
                         .with(csrf())
-                        .content(bodyWithMissingPersonId())
+                        .content(BODY_WITH_MISSING_PERSON_ID)
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                     .andExpect(status().isBadRequest())
-                    .andExpect(
-                        content().json(
-                            """{
-  "tidligstMuligeUttakstidspunktListe" : [],
-  "feil" : {
-    "type" : "ANNEN_KLIENTFEIL",
-    "beskrivelse" : "Parameter specified as non-null is null: method no.nav.pensjon.simulator.uttak.api.acl.TidligstMuligUttakSpecV1.<init>, parameter personId"
-  }
-}"""
-                        )
-                    )
+                    .andExpect(feilbeskrivelseInneholder("personId"))
             }
         }
 
@@ -124,31 +117,20 @@ class UttakControllerTest : ShouldSpec() {
                 mvc.perform(
                     post(URL)
                         .with(csrf())
-                        .content(bodyWithBadDate())
+                        .content(BODY_WITH_BAD_DATE)
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                     .andExpect(status().isBadRequest())
-                    .andExpect(
-                        content().json(
-                            """{
-  "tidligstMuligeUttakstidspunktListe": [],
-  "feil": {
-    "type": "ANNEN_KLIENTFEIL",
-    "beskrivelse": "Cannot deserialize value of type `java.time.LocalDate` from String \"2030.02.01\": Failed to deserialize `java.time.LocalDate` (with format 'Value(YearOfEra,4,19,EXCEEDS_PAD)'-'Value(MonthOfYear,2)'-'Value(DayOfMonth,2)'): (java.time.format.DateTimeParseException) Text '2030.02.01' could not be parsed at index 4\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); byte offset: #117] (through reference chain: no.nav.pensjon.simulator.uttak.api.acl.TidligstMuligUttakSpecV1[\"heltUttakFraOgMedDato\"])"
-  }
-}"""
-                        )
-                    )
+                    .andExpect(feilbeskrivelseInneholder("2030.02.01"))
             }
         }
     }
+}
 
-    private companion object {
+private const val URL = "/api/v1/tidligst-mulig-uttak"
 
-        private const val URL = "/api/v1/tidligst-mulig-uttak"
-
-        @Language("json")
-        private fun okRequestBody() = """{
+@Language("json")
+private const val OK_REQUEST_BODY = """{
     "personId": "02816396649",
     "fodselsdato": "1963-01-02",
     "uttaksgrad": 50,
@@ -164,10 +146,10 @@ class UttakControllerTest : ShouldSpec() {
             "fraOgMedDato": "2030-02-01"
         }
     ]
-}""".trimIndent()
+}"""
 
-        @Language("json")
-        private fun bodyWithMissingPersonId() = """{
+@Language("json")
+private const val BODY_WITH_MISSING_PERSON_ID = """{
     "fodselsdato": "1963-01-02",
     "uttaksgrad": 50,
     "heltUttakFraOgMedDato": "2030-02-01",
@@ -182,10 +164,10 @@ class UttakControllerTest : ShouldSpec() {
             "fraOgMedDato": "2030-02-01"
         }
     ]
-}""".trimIndent()
+}"""
 
-        @Language("json")
-        private fun bodyWithBadDate() = """{
+@Language("json")
+private const val BODY_WITH_BAD_DATE = """{
     "personId": "02816396649",
     "fodselsdato": "1963-01-02",
     "uttaksgrad": 50,
@@ -201,6 +183,7 @@ class UttakControllerTest : ShouldSpec() {
             "fraOgMedDato": "2030-02-01"
         }
     ]
-}""".trimIndent()
-    }
-}
+}"""
+
+private fun feilbeskrivelseInneholder(value: String): ResultMatcher =
+    jsonPath("$.feil.beskrivelse", containsString(value))

--- a/src/test/kotlin/no/nav/pensjon/simulator/validity/IngressErrorHandlerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/validity/IngressErrorHandlerTest.kt
@@ -1,0 +1,81 @@
+package no.nav.pensjon.simulator.validity
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import tools.jackson.databind.exc.MismatchedInputException
+import tools.jackson.databind.json.JsonMapper
+import java.time.format.DateTimeParseException
+
+class IngressErrorHandlerTest : ShouldSpec({
+
+    context("extractExceptionNames") {
+        should("ikke returnere mulig sensitiv exception message") {
+            IngressErrorHandler.extractExceptionNames(e = RuntimeException("sensitiv info")) shouldBe "RuntimeException"
+        }
+
+        should("ikke inkludere mulig sensitiv årsak") {
+            val cause = IllegalArgumentException("sensitiv rotårsak")
+
+            IngressErrorHandler.extractExceptionNames(
+                e = RuntimeException("Outer error", cause)
+            ) shouldBe "RuntimeException | Cause: IllegalArgumentException"
+        }
+
+        should("håndtere flere nivåer av årsaker") {
+            val rootCause = IllegalStateException("Root")
+            val middleCause = IllegalArgumentException("Middle", rootCause)
+            val exception = RuntimeException("Top", middleCause)
+
+            IngressErrorHandler.extractExceptionNames(exception) shouldBe
+                    "RuntimeException | Cause: IllegalArgumentException | Cause: IllegalStateException"
+        }
+
+        should("bruke klassenavn når message er udefinert") {
+            IngressErrorHandler.extractExceptionNames(e = RuntimeException()) shouldBe "RuntimeException"
+        }
+    }
+
+    context("extractUnsafeMessages") {
+        should("håndtere flere nivåer av årsaker") {
+            val rootCause = IllegalStateException("Root")
+            val middleCause = IllegalArgumentException("Middle", rootCause)
+            val exception = RuntimeException("Top", middleCause)
+
+            IngressErrorHandler.extractUnsafeMessages(exception) shouldBe "Top | Cause: Middle | Cause: Root"
+        }
+
+        should("bruke klassenavn når message er udefinert") {
+            val rootCause = NumberFormatException()
+            val exception = IllegalArgumentException(null, rootCause)
+
+            IngressErrorHandler.extractUnsafeMessages(exception) shouldBe "IllegalArgumentException | Cause: NumberFormatException"
+        }
+    }
+
+    context("extractSafeMessage") {
+        should("betrakte DateTimeParseException som sikker") {
+            val exception = DateTimeParseException("Oops", "2023.01.01", 4)
+            IngressErrorHandler.extractSafeMessage(exception) shouldBe "Oops"
+        }
+
+        should("betrakte NullPointerException som sikker, men fjerne intern info") {
+            val exception =
+                NullPointerException("Parameter specified as non-null is null: method internal.info.MyClass.<init>, parameter personId")
+            IngressErrorHandler.extractSafeMessage(exception) shouldBe "Missing required parameter: personId"
+        }
+
+        should("betrakte MismatchedInputException som sikker og håndtere flere nivåer av årsaker") {
+            try {
+                JsonMapper().readerFor(TestClass::class.java).readValue<TestClass>("{}")
+            } catch (rootCause: MismatchedInputException) {
+                val middleCause = IllegalArgumentException("Middle", rootCause)
+                val exception = RuntimeException("Oops", middleCause)
+                IngressErrorHandler.extractSafeMessage(exception) shouldBe rootCause.message
+            }
+        }
+    }
+})
+
+private data class TestClass(
+    val number: Int
+)


### PR DESCRIPTION
Håndterer misformet request (JSON-feil) i endepunktene for TMU og 'simuler AP for Nav'.
Dvs. at klienten får en utfyllende feilbeskrivelse i disse tilfellene:
- Når et obligatorisk felt mangler (`NullPointerException`)
- Ved feil datoformat (`DateTimeParseException`)
- Ved ukjent enum-verdi (`MismatchedInputException`)

I tillegg:
- Logger JSON-feil som Warning 
- Endrer navn på `extractMessageRecursively` til `extractExceptionNames`
- Fjerner teksten "Ukjent feil" i responsen ved feil
- Gjør om `Organisasjonsnummer` fra `value class` til `data class` (ellers virker ikke testene)