### PR TITLE
TPP-476 Include 'opptjening' in response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,9 @@
                 <version>3.5.6</version>
                 <configuration>
                     <argLine>-XX:+EnableDynamicAgentLoading</argLine>
+                    <systemPropertyVariables>
+                        <kotest.listener.spring.ignore.warning>true</kotest.listener.spring.ignore.warning>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/AlderspensjonService.kt
@@ -49,7 +49,6 @@ class AlderspensjonService(
         )
     }
 
-    // PEN: simdomSimulerAlderspensjon1963Plus
     private fun simulerMedMuligAlternativ(spec: SimuleringSpec): SimulertPensjonEllerAlternativ {
         try {
             val result: SimulatorOutput = simulator.simuler(spec)
@@ -58,7 +57,7 @@ class AlderspensjonService(
                 pensjon = SimulatorOutputConverter.pensjon( // SimulatorOutput -> SimulertPensjon
                     source = result,
                     today = time.today(),
-                    inntektVedFase1Uttak = spec.inntektUnderGradertUttakBeloep
+                    inntektVedTidsbegrensetOffentligAfpUttak = spec.inntektUnderGradertUttakBeloep
                 ),
                 alternativ = null
             )

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativSimuleringService.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativSimuleringService.kt
@@ -52,7 +52,7 @@ class AlternativSimuleringService(
                         pensjon(
                             source = result,
                             today = time.today(),
-                            inntektVedFase1Uttak = spec.inntektUnderGradertUttakBeloep
+                            inntektVedTidsbegrensetOffentligAfpUttak = spec.inntektUnderGradertUttakBeloep
                         )
                 // for 'onlyVilkaarsproeving' er beregnet pensjon uinteressant (kun vilkårsvurdering blir brukt)
             )
@@ -128,7 +128,7 @@ class AlternativSimuleringService(
                         pensjon(
                             source = result,
                             today = time.today(),
-                            inntektVedFase1Uttak = spec.inntektUnderGradertUttakBeloep
+                            inntektVedTidsbegrensetOffentligAfpUttak = spec.inntektUnderGradertUttakBeloep
                         )
             )
         } catch (e: UtilstrekkeligOpptjeningException) {

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimuleringFacade.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimuleringFacade.kt
@@ -49,7 +49,7 @@ class SimuleringFacade(
                     else pensjon(
                         source = result,
                         today = time.today(),
-                        inntektVedFase1Uttak = spec.inntektUnderGradertUttakBeloep,
+                        inntektVedTidsbegrensetOffentligAfpUttak = spec.inntektUnderGradertUttakBeloep,
                         gradertUttakDato = if (spec.isGradert()) spec.foersteUttakDato else null,
                         heltUttakDato = heltUttakDato(spec),
                         normertPensjoneringsdato = spec.foedselDato?.let(normalderService::normertPensjoneringsdato)
@@ -143,7 +143,7 @@ class SimuleringFacade(
             SimulertPensjonEllerAlternativ(
                 pensjon = null,
                 alternativ = null,
-                problem = Problem(type, beskrivelse = "Ukjent feil - ${e.javaClass.simpleName}")
+                problem = Problem(type, beskrivelse = e.javaClass.simpleName)
             )
     }
 }

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/SimulertPensjon.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.simulator.alderspensjon.alternativ
 
 import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
+import no.nav.pensjon.simulator.core.result.SimulertOpptjening
 import no.nav.pensjon.simulator.opptjening.OpptjeningGrunnlag
 import no.nav.pensjon.simulator.trygdetid.Trygdetid
 import java.time.LocalDate
@@ -15,7 +16,9 @@ data class SimulertPensjon(
     val pensjonBeholdningPeriodeListe: List<SimulertPensjonBeholdningPeriode>,
     val harUttak: Boolean,
     val primaerTrygdetid: Trygdetid,
-    val opptjeningGrunnlagListe: List<OpptjeningGrunnlag>
+    @Deprecated("Bruk opptjeningListe")
+    val opptjeningGrunnlagListe: List<OpptjeningGrunnlag>,
+    val opptjeningListe: List<SimulertOpptjening>
 )
 
 data class SimulertAarligAlderspensjon(

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3.kt
@@ -18,7 +18,7 @@ object NavSimuleringResultMapperV3 {
         return NavSimuleringResultV3(
             alderspensjonListe = pensjon?.alderspensjon.orEmpty().map(::alderspensjon),
             alderspensjonMaanedsbeloep = maanedsbeloep(pensjon?.alderspensjonFraFolketrygden.orEmpty()),
-            pre2025OffentligAfp = pensjon?.pre2025OffentligAfp?.let(::pre2025OffentligAfp),
+            pre2025OffentligAfp = pensjon?.pre2025OffentligAfp?.let(::tidsbegrensetOffentligAfp),
             privatAfpListe = pensjon?.privatAfp.orEmpty().map(::privatAfp),
             livsvarigOffentligAfpListe = pensjon?.livsvarigOffentligAfp.orEmpty().map(::livsvarigOffentligAfp),
             vilkaarsproeving = vilkaarsproevingResultat(source?.alternativ),
@@ -57,7 +57,7 @@ object NavSimuleringResultMapperV3 {
             heltUttakBeloep = source.firstOrNull(::erHel)?.maanedligBeloep ?: 0
         )
 
-    private fun pre2025OffentligAfp(source: SimulertPre2025OffentligAfp) =
+    private fun tidsbegrensetOffentligAfp(source: SimulertPre2025OffentligAfp) =
         NavPre2025OffentligAfp(
             alderAar = source.alderAar,
             totaltAfpBeloep = source.totaltAfpBeloep,

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/MaanedligAlderspensjonBeregner.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/MaanedligAlderspensjonBeregner.kt
@@ -1,0 +1,78 @@
+package no.nav.pensjon.simulator.alderspensjon.convert
+
+import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertMaanedligAlderspensjon
+import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertMaanedligGarantipensjon
+import no.nav.pensjon.simulator.core.result.PensjonPeriode
+import no.nav.pensjon.simulator.core.result.SimulertBeregningInformasjon
+import java.time.LocalDate
+
+class MaanedligAlderspensjonBeregner(
+    private val beregningsinfoListe: List<SimulertBeregningInformasjon>,
+    private val periodeListe: List<PensjonPeriode>,
+    private val kapittel19Andel: Double?,
+    private val kapittel20Andel: Double?
+) {
+    fun maanedligAlderspensjon(fom: LocalDate): SimulertMaanedligAlderspensjon? =
+        beregningsinfoListe.firstOrNull { it.datoFom == fom }?.let {
+            maanedligAlderspensjon(
+                info = it,
+                kapittel19Andel,
+                kapittel20Andel,
+                beholdningFoerUttak = beholdningFoerUttak(periodeListe, fom),
+                garantipensjonssats = garantipensjonssats(beregningsinfoListe, periodeListe)
+            )
+        }
+
+    private companion object {
+
+        private fun maanedligAlderspensjon(
+            info: SimulertBeregningInformasjon,
+            kapittel19Andel: Double?,
+            kapittel20Andel: Double?,
+            beholdningFoerUttak: Int?,
+            garantipensjonssats: Double?
+        ) =
+            SimulertMaanedligAlderspensjon(
+                beloep = info.maanedligBeloep ?: 0,
+                inntektspensjon = info.inntektspensjonPerMaaned,
+                delingstall = info.delingstall,
+                pensjonBeholdningFoerUttak = beholdningFoerUttak,
+                pensjonBeholdningEtterUttak = info.pensjonBeholdningEtterUttak,
+                sluttpoengtall = info.spt,
+                poengaarFoer92 = info.pa_f92,
+                poengaarEtter91 = info.pa_e91,
+                forholdstall = info.forholdstall,
+                grunnpensjon = info.grunnpensjonPerMaaned,
+                tilleggspensjon = info.tilleggspensjonPerMaaned,
+                pensjonstillegg = info.pensjonstilleggPerMaaned,
+                skjermingstillegg = info.skjermingstilleggPerMaaned,
+                andelsbroekKap19 = kapittel19Andel,
+                andelsbroekKap20 = kapittel20Andel,
+                basispensjon = info.basispensjon,
+                restpensjon = info.restBasisPensjon,
+                gjenlevendetillegg = info.gjtAPKap19PerMaaned,
+                minstePensjonsnivaaSats = info.minstePensjonsnivaSats,
+                trygdetidKap19 = info.tt_anv_kap19,
+                trygdetidKap20 = info.tt_anv_kap20,
+                garantipensjon = info.garantipensjonPerMaaned?.let {
+                    SimulertMaanedligGarantipensjon(maanedligBeloep = it, sats = garantipensjonssats ?: 0.0)
+                },
+                garantitillegg = info.garantitilleggPerMaaned
+            )
+
+        private fun garantipensjonssats(
+            beregningsinfoListe: List<SimulertBeregningInformasjon>,
+            periodeListe: List<PensjonPeriode>
+        ): Double? =
+            beregningsinfoListe.firstNotNullOfOrNull { it.garantipensjonssats }
+                ?: periodeListe
+                    .flatMap { it.simulertBeregningInformasjonListe }
+                    .firstNotNullOfOrNull { it.garantipensjonssats }
+
+        private fun beholdningFoerUttak(periodeListe: List<PensjonPeriode>, fom: LocalDate): Int? =
+            periodeListe
+                .flatMap { it.simulertBeregningInformasjonListe }
+                .firstOrNull { it.datoFom == fom }
+                ?.pensjonBeholdningFoerUttak
+    }
+}

--- a/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverter.kt
@@ -31,7 +31,7 @@ object SimulatorOutputConverter {
     fun pensjon(
         source: SimulatorOutput,
         today: LocalDate,
-        inntektVedFase1Uttak: Int? = null,
+        inntektVedTidsbegrensetOffentligAfpUttak: Int? = null,
         gradertUttakDato: LocalDate? = null,
         heltUttakDato: LocalDate? = null,
         normertPensjoneringsdato: LocalDate? = null
@@ -45,7 +45,8 @@ object SimulatorOutputConverter {
             maanedligAlderspensjonForKnekkpunkter = maanedligAlderspensjonForKnekkpunkter(
                 beregningsinfoListe,
                 periodeListe,
-                alderspensjon,
+                alderspensjon?.kapittel19Andel,
+                alderspensjon?.kapittel20Andel,
                 gradertUttakDato,
                 heltUttakDato,
                 normertPensjoneringsdato
@@ -55,7 +56,7 @@ object SimulatorOutputConverter {
                 tidsbegrensetOffentligAfp(
                     beregning = it,
                     foedselsdato = source.registerData?.soekerFoedselsdato,
-                    inntektVedAfpUttak = inntektVedFase1Uttak
+                    inntektVedAfpUttak = inntektVedTidsbegrensetOffentligAfpUttak
                 )
             },
             privatAfp = source.privatAfpPeriodeListe.map(::privatAfp),
@@ -65,7 +66,8 @@ object SimulatorOutputConverter {
             harUttak = alderspensjon?.uttakGradListe.orEmpty().any { harUttakToday(it, today) },
             primaerTrygdetid = foersteTrygdetid(periodeListe),
             opptjeningGrunnlagListe = source.persongrunnlag?.opptjeningsgrunnlagListe.orEmpty()
-                .map(::opptjeningGrunnlag).sortedBy { it.aar }
+                .map(::opptjeningGrunnlag).sortedBy { it.aar },
+            opptjeningListe = source.opptjeningListe
         )
     }
 
@@ -135,96 +137,22 @@ object SimulatorOutputConverter {
     private fun maanedligAlderspensjonForKnekkpunkter(
         beregningsinfoListe: List<SimulertBeregningInformasjon>,
         periodeListe: List<PensjonPeriode>,
-        alderspensjon: SimulertAlderspensjon?,
+        kapittel19Andel: Double?,
+        kapittel20Andel: Double?,
         gradertUttakDato: LocalDate?,
         heltUttakDato: LocalDate?,
         normertPensjoneringsdato: LocalDate?
     ): SimulertMaanedligAlderspensjonForKnekkpunkter {
-        val garantipensjonssats = finnGarantipensjonssats(beregningsinfoListe, periodeListe)
-
-        val vedGradertUttak = gradertUttakDato?.let {
-            finnBeregningsinfoForDato(beregningsinfoListe, it)?.let { info ->
-                maanedligAlderspensjon(info, alderspensjon, beholdningFoerUttakForDato(periodeListe, it), garantipensjonssats)
-            }
-        }
-
-        val vedHeltUttak = heltUttakDato?.let {
-            finnBeregningsinfoForDato(beregningsinfoListe, it)?.let { info ->
-                maanedligAlderspensjon(info, alderspensjon, beholdningFoerUttakForDato(periodeListe, it), garantipensjonssats)
-            }
-        }
-
-        val vedNormertPensjonsalder = normertPensjoneringsdato?.let {
-            finnBeregningsinfoForDato(beregningsinfoListe, it)?.let { info ->
-                maanedligAlderspensjon(info, alderspensjon, beholdningFoerUttakForDato(periodeListe, it), garantipensjonssats)
-            }
-        }
+        val beregner =
+            MaanedligAlderspensjonBeregner(beregningsinfoListe, periodeListe, kapittel19Andel, kapittel20Andel)
 
         return SimulertMaanedligAlderspensjonForKnekkpunkter(
-            vedGradertUttak = vedGradertUttak,
-            vedHeltUttak = vedHeltUttak,
-            vedNormertPensjonsalder = vedNormertPensjonsalder
+            vedGradertUttak = gradertUttakDato?.let(beregner::maanedligAlderspensjon),
+            vedHeltUttak = heltUttakDato?.let(beregner::maanedligAlderspensjon),
+            vedNormertPensjonsalder = normertPensjoneringsdato?.let(beregner::maanedligAlderspensjon)
         )
     }
 
-    private fun finnGarantipensjonssats(
-        beregningsinfoListe: List<SimulertBeregningInformasjon>,
-        periodeListe: List<PensjonPeriode>
-    ): Double? =
-        beregningsinfoListe.firstNotNullOfOrNull { it.garantipensjonssats }
-            ?: periodeListe
-                .flatMap { it.simulertBeregningInformasjonListe }
-                .firstNotNullOfOrNull { it.garantipensjonssats }
-
-    private fun finnBeregningsinfoForDato(
-        beregningsinfoListe: List<SimulertBeregningInformasjon>,
-        dato: LocalDate
-    ): SimulertBeregningInformasjon? =
-        beregningsinfoListe.firstOrNull { it.datoFom == dato }
-
-    private fun beholdningFoerUttakForDato(periodeListe: List<PensjonPeriode>, dato: LocalDate): Int? =
-        periodeListe
-            .flatMap { it.simulertBeregningInformasjonListe }
-            .firstOrNull { it.datoFom == dato }
-            ?.pensjonBeholdningFoerUttak
-
-    private fun maanedligAlderspensjon(
-        source: SimulertBeregningInformasjon,
-        alderspensjon: SimulertAlderspensjon?,
-        pensjonBeholdningFoerUttak: Int?,
-        garantipensjonssats: Double?
-    ) =
-        SimulertMaanedligAlderspensjon(
-            beloep = source.maanedligBeloep ?: 0,
-            inntektspensjon = source.inntektspensjonPerMaaned,
-            delingstall = source.delingstall,
-            pensjonBeholdningFoerUttak = pensjonBeholdningFoerUttak,
-            pensjonBeholdningEtterUttak = source.pensjonBeholdningEtterUttak,
-            sluttpoengtall = source.spt,
-            poengaarFoer92 = source.pa_f92,
-            poengaarEtter91 = source.pa_e91,
-            forholdstall = source.forholdstall,
-            grunnpensjon = source.grunnpensjonPerMaaned,
-            tilleggspensjon = source.tilleggspensjonPerMaaned,
-            pensjonstillegg = source.pensjonstilleggPerMaaned,
-            skjermingstillegg = source.skjermingstilleggPerMaaned,
-            andelsbroekKap19 = alderspensjon?.kapittel19Andel,
-            andelsbroekKap20 = alderspensjon?.kapittel20Andel,
-            basispensjon = source.basispensjon,
-            restpensjon = source.restBasisPensjon,
-            gjenlevendetillegg = source.gjtAPKap19PerMaaned,
-            minstePensjonsnivaaSats = source.minstePensjonsnivaSats,
-            trygdetidKap19 = source.tt_anv_kap19,
-            trygdetidKap20 = source.tt_anv_kap20,
-            garantipensjon = source.garantipensjonPerMaaned?.let {
-                SimulertMaanedligGarantipensjon(
-                    maanedligBeloep = it,
-                    sats = garantipensjonssats ?: 0.0
-                )
-            },
-            garantitillegg = source.garantitilleggPerMaaned
-        )
-    
     // SimulerAlderspensjonResponseV3Converter.convertSimulertBeregningsinfoToAlderspensjonFraFolketrygden
     private fun alderspensjonFraFolketrygden(source: SimulertBeregningInformasjon) =
         SimulertAlderspensjonFraFolketrygden(

--- a/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/PensjonForNavV2Controller.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/PensjonForNavV2Controller.kt
@@ -131,6 +131,7 @@ class PensjonForNavV2Controller(
                 vilkaarsproevingsresultat = VilkaarsproevingsresultatDto(erInnvilget = false, alternativ = null),
                 primaerTrygdetid = null,
                 pensjonsgivendeInntektListe = emptyList(),
+                opptjeningListe = emptyList(),
                 problem = ProblemDto(kode = type, beskrivelse)
             )
     }

--- a/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/acl/result/SimuleringResultDto.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/acl/result/SimuleringResultDto.kt
@@ -17,7 +17,9 @@ data class SimuleringResultDto(
     @field:NotNull val privatAfpListe: List<PrivatAfpDto>,
     val primaerTrygdetid: TrygdetidDto?,
     @field:NotNull val vilkaarsproevingsresultat: VilkaarsproevingsresultatDto,
+    @Deprecated("Bruk opptjeningListe")
     @field:NotNull val pensjonsgivendeInntektListe: List<AarligBeloepDto>,
+    @field:NotNull val opptjeningListe: List<OpptjeningDto>,
     val problem: ProblemDto? = null
 )
 
@@ -126,6 +128,14 @@ data class PrivatAfpDto(
     @field:NotNull val kronetillegg: Int,
     @field:NotNull val livsvarig: Int,
     @field:NotNull val maanedligBeloep: Int
+)
+
+@JsonInclude(NON_NULL)
+data class OpptjeningDto(
+    val aarstall: Int?,
+    val pensjonsgivendeInntekt: Int?,
+    val pensjonsbeholdning: Int?,
+    val pensjonspoeng: Double?,
 )
 
 @JsonInclude(NON_NULL)

--- a/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/acl/result/SimuleringResultMapper.kt
+++ b/src/main/kotlin/no/nav/pensjon/simulator/api/nav/v2/acl/result/SimuleringResultMapper.kt
@@ -3,6 +3,7 @@ package no.nav.pensjon.simulator.api.nav.v2.acl.result
 import no.nav.pensjon.simulator.alderspensjon.Uttaksgrad
 import no.nav.pensjon.simulator.alderspensjon.alternativ.*
 import no.nav.pensjon.simulator.api.nav.v2.acl.UttaksgradDto
+import no.nav.pensjon.simulator.core.result.SimulertOpptjening
 import no.nav.pensjon.simulator.opptjening.OpptjeningGrunnlag
 import no.nav.pensjon.simulator.trygdetid.Trygdetid
 import no.nav.pensjon.simulator.validity.Problem
@@ -27,6 +28,7 @@ object SimuleringResultMapper {
             primaerTrygdetid = pensjon?.primaerTrygdetid?.let(::trygdetid),
             vilkaarsproevingsresultat = vilkaarsproevingsresultat(source?.alternativ, source?.problem),
             pensjonsgivendeInntektListe = pensjon?.opptjeningGrunnlagListe.orEmpty().map(::opptjeningGrunnlag),
+            opptjeningListe = pensjon?.opptjeningListe.orEmpty().map(::opptjening),
             problem = source?.problem?.let(::problem)
         )
     }
@@ -161,6 +163,14 @@ object SimuleringResultMapper {
             erUtilstrekkelig = source.erTilstrekkelig.not()
         )
 
+    private fun opptjening(source: SimulertOpptjening) =
+        OpptjeningDto(
+            aarstall = source.kalenderAar,
+            pensjonsgivendeInntekt = source.pensjonsgivendeInntekt,
+            pensjonsbeholdning = source.pensjonBeholdning,
+            pensjonspoeng = source.pensjonsgivendeInntektPensjonspoeng,
+        )
+
     private fun vilkaarsproevingsresultat(alternativ: SimulertAlternativ?, problem: Problem?) =
         VilkaarsproevingsresultatDto(
             erInnvilget = alternativ == null && problem == null,
@@ -197,7 +207,8 @@ object SimuleringResultMapper {
 
     private fun problem(source: Problem) =
         ProblemDto(
-            kode = ProblemTypeDto.entries.firstOrNull { it.internalValue == source.type } ?: ProblemTypeDto.ANNEN_SERVERFEIL,
+            kode = ProblemTypeDto.entries.firstOrNull { it.internalValue == source.type }
+                ?: ProblemTypeDto.ANNEN_SERVERFEIL,
             beskrivelse = source.beskrivelse
         )
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -21,6 +21,7 @@
         </encoder>
     </appender>
     <logger name="org.flywaydb.core" level="WARN"/>
+    <logger name="org.springframework.test.context.support.AnnotationConfigContextLoaderUtils" level="WARN"/>
 
     <root level="INFO">
         <appender-ref ref="${STDOUT_LOG_APPENDER}"/>

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakServiceTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/alternativ/AlternativtUttakServiceTest.kt
@@ -23,7 +23,7 @@ import no.nav.pensjon.simulator.testutil.TestObjects.pid
 import no.nav.pensjon.simulator.trygdetid.Trygdetid
 import java.time.LocalDate
 
-class AlternativtUttakServiceTest : FunSpec({
+open class AlternativtUttakServiceTest : FunSpec({
 
     val foedselsdato = LocalDate.of(1967, 1, 1)
 
@@ -61,12 +61,19 @@ class AlternativtUttakServiceTest : FunSpec({
                 pensjonBeholdningPeriodeListe = emptyList(),
                 harUttak = false,
                 primaerTrygdetid = Trygdetid(kapittel19 = 0, kapittel20 = 0),
-                opptjeningGrunnlagListe = emptyList()
+                opptjeningGrunnlagListe = emptyList(),
+                opptjeningListe = emptyList()
             ),
             alternativ = SimulertAlternativ(
-                gradertUttakAlder = SimulertUttakAlder(alder = Alder(aar = 65, maaneder = 1), uttakDato = LocalDate.of(2032, 3, 1)),
+                gradertUttakAlder = SimulertUttakAlder(
+                    alder = Alder(aar = 65, maaneder = 1),
+                    uttakDato = LocalDate.of(2032, 3, 1)
+                ),
                 uttakGrad = UttakGradKode.P_40,
-                heltUttakAlder = SimulertUttakAlder(alder = Alder(aar = 66, maaneder = 1), uttakDato = LocalDate.of(2033, 3, 1)),
+                heltUttakAlder = SimulertUttakAlder(
+                    alder = Alder(aar = 66, maaneder = 1),
+                    uttakDato = LocalDate.of(2033, 3, 1)
+                ),
                 resultStatus = SimulatorResultStatus.GOOD
             )
         )

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test.kt
@@ -6,12 +6,13 @@ import no.nav.pensjon.simulator.alder.Alder
 import no.nav.pensjon.simulator.alderspensjon.alternativ.*
 import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.result.SimulertOpptjening
 import no.nav.pensjon.simulator.opptjening.OpptjeningGrunnlag
 import no.nav.pensjon.simulator.testutil.TestObjects.emptyKnekkpunkter
 import no.nav.pensjon.simulator.trygdetid.Trygdetid
 import java.time.LocalDate
 
-class NavSimuleringResultMapperV3Test : FunSpec({
+open class NavSimuleringResultMapperV3Test : FunSpec({
 
     /**
      * Test av mapping ved gradert uttak.
@@ -109,7 +110,8 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                     ),
                     harUttak = true,
                     primaerTrygdetid = Trygdetid(kapittel19 = 0, kapittel20 = 39),
-                    opptjeningGrunnlagListe = listOf(OpptjeningGrunnlag(aar = 1999, pensjonsgivendeInntekt = 1002))
+                    opptjeningGrunnlagListe = listOf(OpptjeningGrunnlag(aar = 1999, pensjonsgivendeInntekt = 1002)),
+                    opptjeningListe = listOf(SimulertOpptjening(kalenderAar = 1999, pensjonsgivendeInntekt = 1002))
                 ),
                 alternativ = SimulertAlternativ(
                     gradertUttakAlder = SimulertUttakAlder(
@@ -225,7 +227,8 @@ class NavSimuleringResultMapperV3Test : FunSpec({
                     pensjonBeholdningPeriodeListe = emptyList(),
                     harUttak = true,
                     primaerTrygdetid = Trygdetid(kapittel19 = 0, kapittel20 = 0),
-                    opptjeningGrunnlagListe = emptyList()
+                    opptjeningGrunnlagListe = emptyList(),
+                    opptjeningListe = emptyList()
                 ),
                 alternativ = null
             )

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/nav/direct/acl/v3/result/NavSimuleringResultMapperV3Test2.kt
@@ -6,13 +6,14 @@ import no.nav.pensjon.simulator.alderspensjon.alternativ.*
 import no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.result.NavSimuleringResultMapperV3Test2Assert.assertResult
 import no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.result.NavSimuleringResultMapperV3Test2Objects.alderspensjonFraFolketrygden
 import no.nav.pensjon.simulator.alderspensjon.api.nav.direct.acl.v3.result.NavSimuleringResultMapperV3Test2Objects.simulertPensjonEllerAlternativ
+import no.nav.pensjon.simulator.core.result.SimulertOpptjening
 import no.nav.pensjon.simulator.opptjening.OpptjeningGrunnlag
 import no.nav.pensjon.simulator.testutil.TestObjects.emptyKnekkpunkter
 import no.nav.pensjon.simulator.trygdetid.Trygdetid
 import java.time.LocalDate
 
 // Copied from PEN
-class NavSimuleringResultMapperV3Test2 : FunSpec({
+open class NavSimuleringResultMapperV3Test2 : FunSpec({
 
     test("map resultat med gradert uttak") {
         val source = simulertPensjonEllerAlternativ(
@@ -157,12 +158,8 @@ private object NavSimuleringResultMapperV3Test2Objects {
                 ),
                 harUttak = true,
                 primaerTrygdetid = Trygdetid(kapittel19 = 0, kapittel20 = 21),
-                opptjeningGrunnlagListe = listOf(
-                    OpptjeningGrunnlag(
-                        aar = 22,
-                        pensjonsgivendeInntekt = 23
-                    )
-                )
+                opptjeningGrunnlagListe = listOf(OpptjeningGrunnlag(aar = 22, pensjonsgivendeInntekt = 23)),
+                opptjeningListe = listOf(SimulertOpptjening(kalenderAar = 22, pensjonsgivendeInntekt = 23))
             ),
             alternativ = null
         )

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/samhandler/SamhandlerAlderspensjonResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/api/samhandler/SamhandlerAlderspensjonResultMapperTest.kt
@@ -5,12 +5,13 @@ import io.kotest.matchers.shouldBe
 import no.nav.pensjon.simulator.alderspensjon.*
 import no.nav.pensjon.simulator.alderspensjon.alternativ.*
 import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
+import no.nav.pensjon.simulator.core.result.SimulertOpptjening
 import no.nav.pensjon.simulator.opptjening.OpptjeningGrunnlag
 import no.nav.pensjon.simulator.testutil.TestObjects.emptyKnekkpunkter
 import no.nav.pensjon.simulator.trygdetid.Trygdetid
 import java.time.LocalDate
 
-class SamhandlerAlderspensjonResultMapperTest : FunSpec({
+open class SamhandlerAlderspensjonResultMapperTest : FunSpec({
 
     test("mapPensjonEllerAlternativ for null should resultere i tomt resultat") {
         SamhandlerAlderspensjonResultMapper.mapPensjonEllerAlternativ(
@@ -103,9 +104,8 @@ class SamhandlerAlderspensjonResultMapperTest : FunSpec({
                     harUttak = true,
                     primaerTrygdetid = Trygdetid(kapittel19 = 0, kapittel20 = 40),
                     maanedligAlderspensjonForKnekkpunkter = emptyKnekkpunkter,
-                    opptjeningGrunnlagListe = listOf(
-                        OpptjeningGrunnlag(aar = 2024, pensjonsgivendeInntekt = 50000)
-                    )
+                    opptjeningGrunnlagListe = listOf(OpptjeningGrunnlag(aar = 2024, pensjonsgivendeInntekt = 50000)),
+                    opptjeningListe = listOf(SimulertOpptjening(kalenderAar = 2024, pensjonsgivendeInntekt = 50000))
                 ),
                 alternativ = null
             ),
@@ -257,7 +257,8 @@ private fun simulertPensjon(alderspensjonFraFolketrygden: List<SimulertAlderspen
             pensjonBeholdningPeriodeListe = emptyList(),
             harUttak = true,
             primaerTrygdetid = Trygdetid(kapittel19 = 0, kapittel20 = 40),
-            opptjeningGrunnlagListe = emptyList()
+            opptjeningGrunnlagListe = emptyList(),
+            opptjeningListe = emptyList()
         ),
         alternativ = null
     )

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/MaanedligAlderspensjonBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/MaanedligAlderspensjonBeregnerTest.kt
@@ -1,0 +1,105 @@
+package no.nav.pensjon.simulator.alderspensjon.convert
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertMaanedligAlderspensjon
+import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertMaanedligGarantipensjon
+import no.nav.pensjon.simulator.core.result.PensjonPeriode
+import no.nav.pensjon.simulator.core.result.SimulertBeregningInformasjon
+import java.time.LocalDate
+
+open class MaanedligAlderspensjonBeregnerTest : ShouldSpec({
+
+    should("gi simulert månedlig alderspensjon") {
+        val fom = LocalDate.of(2030, 1, 1)
+
+        MaanedligAlderspensjonBeregner(
+            beregningsinfoListe = beregningsinformasjonListe(fom),
+            periodeListe = periodeListe(fom, beholdningFoerUttak = 1234),
+            kapittel19Andel = 0.3,
+            kapittel20Andel = 0.7
+        ).maanedligAlderspensjon(fom) shouldBe
+                SimulertMaanedligAlderspensjon(
+                    beloep = 5000,
+                    inntektspensjon = 1000,
+                    delingstall = 14.5,
+                    pensjonBeholdningFoerUttak = 1234,
+                    pensjonBeholdningEtterUttak = 500000,
+                    sluttpoengtall = 3.5,
+                    poengaarFoer92 = 10,
+                    poengaarEtter91 = 15,
+                    forholdstall = 1.1,
+                    grunnpensjon = 800,
+                    tilleggspensjon = 900,
+                    pensjonstillegg = 200,
+                    skjermingstillegg = 50,
+                    andelsbroekKap19 = 0.3,
+                    andelsbroekKap20 = 0.7,
+                    basispensjon = 1200,
+                    restpensjon = 300,
+                    gjenlevendetillegg = 100,
+                    minstePensjonsnivaaSats = 2.5,
+                    trygdetidKap19 = 40,
+                    trygdetidKap20 = 20,
+                    garantipensjon = SimulertMaanedligGarantipensjon(maanedligBeloep = 600, sats = 2.0),
+                    garantitillegg = 50
+                )
+    }
+
+    should("hente garantipensjonssats fra periodelisten hvis beregningsinfo mangler den verdien") {
+        val fom = LocalDate.of(2030, 1, 1)
+
+        MaanedligAlderspensjonBeregner(
+            beregningsinfoListe = beregningsinformasjonListe(fom, garantipensjonssats = null),
+            periodeListe = periodeListe(fom, garantipensjonssats = 2.1),
+            kapittel19Andel = 0.3,
+            kapittel20Andel = 0.7
+        ).maanedligAlderspensjon(fom)?.garantipensjon?.sats shouldBe 2.1
+    }
+})
+
+private fun beregningsinformasjonListe(
+    fom: LocalDate,
+    garantipensjonssats: Double? = 2.0
+): List<SimulertBeregningInformasjon> =
+    listOf(
+        SimulertBeregningInformasjon().apply {
+            datoFom = fom
+            maanedligBeloep = 5000
+            inntektspensjonPerMaaned = 1000
+            delingstall = 14.5
+            pensjonBeholdningEtterUttak = 500000
+            spt = 3.5
+            pa_f92 = 10
+            pa_e91 = 15
+            forholdstall = 1.1
+            grunnpensjonPerMaaned = 800
+            tilleggspensjonPerMaaned = 900
+            pensjonstilleggPerMaaned = 200
+            skjermingstillegg = 500
+            skjermingstilleggPerMaaned = 50
+            basispensjon = 1200
+            restBasisPensjon = 300
+            gjtAPKap19PerMaaned = 100
+            minstePensjonsnivaSats = 2.5
+            tt_anv_kap19 = 40
+            tt_anv_kap20 = 20
+            garantipensjonPerMaaned = 600
+            this.garantipensjonssats = garantipensjonssats
+            garantitilleggPerMaaned = 50
+        })
+
+private fun periodeListe(
+    fom: LocalDate,
+    garantipensjonssats: Double? = null,
+    beholdningFoerUttak: Int? = null
+): List<PensjonPeriode> =
+    listOf(
+        PensjonPeriode().apply {
+            simulertBeregningInformasjonListe = mutableListOf(
+                SimulertBeregningInformasjon().apply {
+                    datoFom = fom
+                    this.garantipensjonssats = garantipensjonssats
+                    pensjonBeholdningFoerUttak = beholdningFoerUttak
+                })
+        })

--- a/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverterTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/alderspensjon/convert/SimulatorOutputConverterTest.kt
@@ -12,7 +12,7 @@ import no.nav.pensjon.simulator.testutil.TestObjects.emptyKnekkpunkter
 import no.nav.pensjon.simulator.trygdetid.Trygdetid
 import java.time.LocalDate
 
-class SimulatorOutputConverterTest : FunSpec({
+open class SimulatorOutputConverterTest : FunSpec({
 
     /**
      * Tests mapping of:
@@ -71,7 +71,7 @@ class SimulatorOutputConverterTest : FunSpec({
                 }
             },
             today = LocalDate.of(2025, 2, 15), // no uttaksgrad covers this date
-            inntektVedFase1Uttak = 123
+            inntektVedTidsbegrensetOffentligAfpUttak = 123
         ) shouldBe SimulertPensjon(
             alderspensjon = listOf(
                 SimulertAarligAlderspensjon(
@@ -115,7 +115,8 @@ class SimulatorOutputConverterTest : FunSpec({
             pensjonBeholdningPeriodeListe = emptyList(),
             harUttak = false,
             primaerTrygdetid = Trygdetid(kapittel19 = 19, kapittel20 = 4),
-            opptjeningGrunnlagListe = emptyList()
+            opptjeningGrunnlagListe = emptyList(),
+            opptjeningListe = emptyList()
         )
     }
 

--- a/src/test/kotlin/no/nav/pensjon/simulator/api/nav/v2/PensjonForNavV2ControllerTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/api/nav/v2/PensjonForNavV2ControllerTest.kt
@@ -10,6 +10,7 @@ import no.nav.pensjon.simulator.alderspensjon.alternativ.*
 import no.nav.pensjon.simulator.api.nav.v2.acl.spec.SimuleringSpecMapperForNavV2
 import no.nav.pensjon.simulator.core.domain.regler.enum.YtelseskomponentTypeEnum
 import no.nav.pensjon.simulator.core.krav.UttakGradKode
+import no.nav.pensjon.simulator.core.result.SimulertOpptjening
 import no.nav.pensjon.simulator.opptjening.OpptjeningGrunnlag
 import no.nav.pensjon.simulator.statistikk.StatistikkService
 import no.nav.pensjon.simulator.tech.sporing.SporingsloggService
@@ -30,7 +31,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDate
 
 @WebMvcTest(PensjonForNavV2Controller::class)
-class PensjonForNavV2ControllerTest : ShouldSpec() {
+open class PensjonForNavV2ControllerTest : ShouldSpec() {
 
     @Autowired
     private lateinit var mvc: MockMvc
@@ -336,7 +337,8 @@ class PensjonForNavV2ControllerTest : ShouldSpec() {
                     ),
                     harUttak = true,
                     primaerTrygdetid = Trygdetid(kapittel19 = 0, kapittel20 = 39),
-                    opptjeningGrunnlagListe = listOf(OpptjeningGrunnlag(aar = 1999, pensjonsgivendeInntekt = 1002))
+                    opptjeningGrunnlagListe = listOf(OpptjeningGrunnlag(aar = 1999, pensjonsgivendeInntekt = 1002)),
+                    opptjeningListe = listOf(SimulertOpptjening(kalenderAar = 1999, pensjonsgivendeInntekt = 1002))
                 ),
                 alternativ = SimulertAlternativ(
                     gradertUttakAlder = SimulertUttakAlder(

--- a/src/test/kotlin/no/nav/pensjon/simulator/api/nav/v2/acl/result/SimuleringResultMapperTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/api/nav/v2/acl/result/SimuleringResultMapperTest.kt
@@ -8,7 +8,7 @@ import no.nav.pensjon.simulator.trygdetid.Trygdetid
 import no.nav.pensjon.simulator.validity.Problem
 import no.nav.pensjon.simulator.validity.ProblemType
 
-class SimuleringResultMapperTest : ShouldSpec({
+open class SimuleringResultMapperTest : ShouldSpec({
 
     should("map empty result to DTO with empty lists") {
         SimuleringResultMapper.toDto(
@@ -30,6 +30,7 @@ class SimuleringResultMapperTest : ShouldSpec({
                 alternativ = null
             ),
             pensjonsgivendeInntektListe = emptyList(),
+            opptjeningListe = emptyList(),
             problem = null
         )
     }
@@ -46,8 +47,8 @@ class SimuleringResultMapperTest : ShouldSpec({
                             garantipensjon = SimulertGarantipensjon(aarligBeloep = 125, sats = 1.2),
                             garantitillegg = 126,
                             delingstall = 1.3,
-                             pensjonBeholdningFoerUttak = 127,
-                             andelsbroekKap19 = 1.4,
+                            pensjonBeholdningFoerUttak = 127,
+                            andelsbroekKap19 = 1.4,
                             andelsbroekKap20 = 1.5,
                             sluttpoengtall = 1.6,
                             trygdetidKap19 = 19,
@@ -73,7 +74,8 @@ class SimuleringResultMapperTest : ShouldSpec({
                     harUttak = true,
                     primaerTrygdetid = Trygdetid(kapittel19 = 19, kapittel20 = 20),
                     maanedligAlderspensjonForKnekkpunkter = emptyKnekkpunkter,
-                    opptjeningGrunnlagListe = emptyList()
+                    opptjeningGrunnlagListe = emptyList(),
+                    opptjeningListe = emptyList()
                 ),
                 alternativ = null,
                 problem = null
@@ -128,6 +130,7 @@ class SimuleringResultMapperTest : ShouldSpec({
             ),
             vilkaarsproevingsresultat = VilkaarsproevingsresultatDto(erInnvilget = true, alternativ = null),
             pensjonsgivendeInntektListe = emptyList(),
+            opptjeningListe = emptyList(),
             problem = null
         )
     }
@@ -138,10 +141,7 @@ class SimuleringResultMapperTest : ShouldSpec({
                 source = SimulertPensjonEllerAlternativ(
                     pensjon = null,
                     alternativ = null,
-                    problem = Problem(
-                        type = ProblemType.PERSON_IKKE_FUNNET,
-                        beskrivelse = "x"
-                    )
+                    problem = Problem(type = ProblemType.PERSON_IKKE_FUNNET, beskrivelse = "x")
                 )
             ) shouldBe SimuleringResultDto(
                 alderspensjonListe = emptyList(),
@@ -151,15 +151,10 @@ class SimuleringResultMapperTest : ShouldSpec({
                 tidsbegrensetOffentligAfp = null,
                 privatAfpListe = emptyList(),
                 primaerTrygdetid = null,
-                vilkaarsproevingsresultat = VilkaarsproevingsresultatDto(
-                    erInnvilget = false,
-                    alternativ = null
-                ),
+                vilkaarsproevingsresultat = VilkaarsproevingsresultatDto(erInnvilget = false, alternativ = null),
                 pensjonsgivendeInntektListe = emptyList(),
-                problem = ProblemDto(
-                    kode = ProblemTypeDto.PERSON_IKKE_FUNNET,
-                    beskrivelse = "x"
-                )
+                opptjeningListe = emptyList(),
+                problem = ProblemDto(kode = ProblemTypeDto.PERSON_IKKE_FUNNET, beskrivelse = "x")
             )
         }
     }

--- a/src/test/kotlin/no/nav/pensjon/simulator/testutil/TestObjects.kt
+++ b/src/test/kotlin/no/nav/pensjon/simulator/testutil/TestObjects.kt
@@ -1,5 +1,6 @@
 package no.nav.pensjon.simulator.testutil
 
+import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertMaanedligAlderspensjonForKnekkpunkter
 import no.nav.pensjon.simulator.core.domain.Avdoed
 import no.nav.pensjon.simulator.core.domain.SivilstatusType
 import no.nav.pensjon.simulator.core.domain.regler.PenPerson
@@ -15,7 +16,6 @@ import no.nav.pensjon.simulator.core.spec.Pre2025OffentligAfpSpec
 import no.nav.pensjon.simulator.core.spec.SimuleringSpec
 import no.nav.pensjon.simulator.generelt.organisasjon.Organisasjonsnummer
 import no.nav.pensjon.simulator.person.Pid
-import no.nav.pensjon.simulator.alderspensjon.alternativ.SimulertMaanedligAlderspensjonForKnekkpunkter
 import no.nav.pensjon.simulator.trygdetid.UtlandPeriode
 import org.springframework.security.oauth2.jwt.Jwt
 import java.time.LocalDate

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -20,7 +20,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.flywaydb.core" level="WARN"/>
+    <logger name="org.springframework.test.context.support.AnnotationConfigContextLoaderUtils" level="WARN"/>
 
     <root level="INFO">
         <appender-ref ref="${STDOUT_LOG_APPENDER}"/>


### PR DESCRIPTION
Hovedendring (commit 1):
- Inkluderer opptjening (med beholdning) i responsen til endepunktet `api/nav/v2/simuler-pensjon` (innført `OpptjeningDto`)
- Navneendring: `inntektVedFase1Uttak` -> `inntektVedTidsbegrensetOffentligAfpUttak`
- Navneendring: `pre2025OffentligAfp` -> `tidsbegrensetOffentligAfp`
- Trekker ut `MaanedligAlderspensjonBeregner` som egen klasse med tilhørende enhetstester (og sender over verdiene `kapittel19Andel` og `kapittel20Andel` istedenfor hele `alderspensjon`-objektet)
- Gjør testklasser `open` for å slippe støy i loggen ved kjøring av enhetstester
- Litt opprydding i indentering og linjeskift

Commit 2 er for å fjerne støy i loggen ved kjøring av enhetstester:
- Ignorerer Spring-relaterte Kotest warnings
- Dropper logging av info-meldinger fra `AnnotationConfigContextLoaderUtils` ("Could not detect default configuration classes for test class")

Commit 3 innfører en egen logg-konfig for testene (Copilot-forslag).

NB: Beholder foreløpig både `opptjeningGrunnlagListe` og `opptjeningListe` i responsen i en overgangsperiode inntil klienten (pensjonskalkulator-backend) går over til å bruke `opptjeningListe`.

Endringen muliggjør [pensjonskalkulator-backend PR 510](pensjonskalkulator-backend/pull/510).